### PR TITLE
FIX: Account for label entity when querying brain mask

### DIFF
--- a/smriprep/interfaces/templateflow.py
+++ b/smriprep/interfaces/templateflow.py
@@ -86,6 +86,9 @@ class TemplateFlowSelect(SimpleInterface):
     >>> result.outputs.t1w_file  # doctest: +ELLIPSIS
     '.../tpl-MNIPediatricAsym_cohort-5_res-1_T1w.nii.gz'
 
+    >>> select = TemplateFlowSelect()
+    >>> select.inputs.template = 'UNCInfant:cohort-1'
+    >>> result = select.run()
     """
 
     input_spec = _TemplateFlowSelectInputSpec
@@ -113,8 +116,9 @@ class TemplateFlowSelect(SimpleInterface):
 
         self._results["t1w_file"] = tf.get(name[0], desc=None, suffix="T1w", **specs)
 
-        self._results["brain_mask"] = tf.get(
-            name[0], desc="brain", suffix="mask", **specs
+        self._results["brain_mask"] = (
+            tf.get(name[0], desc="brain", suffix="mask", **specs)
+            or tf.get(name[0], label="brain", suffix="mask", **specs)
         )
         return runtime
 

--- a/smriprep/interfaces/templateflow.py
+++ b/smriprep/interfaces/templateflow.py
@@ -89,6 +89,7 @@ class TemplateFlowSelect(SimpleInterface):
     >>> select = TemplateFlowSelect()
     >>> select.inputs.template = 'UNCInfant:cohort-1'
     >>> result = select.run()
+
     """
 
     input_spec = _TemplateFlowSelectInputSpec


### PR DESCRIPTION
UNCInfant template currently fails, since the brain mask contains `label-brain` instead of `desc-brain`. AFAIK, `label` is the preferred entity for this.

This is a quick fix, but looking through the code, I think the `TemplateFlowSelect` interface as a whole needs a substantial rework. Was it envisioned as a nipype wrapper for `templateflow.api.get`?