### PR TITLE
RF: Structural outputs

### DIFF
--- a/smriprep/workflows/anatomical.py
+++ b/smriprep/workflows/anatomical.py
@@ -325,7 +325,9 @@ the brain-extracted T1w using `fast` [FSL {fsl_ver}, RRID:SCR_002823,
     anat_norm_wf = init_anat_norm_wf(
         debug=debug,
         omp_nthreads=omp_nthreads,
-        templates=spaces.get_spaces(nonstandard=False, dim=(3,)),
+        templates=[
+            str(ref) for ref in spaces.get_standard(full_spec=True, dim=(3,))
+        ],
     )
 
     workflow.connect([

--- a/smriprep/workflows/outputs.py
+++ b/smriprep/workflows/outputs.py
@@ -225,7 +225,7 @@ def init_anat_derivatives_wf(*, bids_root, freesurfer, num_t1w, output_dir,
 
     ds_t1w_preproc = pe.Node(
         DerivativesDataSink(base_directory=output_dir, desc='preproc', compress=True,
-                            dismiss_entities=("session",)),
+                            dismiss_entities=("session",), data_dtype='source'),
         name='ds_t1w_preproc', run_without_submitting=True)
     ds_t1w_preproc.inputs.SkullStripped = False
 
@@ -247,7 +247,7 @@ def init_anat_derivatives_wf(*, bids_root, freesurfer, num_t1w, output_dir,
     ds_t1w_tpms.inputs.label = tpm_labels
 
     ds_t1w_tpl = pe.Node(
-        DerivativesDataSink(base_directory=output_dir, desc='preproc', keep_dtype=True,
+        DerivativesDataSink(base_directory=output_dir, desc='preproc', data_dtype='source',
                             compress=True, dismiss_entities=("session",)),
         name='ds_t1w_tpl', run_without_submitting=True)
     ds_t1w_tpl.inputs.SkullStripped = True


### PR DESCRIPTION
Currently, there is a fundamental difference between how smriprep and fmriprep are producing outputs. smriprep outputs will always be in a templateflow-supported resolution, whereas fmriprep allows having its outputs match the native BOLD resolution.

Related issue: https://github.com/poldracklab/fmriprep/issues/2226