### PR TITLE
modified gifti_surface_wf to remove the fsnative transform and replace using to_scanner

### DIFF
--- a/smriprep/workflows/surfaces.py
+++ b/smriprep/workflows/surfaces.py
@@ -269,8 +269,6 @@ gray-matter of Mindboggle [RRID:SCR_002438, @mindboggle].
         # reoriented image
         (inputnode, fsnative2t1w_xfm, [('t1w', 'target_file')]),
         (autorecon1, fsnative2t1w_xfm, [('T1', 'source_file')]),
-        (fsnative2t1w_xfm, gifti_surface_wf, [
-            ('out_reg_file', 'inputnode.fsnative2t1w_xfm')]),
         (fsnative2t1w_xfm, t1w2fsnative_xfm, [('out_reg_file', 'in_lta')]),
         # Refine ANTs mask, deriving new mask from FS' aseg
         (inputnode, refine, [('corrected_t1', 'in_anat'),
@@ -531,9 +529,8 @@ def init_gifti_surface_wf(*, name="gifti_surface_wf"):
         run_without_submitting=True,
     )
     fs2gii = pe.MapNode(
-        fs.MRIsConvert(out_datatype="gii"), iterfield="in_file", name="fs2gii"
+        fs.MRIsConvert(out_datatype="gii",to_scanner=True), iterfield="in_file", name="fs2gii"
     )
-    fix_surfs = pe.MapNode(NormalizeSurf(), iterfield="in_file", name="fix_surfs")
 
     # fmt:off
     workflow.connect([
@@ -551,9 +548,7 @@ def init_gifti_surface_wf(*, name="gifti_surface_wf"):
                                       ('inflated', 'in3')]),
         (save_midthickness, surface_list, [('out_file', 'in4')]),
         (surface_list, fs2gii, [('out', 'in_file')]),
-        (fs2gii, fix_surfs, [('converted', 'in_file')]),
-        (inputnode, fix_surfs, [('fsnative2t1w_xfm', 'transform_file')]),
-        (fix_surfs, outputnode, [('out_file', 'surfaces')]),
+        (fs2gii, outputnode, [('converted', 'surfaces')])
     ])
     # fmt:on
     return workflow

--- a/smriprep/workflows/surfaces.py
+++ b/smriprep/workflows/surfaces.py
@@ -535,6 +535,11 @@ def init_gifti_surface_wf(*, name="gifti_surface_wf"):
         name="surfmorph_list",
         run_without_submitting=True,
     )
+    whitesurf_list = pe.Node(
+        niu.Merge(3,ravel_inputs=True),
+        name="whitesurf_list",
+        run_without_submitting=True,
+    )
     fscurv2funcgii = pe.MapNode(
         fs.MRIsConvert(out_datatype="gii", to_scanner=True),
         iterfield=["in_file", "scalarcurv_file"], name="fscurv2funcgii"
@@ -564,7 +569,10 @@ def init_gifti_surface_wf(*, name="gifti_surface_wf"):
         (get_surfaces, surfmorph_list, [('thickness', 'in1'),
                                         ('sulc', 'in2'),
                                         ('curv', 'in3')]),
-        (surface_list, fscurv2funcgii, [('in1', 'in_file')]),
+        (get_surfaces,whitesurf_list, [('smoothwm','in1'),
+                                       ('smoothwm','in2'),
+                                       ('smoothwm','in3')]),
+        (whitesurf_list, fscurv2funcgii, [('out', 'in_file')]),
         (surfmorph_list, fscurv2funcgii, [('out', 'scalarcurv_file')]),
         (fs2gii, allsurf_list, [('converted', 'in1')]),
         (fscurv2funcgii, allsurf_list, [('converted', 'in2')]),

--- a/smriprep/workflows/surfaces.py
+++ b/smriprep/workflows/surfaces.py
@@ -540,7 +540,7 @@ def init_gifti_surface_wf(*, name="gifti_surface_wf"):
         iterfield=["in_file", "scalarcurv_file"], name="fscurv2funcgii"
     )
     allsurf_list = pe.Node(
-        niu.merge(7),
+        niu.Merge(7),
         name="allsurf_list",
         run_without_submitting=True,
     )

--- a/smriprep/workflows/surfaces.py
+++ b/smriprep/workflows/surfaces.py
@@ -529,18 +529,19 @@ def init_gifti_surface_wf(*, name="gifti_surface_wf"):
         run_without_submitting=True,
     )
     fs2gii = pe.MapNode(
-        fs.MRIsConvert(out_datatype="gii",to_scanner=True), iterfield="in_file", name="fs2gii"
+        fs.MRIsConvert(out_datatype="gii", to_scanner=True), iterfield="in_file", name="fs2gii"
     )
     surfmorph_list = pe.Node(
-        niu.Merge(3,ravel_inputs=True),
+        niu.Merge(3, ravel_inputs=True),
         name="surfmorph_list",
         run_without_submitting=True,
     )
     fscurv2funcgii = pe.MapNode(
-        fs.MRIsConvert(out_datatype="gii",to_scanner=True,scalarcurv_file=True),iterfield="in_file", name="fscurv2funcgii"
+        fs.MRIsConvert(out_datatype="gii", to_scanner=True),
+        iterfield=["in_file", "scalarcurv_file"], name="fscurv2funcgii"
     )
     allsurf_list = pe.Node(
-        niu.merge(7,ravel_inputs=True),
+        niu.merge(7),
         name="allsurf_list",
         run_without_submitting=True,
     )
@@ -561,13 +562,14 @@ def init_gifti_surface_wf(*, name="gifti_surface_wf"):
                                       ('inflated', 'in3')]),
         (save_midthickness, surface_list, [('out_file', 'in4')]),
         (surface_list, fs2gii, [('out', 'in_file')]),
