### PR TITLE
FIX: Update removed `-autorecon-hemi` flag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -738,6 +738,9 @@ jobs:
           name: Install deps
           command: pip install -r docs/requirements.txt
       - run:
+          name: Install package in editable mode
+          command: pip install -e .
+      - run:
           name: Build only this commit
           no_output_timeout: 30m
           command: make -C docs NO_ET=1 SPHINXOPTS="-W" BUILDDIR="_build/no_version_html" html

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -738,8 +738,8 @@ jobs:
           name: Install deps
           command: pip install -r docs/requirements.txt
       - run:
-          name: Install package in editable mode
-          command: pip install -e .
+          name: Install package
+          command: pip install .
       - run:
           name: Build only this commit
           no_output_timeout: 30m

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,13 +1,7 @@
 git+https://github.com/AleksandarPetrov/napoleon.git@0dc3f28a309ad602be5f44a9049785a1026451b3#egg=sphinxcontrib-napoleon
 git+https://github.com/effigies/sphinxcontrib-versioning.git@master
 nbsphinx
-nipype >= 1.5.1
-niworkflows >= 1.4.0, <1.6
-packaging
-pydot
 sphinx-argparse
 sphinx
 sphinx_rtd_theme
 sphinxcontrib-apidoc ~= 0.3.0
-templateflow
-networkx != 2.8.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ install_requires =
     matplotlib >= 2.2.0
     nibabel >= 4.0.1
     nipype >= 1.7.0
+    traits < 6.4
     niworkflows ~= 1.6.0
     numpy
     packaging

--- a/smriprep/interfaces/freesurfer.py
+++ b/smriprep/interfaces/freesurfer.py
@@ -99,7 +99,7 @@ class _ReconAllInputSpec(fs.preprocess.ReconAllInputSpec):
             "parcstats2",
             "cortparc3",
             "parcstats3",
-            "label-exvivo-ec",
+            "label-exvivo-ec-avg",
             # autorecon vol
             "cortribbon",
             "hyporelabel",  # 6.0

--- a/smriprep/interfaces/freesurfer.py
+++ b/smriprep/interfaces/freesurfer.py
@@ -99,7 +99,8 @@ class _ReconAllInputSpec(fs.preprocess.ReconAllInputSpec):
             "parcstats2",
             "cortparc3",
             "parcstats3",
-            "label-exvivo-ec-avg",
+            "label-exvivo-ec",  # 5.3
+            "label-exvivo-ec-avg",  # 6.0+
             # autorecon vol
             "cortribbon",
             "hyporelabel",  # 6.0


### PR DESCRIPTION
Fixes https://github.com/nipreps/fmriprep/issues/2832

The `<no>label-exvivo-ec` is now removed, this substitutes it with  `<no>label-exvivo-ec-avg`, though I am not even sure this is necessary anymore?

FS changes from 2015... https://github.com/freesurfer/freesurfer/commit/939c3cbab4f81ef0b54dd2599a591f88dd528ac9
