### PR TITLE
CI: Update Python images to 3.8.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,7 +126,7 @@ jobs:
 
   get_data:
     docker:
-      - image: circleci/python:3.7.4
+      - image: circleci/python:3.8.5
     working_directory: /home/circleci/data
     steps:
       - restore_cache:
@@ -271,7 +271,7 @@ jobs:
 
   test_deploy_pypi:
     docker:
-      - image: circleci/python:3.7.4
+      - image: circleci/python:3.8.5
     working_directory: /tmp/src/smriprep
     steps:
       - checkout
@@ -660,9 +660,10 @@ jobs:
       - store_artifacts:
           path: /tmp/ds054/derivatives
           destination: fasttrack-derivatives
+
   build_docs:
     docker:
-      - image: python:3.7.4
+      - image: circleci/python:3.8.5
     working_directory: /tmp/gh-pages
     environment:
       - FSLOUTPUTTYPE: NIFTI
@@ -718,7 +719,7 @@ jobs:
 
   deploy_pypi:
     docker:
-      - image: circleci/python:3.7.4
+      - image: circleci/python:3.8.5
     working_directory: /tmp/src/smriprep
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -672,7 +672,7 @@ jobs:
       - checkout
       - run:
           name: Install Graphviz
-          command: apt update && apt -y install graphviz
+          command: sudo apt update && sudo apt -y install graphviz
       - run:
           name: Install deps
           command: pip install -r docs/requirements.txt


### PR DESCRIPTION
`test_deploy_pypi` is failing because of dependency resolution failure in Python 3.7. Could find a workaround to fix it, but it's just for checking sdists/wheels, so it's not an issue we're responsible for. It's somewhere between the pip resolver and twine's dependency tree.

3.8 support is universal, so I can't see any reason to hold on to 3.7, so I bumped all of our `python:<ver>` images up.