### PR TITLE
CI: Set max Python version to 3.10

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -69,11 +69,11 @@ jobs:
         python-version: [3.7, 3.8, 3.9, "3.10"]
         install: [repo]
         include:
-          - python-version: 3
+          - python-version: "3.10"
             install: sdist
-          - python-version: 3
+          - python-version: "3.10"
             install: wheel
-          - python-version: 3
+          - python-version: "3.10"
             install: editable
 
     env:


### PR DESCRIPTION
Until scikit-image, h5py and pytables have 3.11 wheels on PyPI, it's not worth testing it.