### PR TITLE
ENH: Add function to handle stale IsRunning files

### DIFF
--- a/smriprep/utils/misc.py
+++ b/smriprep/utils/misc.py
@@ -55,15 +55,12 @@ def fs_isRunning(subjects_dir, subject_id, mtime_tol=86400):
     isrunning = tuple(subj_dir.glob("**/IsRunning*"))
     if not isrunning:
         return subjects_dir
-    try:
-        reconlog = next(subj_dir.glob("**/recon-all.log"))
-    except StopIteration:
-        # problems finding recon-all.log, just return subjects_dir
-        return subjects_dir
-
-    # if any IsRunning files are found, first check on last modified time of log
-    if (time.time() - reconlog.stat().st_mtime) < mtime_tol:
-        return subjects_dir
+    reconlog = subj_dir / "scripts" / "recon-all.log"
+    if not reconlog.is_file() or (time.time() - reconlog.stat().st_mtime) < mtime_tol:
+        raise RuntimeError(f"{subj_dir} contains IsRunning files: {isrunning}\n"
+                           "FreeSurfer will not run if these are present, to avoid "
+                           "interfering with a running process. If no process is running, "
+                           "they may be safely removed.")
 
     for fl in isrunning:
         fl.unlink()

--- a/smriprep/utils/misc.py
+++ b/smriprep/utils/misc.py
@@ -58,10 +58,12 @@ def fs_isRunning(subjects_dir, subject_id, mtime_tol=86400, logger=None):
     # if recon log doesn't exist, just clear IsRunning
     mtime = reconlog.stat().st_mtime if reconlog.exists() else 0
     if (time.time() - mtime) < mtime_tol:
-        raise RuntimeError(f"{subj_dir} contains IsRunning files: {isrunning}\n"
-                           "FreeSurfer will not run if these are present, to avoid "
-                           "interfering with a running process. If no process is running, "
-                           "they may be safely removed.")
+        raise RuntimeError(f"""\
+The FreeSurfer's subject folder <{subj_dir}> contains IsRunning files that \
+may pertain to a current or past execution: {isrunning}.
+FreeSurfer cannot run if these are present, to avoid interfering with a running \
+process. Please, make sure no other process is running ``recon-all`` on this subject \
+and proceed to delete the files listed above.""")
     for fl in isrunning:
         fl.unlink()
     if logger:

--- a/smriprep/utils/misc.py
+++ b/smriprep/utils/misc.py
@@ -21,3 +21,53 @@ def apply_lut(in_dseg, lut, newpath=None):
                    segm.affine, hdr).to_filename(out_file)
 
     return out_file
+
+
+def fs_isRunning(subjects_dir, subject_id, mtime_tol=86400):
+    """
+    Checks FreeSurfer subjects dir for presence of recon-all blocking ``IsRunning`` files,
+    and optionally removes any based on the modification time.
+
+    Parameters
+    ----------
+    subjects_dir : os.PathLike or None
+        Existing FreeSurfer subjects directory
+    subject_id : str
+        Subject label
+    mtime_tol : int
+        Tolerance time (in seconds) between current time and last modification of ``recon-all.log``
+
+    Returns
+    -------
+    subjects_dir : os.PathLike or None
+
+    """
+    import logging
+    from pathlib import Path
+    import time
+
+    if subjects_dir is None:
+        return subjects_dir
+    subj_dir = Path(subjects_dir) / subject_id
+    if not subj_dir.exists():
+        return subjects_dir
+
+    isrunning = tuple(subj_dir.glob("**/IsRunning*"))
+    if not isrunning:
+        return subjects_dir
+    try:
+        reconlog = next(subj_dir.glob("**/recon-all.log"))
+    except StopIteration:
+        # problems finding recon-all.log, just return subjects_dir
+        return subjects_dir
+
+    # if any IsRunning files are found, first check on last modified time of log
+    if (time.time() - reconlog.stat().st_mtime) < mtime_tol:
+        return subjects_dir
+
+    for fl in isrunning:
+        fl.unlink()
+
+    logger = logging.getLogger('nipype.interface')
+    logger.warn(f"Removed older IsRunning files found under {subj_dir}")
+    return subjects_dir

--- a/smriprep/utils/tests/test_misc.py
+++ b/smriprep/utils/tests/test_misc.py
@@ -2,7 +2,8 @@ import pytest
 
 from ..misc import fs_isRunning
 
-def gen_fs_dir(tmp_path, isrunning):
+
+def _gen_fsdir(tmp_path, isrunning):
     fsdir = tmp_path / 'sample_freesurfer'
     (fsdir / 'sub-01' / 'scripts').mkdir(parents=True)
     (fsdir / 'sub-01' / 'scripts' / 'recon-all.log').write_text('log')
@@ -11,13 +12,14 @@ def gen_fs_dir(tmp_path, isrunning):
         (fsdir / 'sub-01' / 'scripts' / 'IsRunning.lh').write_text('running')
     return fsdir
 
+
 @pytest.mark.parametrize('isrunning,mtime_tol,error', [
     (False, 86400, None),
     (True, 86400, RuntimeError),
     (True, 0, None),
 ])
 def test_fs_isRunning(tmp_path, isrunning, mtime_tol, error):
