### PR TITLE
WRAPPER: Fix help merge in smriprep-docker

### DIFF
--- a/wrapper/smriprep_docker.py
+++ b/wrapper/smriprep_docker.py
@@ -132,7 +132,7 @@ def merge_help(wrapper_help, target_help):
         and the docker wrapper (`smriprep-docker -h`).
         """
         posargs = []
-        for targ in usage.split('\n')[-3:]:
+        for targ in usage.split()[-3:]:
             line = targ.lstrip()
             if line.startswith('usage'):
                 continue


### PR DESCRIPTION
With a sufficiently wide terminal, `argparse` can decide to rearrange the usage string. Instead of splitting on lines, split on whitespace. We're still looking for the last three items.