### PR TITLE
FIX: Generate anatomical conversions with full spec from ``--output-spaces``

### DIFF
--- a/.circleci/ds054_outputs.txt
+++ b/.circleci/ds054_outputs.txt
@@ -35,5 +35,13 @@ smriprep/sub-100185/anat/sub-100185_space-MNI152NLin2009cAsym_dseg.nii.gz
 smriprep/sub-100185/anat/sub-100185_space-MNI152NLin2009cAsym_label-CSF_probseg.nii.gz
 smriprep/sub-100185/anat/sub-100185_space-MNI152NLin2009cAsym_label-GM_probseg.nii.gz
 smriprep/sub-100185/anat/sub-100185_space-MNI152NLin2009cAsym_label-WM_probseg.nii.gz
+smriprep/sub-100185/anat/sub-100185_space-MNI152NLin2009cAsym_res-2_desc-brain_mask.json
+smriprep/sub-100185/anat/sub-100185_space-MNI152NLin2009cAsym_res-2_desc-brain_mask.nii.gz
+smriprep/sub-100185/anat/sub-100185_space-MNI152NLin2009cAsym_res-2_desc-preproc_T1w.json
+smriprep/sub-100185/anat/sub-100185_space-MNI152NLin2009cAsym_res-2_desc-preproc_T1w.nii.gz
+smriprep/sub-100185/anat/sub-100185_space-MNI152NLin2009cAsym_res-2_dseg.nii.gz
+smriprep/sub-100185/anat/sub-100185_space-MNI152NLin2009cAsym_res-2_label-CSF_probseg.nii.gz
+smriprep/sub-100185/anat/sub-100185_space-MNI152NLin2009cAsym_res-2_label-GM_probseg.nii.gz
+smriprep/sub-100185/anat/sub-100185_space-MNI152NLin2009cAsym_res-2_label-WM_probseg.nii.gz
 smriprep/sub-100185.html
 /tmp/ds054/derivatives

--- a/.circleci/ds054_run.sh
+++ b/.circleci/ds054_run.sh
@@ -14,7 +14,7 @@ docker run --rm -it -e FMRIPREP_DEV=1 -u $(id -u) \
     /tmp/data/ds054 /tmp/ds054/derivatives participant \
     -w /tmp/ds054/work --fs-no-reconall --sloppy \
     --skull-strip-template OASIS30ANTs:res-1 \
-    --output-spaces MNI152Lin MNI152NLin2009cAsym \
+    --output-spaces MNI152Lin MNI152NLin2009cAsym:res-2:res-native \
     --mem-gb 4 --ncpus 2 --omp-nthreads 2 -vv \
     --fs-license-file /tmp/fslicense/license.txt \
     ${@:1}

--- a/smriprep/cli/run.py
+++ b/smriprep/cli/run.py
@@ -403,7 +403,8 @@ def build_workflow(opts, retval):
         return retval
 
     output_spaces = opts.output_spaces
-    output_spaces.checkpoint()
+    if not output_spaces.is_cached():
+        output_spaces.checkpoint()
 
     logger.log(25, INIT_MSG(
         version=__version__,

--- a/smriprep/cli/run.py
+++ b/smriprep/cli/run.py
@@ -402,12 +402,15 @@ def build_workflow(opts, retval):
                                                  packagename="smriprep")
         return retval
 
+    output_spaces = opts.output_spaces
+    output_spaces.checkpoint()
+
     logger.log(25, INIT_MSG(
         version=__version__,
         bids_dir=bids_dir,
         subject_list=subject_list,
         uuid=run_uuid,
-        spaces=opts.output_spaces)
+        spaces=output_spaces)
     )
 
     # Build main workflow
@@ -426,7 +429,7 @@ def build_workflow(opts, retval):
         skull_strip_fixed_seed=opts.skull_strip_fixed_seed,
         skull_strip_mode=opts.skull_strip_mode,
         skull_strip_template=opts.skull_strip_template[0],
-        spaces=opts.output_spaces,
+        spaces=output_spaces,
         subject_list=subject_list,
         work_dir=str(work_dir),
         bids_filters=bids_filters,

