### PR TITLE
ENH: Merge T2w images and coregister to T1w template

### DIFF
--- a/smriprep/workflows/anatomical.py
+++ b/smriprep/workflows/anatomical.py
@@ -231,7 +231,8 @@ BIDS dataset.""".format(
 
     outputnode = pe.Node(
         niu.IdentityInterface(
-            fields=["template", "subjects_dir", "subject_id", "t2w_preproc"] + get_outputnode_spec()
+            fields=["template", "subjects_dir", "subject_id", "t2w_preproc"]
+            + get_outputnode_spec()
         ),
         name="outputnode",
     )
@@ -514,6 +515,7 @@ the brain-extracted T1w using `fast` [FSL {fsl_ver}, RRID:SCR_002823,
                 (('outputnode.out_file', _pop), 't1w_brain'),
                 ('outputnode.out_mask', 't1w_mask')]),
         ])
+        # fmt:on
         return workflow
 
     # check for older IsRunning files and remove accordingly

--- a/smriprep/workflows/base.py
+++ b/smriprep/workflows/base.py
@@ -308,6 +308,7 @@ def init_single_subject_wf(
         # for documentation purposes
         subject_data = {
             "t1w": ["/completely/made/up/path/sub-01_T1w.nii.gz"],
+            "t2w": [],
         }
     else:
         subject_data = collect_data(layout, subject_id, bids_filters=bids_filters)[0]
@@ -406,6 +407,7 @@ to workflows in *sMRIPrep*'s documentation]\
         longitudinal=longitudinal,
         name="anat_preproc_wf",
         t1w=subject_data["t1w"],
+        t2w=subject_data["t2w"],
         omp_nthreads=omp_nthreads,
         output_dir=output_dir,
         skull_strip_fixed_seed=skull_strip_fixed_seed,

--- a/smriprep/workflows/outputs.py
+++ b/smriprep/workflows/outputs.py
@@ -201,6 +201,7 @@ def init_anat_derivatives_wf(
     bids_root,
     freesurfer,
     num_t1w,
+    t2w,
     output_dir,
     spaces,
     name="anat_derivatives_wf",
@@ -241,6 +242,8 @@ def init_anat_derivatives_wf(
         Segmentation in T1w space
     t1w_tpms
         Tissue probability maps in T1w space
+    t2w_preproc
+        The preprocessed T2w image, bias-corrected and resampled into anatomical space.
     anat2std_xfm
         Nonlinear spatial transform to resample imaging data given in anatomical space
         into standard space.
@@ -284,6 +287,7 @@ def init_anat_derivatives_wf(
                 "t1w_mask",
                 "t1w_dseg",
                 "t1w_tpms",
+                "t2w_preproc",
                 "anat2std_xfm",
                 "std2anat_xfm",
                 "t1w2fsnative_xfm",
@@ -557,6 +561,27 @@ def init_anat_derivatives_wf(
 
     if not freesurfer:
         return workflow
+
+    # T2w coregistration requires FreeSurfer surfaces, so only try to save if freesurfer
+    if t2w:
+        ds_t2w_preproc = pe.Node(
+            DerivativesDataSink(
+                base_directory=output_dir,
+                desc="preproc",
+                suffix="T2w",
+                compress=True,
+            ),
+            name="ds_t2w_preproc",
+            run_without_submitting=True,
+        )
+        ds_t2w_preproc.inputs.SkullStripped = False
+        ds_t2w_preproc.inputs.source_file = t2w
+
+        # fmt:off
+        workflow.connect([
+            (inputnode, ds_t2w_preproc, [('t2w_preproc', 'in_file')]),
+        ])
+        # fmt:on
 
     from niworkflows.interfaces.nitransforms import ConcatenateXFMs
     from niworkflows.interfaces.surf import Path2BIDS


### PR DESCRIPTION
The approach taken here is to merge the T2w images in exactly the same way as T1w images (N4 -> mri_robust_template) and then bbregister. This is the approach taken by `recon-all`, and seems the safest way to do this without running brain extraction first. Therefore this is only available if FreeSurfer is run.

Closes #69.

We could probably throw in #13 at the same time and pass the merged T2w image to FreeSurfer...