### PR TITLE
FIX: Sturdier version check of sMRIPrep-wrapper package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -371,7 +371,9 @@ jobs:
             pip wheel --no-deps -w dist/ .
             twine check dist/smriprep*.whl
             pip install dist/smriprep*.whl
+            set +e
             INSTALLED_VERSION=$(yes n | smriprep-docker --version)
+            set -e
             INSTALLED_VERSION=${INSTALLED_VERSION%$'\r'}
             INSTALLED_VERSION=${INSTALLED_VERSION#*"smriprep wrapper "}
             INSTALLED_VERSION=$( echo ${INSTALLED_VERSION} | cut -f1 -d" ")

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -365,9 +365,16 @@ jobs:
             virtualenv --python=python build
             source build/bin/activate
             pip install --upgrade "pip>=19.1"
-            sed -i -E "s/(__version__ = )'[A-Za-z0-9.-]+'/\1'${CIRCLE_TAG:-$THISVERSION}'/" smriprep_docker.py
+            sed -i -E "s/(__version__ = )\"[A-Za-z0-9.-]+\"/\1\"${CIRCLE_TAG:-$THISVERSION}\"/" smriprep_docker.py
             python setup.py sdist
             pip wheel --no-deps -w dist/ .
+            INSTALLED_VERSION=$(yes n | smriprep-docker --version)
+            INSTALLED_VERSION=${INSTALLED_VERSION%$'\r'}
+            INSTALLED_VERSION=${INSTALLED_VERSION#*"smriprep wrapper "}
+            INSTALLED_VERSION=$( echo ${INSTALLED_VERSION} | cut -f1 -d" ")
+            echo "VERSION: \"$THISVERSION\""
+            echo "INSTALLED: \"$INSTALLED_VERSION\""
+            test "$INSTALLED_VERSION" = "$THISVERSION"
       - store_artifacts:
           path: /tmp/src/smriprep/wrapper/dist
 
@@ -799,7 +806,7 @@ jobs:
             virtualenv --python=python build
             source build/bin/activate
             pip install --upgrade "pip>=19.1"
-            sed -i -E "s/(__version__ = )'[A-Za-z0-9.-]+'/\1'${CIRCLE_TAG:-$THISVERSION}'/" smriprep_docker.py
+            sed -i -E "s/(__version__ = )\"[A-Za-z0-9.-]+\"/\1\"${CIRCLE_TAG:-$THISVERSION}\"/" smriprep_docker.py
             python setup.py sdist
             pip wheel --no-deps -w dist/ .
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -367,7 +367,10 @@ jobs:
             pip install --upgrade "pip>=19.1"
             sed -i -E "s/(__version__ = )\"[A-Za-z0-9.-]+\"/\1\"${CIRCLE_TAG:-$THISVERSION}\"/" smriprep_docker.py
             python setup.py sdist
+            twine check dist/smriprep*.tar.gz
             pip wheel --no-deps -w dist/ .
+            twine check dist/smriprep*.whl
+            pip install dist/smriprep*.whl
             INSTALLED_VERSION=$(yes n | smriprep-docker --version)
             INSTALLED_VERSION=${INSTALLED_VERSION%$'\r'}
             INSTALLED_VERSION=${INSTALLED_VERSION#*"smriprep wrapper "}


### PR DESCRIPTION
After running black, quotes of ``__version__`` changed from single to double,
and the ``sed`` expression we were using on CircleCI to set the actual version
stopped working as it expected single quotes.

Resolves: #234.