### PR TITLE
ENH: Retain session info when multi-session data are not averaged

### DIFF
--- a/smriprep/workflows/anatomical.py
+++ b/smriprep/workflows/anatomical.py
@@ -204,6 +204,7 @@ BIDS dataset.""".format(num_t1w=num_t1w)
     # Connect reportlets workflows
     anat_reports_wf = init_anat_reports_wf(
         freesurfer=freesurfer,
+        num_t1w=num_t1w,
         output_dir=output_dir,
     )
     workflow.connect([


### PR DESCRIPTION
Multi-session data used to be combined, but after adopting ``--bids-filters``, now it is possible to select a single session.

This PR uses a tiny hack, just using the ``num_t1w`` variable already present in the derivatives workflow (it has been added to the reports workflow).

The idea is that session is dropped when ``num_t1w`` > 1.
This works because single-session datasets do not carry any ``session`` information on to the ``DerivativesDataSink``.
So, if ``num_t1w`` is 1 in a multisession dataset, the T1w reference name should carry (and keep) the session entity.

Resolves: #197.