### PR TITLE
MAINT: Mount TemplateFlow's home directory in CircleCI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -490,6 +490,7 @@ jobs:
             docker run -it -e FMRIPREP_DEV=1 -u $(id -u) \
                 -v /tmp/ds005:/tmp/ds005 \
                 -v /tmp/src/smriprep:/src/smriprep \
+                -v /tmp/templateflow:/home/smriprep/.cache/templateflow \
                 -w /src/smriprep \
                 -e COVERAGE_FILE=/tmp/ds005/work/.coverage \
                 -e COVERAGE_RCFILE=/src/smriprep/docker/multiproc.coveragerc \
@@ -500,6 +501,7 @@ jobs:
             docker run -it -e FMRIPREP_DEV=1 -u $(id -u) \
                 -v /tmp/ds005:/tmp/ds005 \
                 -v /tmp/src/smriprep:/src/smriprep \
+                -v /tmp/templateflow:/home/smriprep/.cache/templateflow \
                 -w /src/smriprep \
                 -e COVERAGE_FILE=/tmp/ds005/work/.coverage \
                 -e COVERAGE_RCFILE=/src/smriprep/docker/multiproc.coveragerc \
@@ -662,6 +664,7 @@ jobs:
             docker run --rm=false -it \
                 -v /tmp/ds054:/tmp/ds054 \
                 -v /tmp/src/smriprep:/src/smriprep \
+                -v /tmp/templateflow:/home/smriprep/.cache/templateflow \
                 -w /src/smriprep \
                 -e FMRIPREP_DEV=1 -u $(id -u) \
                 -e COVERAGE_FILE=/tmp/ds054/work/.coverage \
@@ -673,6 +676,7 @@ jobs:
             docker run --rm=false -it \
                 -v /tmp/ds054:/tmp/ds054 \
                 -v /tmp/src/smriprep:/src/smriprep \
+                -v /tmp/templateflow:/home/smriprep/.cache/templateflow \
                 -w /src/smriprep \
                 -e FMRIPREP_DEV=1 -u $(id -u) \
                 -e COVERAGE_FILE=/tmp/ds054/work/.coverage \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,7 +223,9 @@ jobs:
                        tfapi.get(['MNI152NLin2009cAsym', 'OASIS30ANTs', 'NKI'], resolution=1, \
                                  desc='BrainCerebellumExtraction', suffix='mask'); \
                        tfapi.get(['MNI152NLin2009cAsym', 'OASIS30ANTs', 'NKI'], resolution=1, \
-                                 desc='BrainCerebellumRegistration', suffix='mask');"
+                                 desc='BrainCerebellumRegistration', suffix='mask'); \
+                       tfapi.get('OASIS30ANTs', resolution=1, label=['WM', 'BS'], suffix='probseg'); \
+                       tfapi.get('MNI152NLin2009cAsym', resolution=2, label='WM', suffix='probseg');"
       - save_cache:
           key: templateflow-v1-{{ .Branch }}-{{ epoch }}
           paths:


### PR DESCRIPTION
It was a waste to cache it in the ``get_data`` job, load the appropriate cache
before ``docker run``, and finally dismiss its existence not binding the path.

This will evaluate whether the TemplateFlow home directory can be correctly
mounted from the host when using containers.

I would advocate for not overloading the docker image with pre-cached templates
and advise users to bind the appropriate path from their host (#202).

Alternative: #202.