### PR TITLE
FIX: Ordering of ``probseg`` maps with anatomical *fast-track*

### DIFF
--- a/smriprep/data/io_spec.json
+++ b/smriprep/data/io_spec.json
@@ -17,7 +17,7 @@
       },
       "tpms": {
         "datatype": "anat",
-        "label": [ "CSF", "GM", "WM"],
+        "label": ["GM", "WM", "CSF"],
         "suffix": "probseg"
       }
     },


### PR DESCRIPTION
Resolves a problem with the I/O specification where the order of standard tissue labels (GM, WM, CSF) was incorrect.