### PR TITLE
ENH: Register T1w template to FreeSurfer nu.mgz instead of T1.mgz

### DIFF
--- a/smriprep/workflows/surfaces.py
+++ b/smriprep/workflows/surfaces.py
@@ -268,7 +268,7 @@ gray-matter of Mindboggle [RRID:SCR_002438, @mindboggle].
         # Construct transform from FreeSurfer conformed image to sMRIPrep
         # reoriented image
         (inputnode, fsnative2t1w_xfm, [('t1w', 'target_file')]),
-        (autorecon1, fsnative2t1w_xfm, [('T1', 'source_file')]),
+        (autorecon1, fsnative2t1w_xfm, [('nu', 'source_file')]),
         (fsnative2t1w_xfm, gifti_surface_wf, [
             ('out_reg_file', 'inputnode.fsnative2t1w_xfm')]),
         (fsnative2t1w_xfm, t1w2fsnative_xfm, [('out_reg_file', 'in_lta')]),


### PR DESCRIPTION
Here's one step toward supporting FastSurfer, which doesn't generate a T1.mgz file.

Via https://github.com/Deep-MI/FastSurfer/issues/21#issuecomment-984049197

Related https://github.com/nipreps/smriprep/issues/226