-    fs_dir = gen_fs_dir(tmp_path, isrunning)
+    fs_dir = _gen_fsdir(tmp_path, isrunning)
     if error is None:
         fs_isRunning(fs_dir, 'sub-01', mtime_tol=mtime_tol)
         assert not tuple(fs_dir.glob('**/IsRunning*'))

--- a/smriprep/utils/tests/test_misc.py
+++ b/smriprep/utils/tests/test_misc.py
@@ -1,0 +1,27 @@
+import pytest
+
+from ..misc import fs_isRunning
+
+def gen_fs_dir(tmp_path, isrunning):
+    fsdir = tmp_path / 'sample_freesurfer'
+    (fsdir / 'sub-01' / 'scripts').mkdir(parents=True)
+    (fsdir / 'sub-01' / 'scripts' / 'recon-all.log').write_text('log')
+    if isrunning:
+        (fsdir / 'sub-01' / 'scripts' / 'IsRunning.rh').write_text('running')
+        (fsdir / 'sub-01' / 'scripts' / 'IsRunning.lh').write_text('running')
+    return fsdir
+
+@pytest.mark.parametrize('isrunning,mtime_tol,error', [
+    (False, 86400, None),
+    (True, 86400, RuntimeError),
+    (True, 0, None),
+])
+def test_fs_isRunning(tmp_path, isrunning, mtime_tol, error):
+    fs_dir = gen_fs_dir(tmp_path, isrunning)
+    if error is None:
+        fs_isRunning(fs_dir, 'sub-01', mtime_tol=mtime_tol)
+        assert not tuple(fs_dir.glob('**/IsRunning*'))
+    else:
+        with pytest.raises(error):
+            fs_isRunning(fs_dir, 'sub-01', mtime_tol=mtime_tol)
+        assert tuple(fs_dir.glob('**/IsRunning*'))

--- a/smriprep/workflows/anatomical.py
+++ b/smriprep/workflows/anatomical.py
@@ -26,7 +26,7 @@ from niworkflows.interfaces.utility import KeySelect
 from niworkflows.utils.misc import fix_multi_T1w_source_name, add_suffix
 from niworkflows.anat.ants import init_brain_extraction_wf, init_n4_only_wf
 from ..utils.bids import get_outputnode_spec
-from ..utils.misc import apply_lut as _apply_bids_lut
+from ..utils.misc import apply_lut as _apply_bids_lut, fs_isRunning as _fs_isRunning
 from .norm import init_anat_norm_wf
 from .outputs import init_anat_reports_wf, init_anat_derivatives_wf
 from .surfaces import init_surface_recon_wf
@@ -433,16 +433,23 @@ the brain-extracted T1w using `fast` [FSL {fsl_ver}, RRID:SCR_002823,
     split_seg = pe.Node(niu.Function(function=_split_segments),
                         name='split_seg')
 
+    # check for older IsRunning files and remove accordingly
+    fs_isrunning = pe.Node(niu.Function(function=_fs_isRunning),
+                           overwrite=True, name='fs_isrunning')
+
     # 5. Surface reconstruction (--fs-no-reconall not set)
     surface_recon_wf = init_surface_recon_wf(name='surface_recon_wf',
                                              omp_nthreads=omp_nthreads, hires=hires)
     applyrefined = pe.Node(fsl.ApplyMask(), name='applyrefined')
     workflow.connect([
+        (inputnode, fs_isrunning, [
+            ('subjects_dir', 'subjects_dir'),
+            ('subject_id', 'subject_id')]),
         (inputnode, surface_recon_wf, [
             ('t2w', 'inputnode.t2w'),
             ('flair', 'inputnode.flair'),
-            ('subjects_dir', 'inputnode.subjects_dir'),
             ('subject_id', 'inputnode.subject_id')]),
+        (fs_isrunning, surface_recon_wf, [('out', 'inputnode.subjects_dir')]),
         (anat_validate, surface_recon_wf, [('out_file', 'inputnode.t1w')]),
         (brain_extraction_wf, surface_recon_wf, [
             (('outputnode.out_file', _pop), 'inputnode.skullstripped_t1'),

--- a/smriprep/workflows/anatomical.py
+++ b/smriprep/workflows/anatomical.py
@@ -436,6 +436,7 @@ the brain-extracted T1w using `fast` [FSL {fsl_ver}, RRID:SCR_002823,
     # check for older IsRunning files and remove accordingly
     fs_isrunning = pe.Node(niu.Function(function=_fs_isRunning),
                            overwrite=True, name='fs_isrunning')
+    fs_isrunning.inputs.logger = LOGGER
 
     # 5. Surface reconstruction (--fs-no-reconall not set)
     surface_recon_wf = init_surface_recon_wf(name='surface_recon_wf',


### PR DESCRIPTION
This is a proof of concept for what was discussed in #41

A few things to note:
- The only way `IsRunning` files will be removed is if they have a modification time of `> 1 day/24 hours/86400 seconds` from the time of running.
- This is implemented as an overwrite Node, meaning it will always rerun.
- The function always returns the `subject_dir`, which is then passed to `surface_recon_wf` to ensure any necessary cleaning has occured.

I will add some testing if we decide to go this route