### PR TITLE
ENH: Update derivative description, bidsignore for derivative

### DIFF
--- a/.circleci/ds005_outputs.txt
+++ b/.circleci/ds005_outputs.txt
@@ -1,4 +1,5 @@
 smriprep
+smriprep/.bidsignore
 smriprep/dataset_description.json
 smriprep/desc-aparcaseg_dseg.tsv
 smriprep/desc-aseg_dseg.tsv

--- a/.circleci/ds054_outputs.txt
+++ b/.circleci/ds054_outputs.txt
@@ -1,4 +1,5 @@
 smriprep
+smriprep/.bidsignore
 smriprep/dataset_description.json
 smriprep/logs
 smriprep/logs/CITATION.bib

--- a/smriprep/cli/run.py
+++ b/smriprep/cli/run.py
@@ -255,13 +255,14 @@ def build_opts(opts):
         logger.log(25, 'sMRIPrep finished without errors')
     finally:
         from niworkflows.reports import generate_reports
-        from ..utils.bids import write_derivative_description
+        from ..utils.bids import write_derivative_description, write_bidsignore
 
         logger.log(25, 'Writing reports for participants: %s', ', '.join(subject_list))
         # Generate reports phase
         errno += generate_reports(subject_list, output_dir, run_uuid,
                                   packagename='smriprep')
         write_derivative_description(bids_dir, str(Path(output_dir) / 'smriprep'))
+        write_bidsignore(Path(output_dir) / 'smriprep')
     sys.exit(int(errno > 0))
 
 


### PR DESCRIPTION
From a review of the expected outputs, the artifacts of a recent build, and the current draft of [BEP-011](https://bids-specification.readthedocs.io/en/bep011/), sMRIPrep produces conformant derivatives, with the exception of the dataset description. This PR updates the description, and adds a `.bidsignore` file to make life easier on the validator.

Closes #210.