--- a/smriprep/interfaces/templateflow.py
+++ b/smriprep/interfaces/templateflow.py
@@ -11,7 +11,8 @@ from nipype.interfaces.base import (
 class _TemplateFlowSelectInputSpec(BaseInterfaceInputSpec):
     template = traits.Str('MNI152NLin2009cAsym', mandatory=True, desc='Template ID')
     atlas = InputMultiObject(traits.Str, desc='Specify an atlas')
-    cohort = InputMultiObject(traits.Int, desc='Specify an atlas')
+    cohort = InputMultiObject(traits.Either(traits.Str, traits.Int),
+                              desc='Specify a cohort')
     resolution = InputMultiObject(traits.Int, desc='Specify a template resolution index')
     template_spec = traits.DictStrAny(
         {'atlas': None, 'cohort': None},

--- a/smriprep/interfaces/templateflow.py
+++ b/smriprep/interfaces/templateflow.py
@@ -11,9 +11,13 @@ from nipype.interfaces.base import (
 class _TemplateFlowSelectInputSpec(BaseInterfaceInputSpec):
     template = traits.Str('MNI152NLin2009cAsym', mandatory=True, desc='Template ID')
     atlas = InputMultiObject(traits.Str, desc='Specify an atlas')
+    cohort = InputMultiObject(traits.Int, desc='Specify an atlas')
     resolution = InputMultiObject(traits.Int, desc='Specify a template resolution index')
     template_spec = traits.DictStrAny(
-        {'atlas': None}, usedefault=True, desc='Template specifications')
+        {'atlas': None, 'cohort': None},
+        usedefault=True,
+        desc='Template specifications'
+    )
 
 
 class _TemplateFlowSelectOutputSpec(TraitedSpec):
@@ -66,6 +70,8 @@ class TemplateFlowSelect(SimpleInterface):
             specs['resolution'] = self.inputs.resolution
         if isdefined(self.inputs.atlas):
             specs['atlas'] = self.inputs.atlas
+        if isdefined(self.inputs.cohort):
+            specs['cohort'] = self.inputs.cohort
 
         name = self.inputs.template.strip(":").split(":", 1)
         if len(name) > 1:

--- a/smriprep/workflows/anatomical.py
+++ b/smriprep/workflows/anatomical.py
@@ -389,6 +389,7 @@ the brain-extracted T1w using `fast` [FSL {fsl_ver}, RRID:SCR_002823,
         freesurfer=freesurfer,
         num_t1w=num_t1w,
         output_dir=output_dir,
+        spaces=spaces,
     )
 
     workflow.connect([
@@ -396,20 +397,16 @@ the brain-extracted T1w using `fast` [FSL {fsl_ver}, RRID:SCR_002823,
         (anat_template_wf, anat_derivatives_wf, [
             ('outputnode.t1w_valid_list', 'inputnode.source_files')]),
         (anat_norm_wf, anat_derivatives_wf, [
-            ('poutputnode.template', 'inputnode.template'),
-            ('poutputnode.anat2std_xfm', 'inputnode.anat2std_xfm'),
-            ('poutputnode.std2anat_xfm', 'inputnode.std2anat_xfm')
+            ('outputnode.template', 'inputnode.template'),
+            ('outputnode.anat2std_xfm', 'inputnode.anat2std_xfm'),
+            ('outputnode.std2anat_xfm', 'inputnode.std2anat_xfm')
         ]),
         (outputnode, anat_derivatives_wf, [
-            ('std_preproc', 'inputnode.std_t1w'),
             ('t1w_ref_xfms', 'inputnode.t1w_ref_xfms'),
             ('t1w_preproc', 'inputnode.t1w_preproc'),
             ('t1w_mask', 'inputnode.t1w_mask'),
             ('t1w_dseg', 'inputnode.t1w_dseg'),
             ('t1w_tpms', 'inputnode.t1w_tpms'),
-            ('std_mask', 'inputnode.std_mask'),
-            ('std_dseg', 'inputnode.std_dseg'),
-            ('std_tpms', 'inputnode.std_tpms'),
         ]),
     ])
 


### PR DESCRIPTION
Generates the anatomical derivatives in standardized volumetric spaces
directly within the derivatives workflow, instead of taking them as
inputs.

The spaces object must be passed in to determine the full specification
of output spaces.

Has some node duplicity for the generation of the reportlet, but I think
this implementation is much more clear, and follows fMRIPrep's patterns.

Resolves: poldracklab/fmriprep#2226.
Supersedes: #218.