### PR TITLE
FIX: Override nipype handling of recon-all hemi input

### DIFF
--- a/smriprep/interfaces/freesurfer.py
+++ b/smriprep/interfaces/freesurfer.py
@@ -113,6 +113,7 @@ class _ReconAllInputSpec(fs.preprocess.ReconAllInputSpec):
         xor=["directive"],
         position=0,
     )
+    hemi = traits.Enum("lh", "rh", desc="hemisphere to process", argstr="-%s-only")
 
 
 class ReconAll(fs.ReconAll):
@@ -191,3 +192,10 @@ class ReconAll(fs.ReconAll):
         cmd += " " + " ".join(flags)
         iflogger.info("resume recon-all : %s", cmd)
         return cmd
+
+    def _format_arg(self, name, trait_spec, value):
+        # Nipype disables this if -autorecon-hemi is passed
+        # We need to use it either way to prevent undesired behavior
+        if name == "hemi":
+            return trait_spec.argstr % value
+        return super()._format_arg(name, trait_spec, value)


### PR DESCRIPTION
FreeSurfer has some bugs with limiting processing that requires both hemispheres to have completed. Changing `-autorecon-hemi lh` to `-autorecon-hemi lh -lh-only` (and likewise for rh) resolves the issue. We might even be able to simplify the workflow with this fix, but that's for another day.