-        (get_surfaces, surfmorph_list, [('thickness','in1'),
-                                      ('sulc','in2'),
-                                      ('curv','in3')]),
-        (surfmorph_list, fscurv2funcgii, [('out','in_file')]),
-        (fs2gii, allsurf_list, [('converted','in1')]),
-        (fscurv2funcgii, allsurf_list, [('converted','in2')]),
-        (allsurf_list,outputnode, [('out', 'surfaces')])
+        (get_surfaces, surfmorph_list, [('thickness', 'in1'),
+                                        ('sulc', 'in2'),
+                                        ('curv', 'in3')]),
+        (surfmorph_list, fscurv2funcgii, [('out', 'in_file')]),
+        (surfmorph_list, fscurv2funcgii, [('out', 'scalarcurv_file')]),
+        (fs2gii, allsurf_list, [('converted', 'in1')]),
+        (fscurv2funcgii, allsurf_list, [('converted', 'in2')]),
+        (allsurf_list, outputnode, [('out', 'surfaces')])
     ])
     # fmt:on
     return workflow

--- a/smriprep/workflows/surfaces.py
+++ b/smriprep/workflows/surfaces.py
@@ -536,7 +536,7 @@ def init_gifti_surface_wf(*, name="gifti_surface_wf"):
         run_without_submitting=True,
     )
     whitesurf_list = pe.Node(
-        niu.Merge(3,ravel_inputs=True),
+        niu.Merge(3, ravel_inputs=True),
         name="whitesurf_list",
         run_without_submitting=True,
     )
@@ -569,9 +569,9 @@ def init_gifti_surface_wf(*, name="gifti_surface_wf"):
         (get_surfaces, surfmorph_list, [('thickness', 'in1'),
                                         ('sulc', 'in2'),
                                         ('curv', 'in3')]),
-        (get_surfaces,whitesurf_list, [('smoothwm','in1'),
-                                       ('smoothwm','in2'),
-                                       ('smoothwm','in3')]),
+        (get_surfaces, whitesurf_list, [('smoothwm', 'in1'),
+                                        ('smoothwm', 'in2'),
+                                        ('smoothwm', 'in3')]),
         (whitesurf_list, fscurv2funcgii, [('out', 'in_file')]),
         (surfmorph_list, fscurv2funcgii, [('out', 'scalarcurv_file')]),
         (fs2gii, allsurf_list, [('converted', 'in1')]),

--- a/smriprep/workflows/surfaces.py
+++ b/smriprep/workflows/surfaces.py
@@ -531,6 +531,19 @@ def init_gifti_surface_wf(*, name="gifti_surface_wf"):
     fs2gii = pe.MapNode(
         fs.MRIsConvert(out_datatype="gii",to_scanner=True), iterfield="in_file", name="fs2gii"
     )
+    surfmorph_list = pe.Node(
+        niu.Merge(3,ravel_inputs=True),
+        name="surfmorph_list",
+        run_without_submitting=True,
+    )
+    fscurv2funcgii = pe.MapNode(
+        fs.MRIsConvert(out_datatype="gii",to_scanner=True,scalarcurv_file=True),iterfield="in_file", name="fscurv2funcgii"
+    )
+    allsurf_list = pe.Node(
+        niu.merge(7,ravel_inputs=True),
+        name="allsurf_list",
+        run_without_submitting=True,
+    )
 
     # fmt:off
     workflow.connect([
@@ -548,7 +561,13 @@ def init_gifti_surface_wf(*, name="gifti_surface_wf"):
                                       ('inflated', 'in3')]),
         (save_midthickness, surface_list, [('out_file', 'in4')]),
         (surface_list, fs2gii, [('out', 'in_file')]),
-        (fs2gii, outputnode, [('converted', 'surfaces')])
+        (get_surfaces, surfmorph_list, [('thickness','in1'),
+                                      ('sulc','in2'),
+                                      ('curv','in3')]),
+        (surfmorph_list, fscurv2funcgii, [('out','in_file')]),
+        (fs2gii, allsurf_list, [('converted','in1')]),
+        (fscurv2funcgii, allsurf_list, [('converted','in2')]),
+        (allsurf_list,outputnode, [('out', 'surfaces')])
     ])
     # fmt:on
     return workflow

--- a/smriprep/workflows/surfaces.py
+++ b/smriprep/workflows/surfaces.py
@@ -564,7 +564,7 @@ def init_gifti_surface_wf(*, name="gifti_surface_wf"):
         (get_surfaces, surfmorph_list, [('thickness', 'in1'),
                                         ('sulc', 'in2'),
                                         ('curv', 'in3')]),
-        (surfmorph_list, fscurv2funcgii, [('out', 'in_file')]),
+        (surface_list, fscurv2funcgii, [('in1', 'in_file')]),
         (surfmorph_list, fscurv2funcgii, [('out', 'scalarcurv_file')]),
         (fs2gii, allsurf_list, [('converted', 'in1')]),
         (fscurv2funcgii, allsurf_list, [('converted', 'in2')]),

--- a/smriprep/workflows/surfaces.py
+++ b/smriprep/workflows/surfaces.py
@@ -46,7 +46,6 @@ from niworkflows.interfaces.freesurfer import (
     PatchedRobustRegister as RobustRegister,
     RefineBrainMask,
 )
-from niworkflows.interfaces.surf import NormalizeSurf
 
 
 def init_surface_recon_wf(*, omp_nthreads, hires, name="surface_recon_wf"):


### PR DESCRIPTION
this pull request address issue #289 -- enabling smriprep to be used with expected inputs for nibabies. Should also improve alignments in edge cases for non-infant processing :)

