### PR TITLE
CI: Drop test for direct invocation of setup.py

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -62,18 +62,16 @@ jobs:
         INSTALLED_VERSION=$(python -c 'import smriprep; print(smriprep.__version__, end="")')
         echo "INSTALLED: \"${INSTALLED_VERSION}\""
         test "${INSTALLED_VERSION}" = "${THISVERSION}"
-    - name: Install in confined environment [setup.py - install]
+    - name: Install in confined environment [pip install source]
       run: |
         python -m venv /tmp/setup_install
         source /tmp/setup_install/bin/activate
         python -m pip install "${{ matrix.pip }}" setuptools
-        python -m pip install numpy scipy "Cython >= 0.28.5" # sklearn needs this
-        python -m pip install scikit-learn  # otherwise it attempts to build it
-        python setup.py install
+        python -m pip install .
         INSTALLED_VERSION=$(python -c 'import smriprep; print(smriprep.__version__, end="")')
         echo "INSTALLED: \"${INSTALLED_VERSION}\""
         test "${INSTALLED_VERSION}" = "${THISVERSION}"
-    - name: Install in confined environment [setup.py - develop]
+    - name: Install in confined environment [pip install editable]
       run: |
         python -m venv /tmp/setup_develop
         source /tmp/setup_develop/bin/activate
@@ -81,7 +79,7 @@ jobs:
         # sklearn needs these dependencies
         python -m pip install numpy scipy "Cython >= 0.28.5"
         python -m pip install scikit-learn  # otherwise it attempts to build it
-        python setup.py develop
+        python -m pip install -e .
         INSTALLED_VERSION=$(python -c 'import smriprep; print(smriprep.__version__, end="")')
         echo "INSTALLED: \"${INSTALLED_VERSION}\""
         test "${INSTALLED_VERSION}" = "${THISVERSION}"


### PR DESCRIPTION
Direct invocations of setup.py are discouraged by everybody including setuptools developers. The contemporary equivalents of these are pip installing, so let's just test those.