### PR TITLE
RF: Make workflows keyword-only (PEP 3102)

### DIFF
--- a/smriprep/workflows/anatomical.py
+++ b/smriprep/workflows/anatomical.py
@@ -35,6 +35,7 @@ LOGGER = logging.getLogger('nipype.workflow')
 
 
 def init_anat_preproc_wf(
+        *,
         bids_root,
         freesurfer,
         hires,
@@ -486,7 +487,7 @@ the brain-extracted T1w using `fast` [FSL {fsl_ver}, RRID:SCR_002823,
     return workflow
 
 
-def init_anat_template_wf(longitudinal, omp_nthreads, num_t1w, name='anat_template_wf'):
+def init_anat_template_wf(*, longitudinal, omp_nthreads, num_t1w, name='anat_template_wf'):
     """
     Generate a canonically-oriented, structural average from all input T1w images.
 

--- a/smriprep/workflows/anatomical.py
+++ b/smriprep/workflows/anatomical.py
@@ -129,10 +129,14 @@ def init_anat_preproc_wf(
         List of T1-weighted structural images
     t2w
         List of T2-weighted structural images
+    roi
+        A mask to exclude regions during standardization
     flair
         List of FLAIR images
     subjects_dir
         FreeSurfer SUBJECTS_DIR
+    subject_id
+        FreeSurfer subject ID
 
     Outputs
     -------

--- a/smriprep/workflows/base.py
+++ b/smriprep/workflows/base.py
@@ -24,6 +24,7 @@ from .anatomical import init_anat_preproc_wf
 
 
 def init_smriprep_wf(
+    *,
     debug,
     fast_track,
     freesurfer,
@@ -175,9 +176,10 @@ def init_smriprep_wf(
 
 
 def init_single_subject_wf(
+    *,
     debug,
-    freesurfer,
     fast_track,
+    freesurfer,
     hires,
     layout,
     longitudinal,
@@ -236,10 +238,10 @@ def init_single_subject_wf(
     ----------
     debug : :obj:`bool`
         Enable debugging outputs
-    freesurfer : :obj:`bool`
-        Enable FreeSurfer surface reconstruction (may increase runtime)
     fast_track : :obj:`bool`
         If ``True``, attempt to collect previously run derivatives.
+    freesurfer : :obj:`bool`
+        Enable FreeSurfer surface reconstruction (may increase runtime)
     hires : :obj:`bool`
         Enable sub-millimeter preprocessing in FreeSurfer
     layout : BIDSLayout object

--- a/smriprep/workflows/norm.py
+++ b/smriprep/workflows/norm.py
@@ -16,6 +16,7 @@ from ..interfaces.templateflow import TemplateFlowSelect, TemplateDesc
 
 
 def init_anat_norm_wf(
+    *,
     debug,
     omp_nthreads,
     templates,

--- a/smriprep/workflows/norm.py
+++ b/smriprep/workflows/norm.py
@@ -20,6 +20,7 @@ def init_anat_norm_wf(
     debug,
     omp_nthreads,
     templates,
+    name="anat_norm_wf",
 ):
     """
     Build an individual spatial normalization workflow using ``antsRegistration``.
@@ -75,6 +76,8 @@ def init_anat_norm_wf(
         input domain to enable standardization of lesioned brains.
     orig_t1w
         The original T1w image from the BIDS structure.
+    template
+        Template name and specification
 
     Outputs
     -------
@@ -100,7 +103,7 @@ def init_anat_norm_wf(
 
     """
     ntpls = len(templates)
-    workflow = Workflow('anat_norm_wf')
+    workflow = Workflow(name=name)
 
     if templates:
         workflow.__desc__ = """\

--- a/smriprep/workflows/outputs.py
+++ b/smriprep/workflows/outputs.py
@@ -11,7 +11,7 @@ from ..interfaces import DerivativesDataSink
 BIDS_TISSUE_ORDER = ("GM", "WM", "CSF")
 
 
-def init_anat_reports_wf(freesurfer, output_dir,
+def init_anat_reports_wf(*, freesurfer, output_dir,
                          name='anat_reports_wf'):
     """Set up a battery of datasinks to store reports in the right location."""
     from niworkflows.interfaces import SimpleBeforeAfter
@@ -105,7 +105,7 @@ def init_anat_reports_wf(freesurfer, output_dir,
     return workflow
 
 
-def init_anat_derivatives_wf(bids_root, freesurfer, num_t1w, output_dir,
+def init_anat_derivatives_wf(*, bids_root, freesurfer, num_t1w, output_dir,
                              name='anat_derivatives_wf', tpm_labels=BIDS_TISSUE_ORDER):
     """Set up a battery of datasinks to store derivatives in the right location."""
     workflow = Workflow(name=name)

--- a/smriprep/workflows/outputs.py
+++ b/smriprep/workflows/outputs.py
@@ -13,7 +13,43 @@ BIDS_TISSUE_ORDER = ("GM", "WM", "CSF")
 
 def init_anat_reports_wf(*, freesurfer, output_dir,
                          name='anat_reports_wf'):
-    """Set up a battery of datasinks to store reports in the right location."""
+    """
+    Set up a battery of datasinks to store reports in the right location.
+
+    Parameters
+    ----------
+    freesurfer : :obj:`bool`
+        FreeSurfer was enabled
+    output_dir : :obj:`str`
+        Directory in which to save derivatives
+    name : :obj:`str`
+        Workflow name (default: anat_reports_wf)
+
+    Inputs
+    ------
+    source_file
+        Input T1w image
+    std_t1w
+        T1w image resampled to standard space
+    std_mask
+        Mask of skull-stripped template
+    subject_dir
+        FreeSurfer SUBJECTS_DIR
+    subject_id
+        FreeSurfer subject ID
+    t1w_conform_report
+        Conformation report
+    t1w_preproc
+        The T1w reference map, which is calculated as the average of bias-corrected
+        and preprocessed T1w images, defining the anatomical space.
+    t1w_dseg
+        Segmentation in T1w space
+    t1w_mask
+        Brain (binary) mask estimated by brain extraction.
+    template
+        Template space and specifications
+
+    """
     from niworkflows.interfaces import SimpleBeforeAfter
     from niworkflows.interfaces.masks import ROIsPlot
     from ..interfaces.templateflow import TemplateFlowSelect
@@ -107,7 +143,68 @@ def init_anat_reports_wf(*, freesurfer, output_dir,
 
 def init_anat_derivatives_wf(*, bids_root, freesurfer, num_t1w, output_dir,
                              name='anat_derivatives_wf', tpm_labels=BIDS_TISSUE_ORDER):
-    """Set up a battery of datasinks to store derivatives in the right location."""
+    """
+    Set up a battery of datasinks to store derivatives in the right location.
+
+    Parameters
+    ----------
+    bids_root : :obj:`str`
+        Root path of BIDS dataset
+    freesurfer : :obj:`bool`
+        FreeSurfer was enabled
+    num_t1w : :obj:`int`
+        Number of T1w images
+    output_dir : :obj:`str`
+        Directory in which to save derivatives
+    name : :obj:`str`
+        Workflow name (default: anat_derivatives_wf)
+    tpm_labels : :obj:`tuple`
+        Tissue probability maps in order
+
+    Inputs
+    ------
+    template
+        Template space and specifications
+    source_files
+        List of input T1w images
+    t1w_ref_xfms
+        List of affine transforms to realign input T1w images
+    t1w_preproc
+        The T1w reference map, which is calculated as the average of bias-corrected
+        and preprocessed T1w images, defining the anatomical space.
+    t1w_mask
+        Mask of the ``t1w_preproc``
+    t1w_dseg
+        Segmentation in T1w space
+    t1w_tpms
+        Tissue probability maps in T1w space
+    anat2std_xfm
+        Nonlinear spatial transform to resample imaging data given in anatomical space
+        into standard space.
+    std2anat_xfm
+        Inverse transform of ``anat2std_xfm``
+    std_t1w
+        T1w reference resampled in one or more standard spaces.
+    std_mask
+        Mask of skull-stripped template, in standard space
+    std_dseg
+        Segmentation, resampled into standard space
+    std_tpms
+        Tissue probability maps in standard space
+    t1w2fsnative_xfm
+        LTA-style affine matrix translating from T1w to
+        FreeSurfer-conformed subject space
+    fsnative2t1w_xfm
+        LTA-style affine matrix translating from FreeSurfer-conformed
+        subject space to T1w
+    surfaces
+        GIFTI surfaces (gray/white boundary, midthickness, pial, inflated)
+    t1w_fs_aseg
+        FreeSurfer's aseg segmentation, in native T1w space
+    t1w_fs_aparc
+        FreeSurfer's aparc+aseg segmentation, in native T1w space
+
+    """
     workflow = Workflow(name=name)
 
     inputnode = pe.Node(

--- a/smriprep/workflows/surfaces.py
+++ b/smriprep/workflows/surfaces.py
@@ -29,7 +29,7 @@ from niworkflows.interfaces.freesurfer import (
 from niworkflows.interfaces.surf import NormalizeSurf
 
 
-def init_surface_recon_wf(omp_nthreads, hires, name='surface_recon_wf'):
+def init_surface_recon_wf(*, omp_nthreads, hires, name='surface_recon_wf'):
     r"""
     Reconstruct anatomical surfaces using FreeSurfer's ``recon-all``.
 
@@ -253,7 +253,7 @@ gray-matter of Mindboggle [RRID:SCR_002438, @mindboggle].
     return workflow
 
 
-def init_autorecon_resume_wf(omp_nthreads, name='autorecon_resume_wf'):
+def init_autorecon_resume_wf(*, omp_nthreads, name='autorecon_resume_wf'):
     r"""
     Resume recon-all execution, assuming the `-autorecon1` stage has been completed.
 
@@ -398,7 +398,7 @@ def init_autorecon_resume_wf(omp_nthreads, name='autorecon_resume_wf'):
     return workflow
 
 
-def init_gifti_surface_wf(name='gifti_surface_wf'):
+def init_gifti_surface_wf(*, name='gifti_surface_wf'):
     r"""
     Prepare GIFTI surfaces from a FreeSurfer subjects directory.
 
@@ -479,7 +479,7 @@ def init_gifti_surface_wf(name='gifti_surface_wf'):
     return workflow
 
 
-def init_segs_to_native_wf(name='segs_to_native', segmentation='aseg'):
+def init_segs_to_native_wf(*, name='segs_to_native', segmentation='aseg'):
     """
     Get a segmentation from FreeSurfer conformed space into native T1w space.
 


### PR DESCRIPTION
This change enforces all `init_*` workflows to be keyword-only. We've generally stuck by the practice anyways when initializing workflows

https://www.python.org/dev/peps/pep-3102/