### PR TITLE
ENH: make cortical ribbon volume based on signed distance of white/pial surfaces

### DIFF
--- a/smriprep/__about__.py
+++ b/smriprep/__about__.py
@@ -29,9 +29,7 @@ from ._version import get_versions
 __version__ = get_versions()["version"]
 del get_versions
 
-__copyright__ = (
-    "Copyright 2019, Center for Reproducible Neuroscience, Stanford University"
-)
+__copyright__ = "Copyright 2019, Center for Reproducible Neuroscience, Stanford University"
 __credits__ = [
     "Oscar Esteban",
     "Chris Gorgolewski",

--- a/smriprep/cli/run.py
+++ b/smriprep/cli/run.py
@@ -37,10 +37,7 @@ def check_deps(workflow):
     return sorted(
         (node.interface.__class__.__name__, node.interface._cmd)
         for node in workflow._get_all_nodes()
-        if (
-            hasattr(node.interface, "_cmd")
-            and which(node.interface._cmd.split()[0]) is None
-        )
+        if (hasattr(node.interface, "_cmd") and which(node.interface._cmd.split()[0]) is None)
     )
 
 
@@ -85,9 +82,7 @@ def get_parser():
     )
 
     # optional arguments
-    parser.add_argument(
-        "--version", action="version", version="smriprep v{}".format(__version__)
-    )
+    parser.add_argument("--version", action="version", version="smriprep v{}".format(__version__))
 
     g_bids = parser.add_argument_group("Options for filtering BIDS queries")
     g_bids.add_argument(
@@ -137,8 +132,7 @@ def get_parser():
     g_perfm.add_argument(
         "--low-mem",
         action="store_true",
-        help="attempt to reduce memory usage (will increase disk usage "
-        "in working directory)",
+        help="attempt to reduce memory usage (will increase disk usage " "in working directory)",
     )
     g_perfm.add_argument(
         "--use-plugin",
@@ -146,9 +140,7 @@ def get_parser():
         default=None,
         help="nipype plugin configuration file",
     )
-    g_perfm.add_argument(
-        "--boilerplate", action="store_true", help="generate boilerplate only"
-    )
+    g_perfm.add_argument("--boilerplate", action="store_true", help="generate boilerplate only")
     g_perfm.add_argument(
         "-v",
         "--verbose",
@@ -276,8 +268,7 @@ def get_parser():
         "--stop-on-first-crash",
         action="store_true",
         default=False,
-        help="Force stopping on first crash, even if a work directory"
-        " was specified.",
+        help="Force stopping on first crash, even if a work directory" " was specified.",
     )
     g_other.add_argument(
         "--notrack",
@@ -395,12 +386,8 @@ def build_opts(opts):
             from niworkflows.utils.misc import _copy_any
 
             dseg_tsv = str(api.get("fsaverage", suffix="dseg", extension=[".tsv"]))
-            _copy_any(
-                dseg_tsv, str(Path(output_dir) / "smriprep" / "desc-aseg_dseg.tsv")
-            )
-            _copy_any(
-                dseg_tsv, str(Path(output_dir) / "smriprep" / "desc-aparcaseg_dseg.tsv")
-            )
+            _copy_any(dseg_tsv, str(Path(output_dir) / "smriprep" / "desc-aseg_dseg.tsv"))
+            _copy_any(dseg_tsv, str(Path(output_dir) / "smriprep" / "desc-aparcaseg_dseg.tsv"))
         logger.log(25, "sMRIPrep finished without errors")
     finally:
         from niworkflows.reports import generate_reports
@@ -408,9 +395,7 @@ def build_opts(opts):
 
         logger.log(25, "Writing reports for participants: %s", ", ".join(subject_list))
         # Generate reports phase
-        errno += generate_reports(
-            subject_list, output_dir, run_uuid, packagename="smriprep"
-        )
+        errno += generate_reports(subject_list, output_dir, run_uuid, packagename="smriprep")
         write_derivative_description(bids_dir, str(Path(output_dir) / "smriprep"))
         write_bidsignore(Path(output_dir) / "smriprep")
     sys.exit(int(errno > 0))
@@ -458,13 +443,9 @@ def build_workflow(opts, retval):
     # First check that bids_dir looks like a BIDS folder
     bids_dir = opts.bids_dir.resolve()
     layout = BIDSLayout(str(bids_dir), validate=False)
-    subject_list = collect_participants(
-        layout, participant_label=opts.participant_label
-    )
+    subject_list = collect_participants(layout, participant_label=opts.participant_label)
 
-    bids_filters = (
-        json.loads(opts.bids_filter_file.read_text()) if opts.bids_filter_file else None
-    )
+    bids_filters = json.loads(opts.bids_filter_file.read_text()) if opts.bids_filter_file else None
 
     # Load base plugin_settings from file if --use-plugin
     if opts.use_plugin is not None:
@@ -552,9 +533,7 @@ def build_workflow(opts, retval):
     if opts.reports_only:
         from niworkflows.reports import generate_reports
 
-        logger.log(
-            25, "Running --reports-only on participants %s", ", ".join(subject_list)
-        )
+        logger.log(25, "Running --reports-only on participants %s", ", ".join(subject_list))
         if opts.run_uuid is not None:
             run_uuid = opts.run_uuid
         retval["return_code"] = generate_reports(
@@ -643,9 +622,7 @@ def build_workflow(opts, retval):
     except (FileNotFoundError, CalledProcessError, TimeoutExpired):
         logger.warning("Could not generate CITATION.tex file:\n%s", " ".join(cmd))
     else:
-        copyfile(
-            pkgrf("smriprep", "data/boilerplate.bib"), str(log_dir / "CITATION.bib")
-        )
+        copyfile(pkgrf("smriprep", "data/boilerplate.bib"), str(log_dir / "CITATION.bib"))
     return retval
 
 

--- a/smriprep/data/io_spec.json
+++ b/smriprep/data/io_spec.json
@@ -77,6 +77,12 @@
         "hemi": ["L", "R"],
         "extension": "shape.gii",
         "suffix": ["thickness", "sulc", "curv"]
+      },
+      "anat_ribbon": {
+        "datatype": "anat",
+        "desc": "ribbon",
+        "suffix": "mask",
+        "extension": "nii.gz"
       }
     }
   },

--- a/smriprep/interfaces/freesurfer.py
+++ b/smriprep/interfaces/freesurfer.py
@@ -256,6 +256,7 @@ class MRIsConvertData(fs.utils.MRIsConvert):
     Wraps mris_convert to automatically select the correct ?h.white surface if
     passed a file from the subject's surf/ directory
     """
+
     input_spec = _MRIsConvertDataInputSpec
 
     def _gen_filename(self, name):

--- a/smriprep/interfaces/templateflow.py
+++ b/smriprep/interfaces/templateflow.py
@@ -36,12 +36,8 @@ from nipype.interfaces.base import (
 class _TemplateFlowSelectInputSpec(BaseInterfaceInputSpec):
     template = traits.Str("MNI152NLin2009cAsym", mandatory=True, desc="Template ID")
     atlas = InputMultiObject(traits.Str, desc="Specify an atlas")
-    cohort = InputMultiObject(
-        traits.Either(traits.Str, traits.Int), desc="Specify a cohort"
-    )
-    resolution = InputMultiObject(
-        traits.Int, desc="Specify a template resolution index"
-    )
+    cohort = InputMultiObject(traits.Either(traits.Str, traits.Int), desc="Specify a cohort")
+    resolution = InputMultiObject(traits.Int, desc="Specify a template resolution index")
     template_spec = traits.DictStrAny(
         {"atlas": None, "cohort": None}, usedefault=True, desc="Template specifications"
     )
@@ -117,10 +113,9 @@ class TemplateFlowSelect(SimpleInterface):
 
         self._results["t1w_file"] = tf.get(name[0], desc=None, suffix="T1w", **specs)
 
-        self._results["brain_mask"] = (
-            tf.get(name[0], desc="brain", suffix="mask", **specs)
-            or tf.get(name[0], label="brain", suffix="mask", **specs)
-        )
+        self._results["brain_mask"] = tf.get(
+            name[0], desc="brain", suffix="mask", **specs
+        ) or tf.get(name[0], label="brain", suffix="mask", **specs)
         return runtime
 
 

--- a/smriprep/interfaces/workbench.py
+++ b/smriprep/interfaces/workbench.py
@@ -1,0 +1,130 @@
+import os
+
+from nipype.interfaces.base import (CommandLineInputSpec, File, Str,
+                                    TraitedSpec, traits)
+from nipype.interfaces.workbench.base import WBCommand
+
+
+class CreateSignedDistanceVolumeInputSpec(CommandLineInputSpec):
+    surf_file = File(
+        exists=True,
+        mandatory=True,
+        argstr="%s",
+        position=0,
+        desc="Input surface GIFTI file (.surf.gii)",
+    )
+    ref_file = File(
+        exists=True,
+        mandatory=True,
+        argstr="%s",
+        position=1,
+        desc="NIfTI volume in the desired output space (dims, spacing, origin)",
+    )
+    out_file = File(
+        name_source=["surf_file"],
+        name_template="%s_distvol.nii.gz",
+        argstr="%s",
+        position=2,
+        desc="Name of output volume containing signed distances",
+    )
+    out_mask = File(
+        name_source=["surf_file"],
+        name_template="%s_distmask.nii.gz",
+        argstr="-roi-out %s",
+        desc="Name of file to store a mask where the ``out_file`` has a computed value",
+    )
+    fill_value = traits.Float(
+        0.0,
+        mandatory=False,
+        usedefault=True,
+        argstr="-fill-value %f",
+        desc="value to put in all voxels that don't get assigned a distance",
+    )
+    exact_limit = traits.Float(
+        5.0,
+        usedefault=True,
+        argstr="-exact-limit %f",
+        desc="distance for exact output in mm",
+    )
+    approx_limit = traits.Float(
+        20.0,
+        usedefault=True,
+        argstr="-approx-limit %f",
+        desc="distance for approximate output in mm",
+    )
+    approx_neighborhood = traits.Int(
+        2,
+        usedefault=True,
+        argstr="-approx-neighborhood %d",
+        desc="size of neighborhood cube measured from center to face in voxels, default 2 = 5x5x5",
+    )
+    winding_method = traits.Enum(
+        "EVEN_ODD",
+        "NEGATIVE",
+        "NONZERO",
+        "NORMALS",
+        argstr="-winding %s",
+        usedefault=True,
+        desc="winding method for point inside surface test",
+    )
+
+
+class CreateSignedDistanceVolumeOutputSpec(TraitedSpec):
+    out_file = File(desc="Name of output volume containing signed distances")
+    out_mask = File(
+        desc="Name of file to store a mask where the ``out_file`` has a computed value"
+    )
+
+
+class CreateSignedDistanceVolume(WBCommand):
+    """CREATE SIGNED DISTANCE VOLUME FROM SURFACE
+    wb_command -create-signed-distance-volume
+       <surface> - the input surface
+       <refspace> - a volume in the desired output space (dims, spacing, origin)
+       <outvol> - output - the output volume
+
+       [-roi-out] - output an roi volume of where the output has a computed
+          value
+          <roi-vol> - output - the output roi volume
+
+       [-fill-value] - specify a value to put in all voxels that don't get
+          assigned a distance
+          <value> - value to fill with (default 0)
+
+       [-exact-limit] - specify distance for exact output
+          <dist> - distance in mm (default 5)
+
+       [-approx-limit] - specify distance for approximate output
+          <dist> - distance in mm (default 20)
+
+       [-approx-neighborhood] - voxel neighborhood for approximate calculation
+          <num> - size of neighborhood cube measured from center to face, in
+             voxels (default 2 = 5x5x5)
+
+       [-winding] - winding method for point inside surface test
+          <method> - name of the method (default EVEN_ODD)
+
+       Computes the signed distance function of the surface.  Exact distance is
+       calculated by finding the closest point on any surface triangle to the
+       center of the voxel.  Approximate distance is calculated starting with
+       these distances, using dijkstra's method with a neighborhood of voxels.
+       Specifying too small of an exact distance may produce unexpected results.
+       Valid specifiers for winding methods are as follows:
+
+       EVEN_ODD (default)
+       NEGATIVE
+       NONZERO
+       NORMALS
+
+       The NORMALS method uses the normals of triangles and edges, or the
+       closest triangle hit by a ray from the point.  This method may be
+       slightly faster, but is only reliable for a closed surface that does not
+       cross through itself.  All other methods count entry (positive) and exit
+       (negative) crossings of a vertical ray from the point, then counts as
+       inside if the total is odd, negative, or nonzero, respectively.
+
+    """
+
+    input_spec = CreateSignedDistanceVolumeInputSpec
+    output_spec = CreateSignedDistanceVolumeOutputSpec
+    _cmd = "wb_command -create-signed-distance-volume"

--- a/smriprep/interfaces/workbench.py
+++ b/smriprep/interfaces/workbench.py
@@ -1,7 +1,6 @@
 import os
 
-from nipype.interfaces.base import (CommandLineInputSpec, File, Str,
-                                    TraitedSpec, traits)
+from nipype.interfaces.base import CommandLineInputSpec, File, Str, TraitedSpec, traits
 from nipype.interfaces.workbench.base import WBCommand
 
 

--- a/smriprep/utils/bids.py
+++ b/smriprep/utils/bids.py
@@ -22,10 +22,11 @@
 #
 """Utilities to handle BIDS inputs."""
 from collections import defaultdict
-from pathlib import Path
 from json import loads
-from pkg_resources import resource_filename as pkgrf
+from pathlib import Path
+
 from bids.layout.writing import build_path
+from pkg_resources import resource_filename as pkgrf
 
 
 def get_outputnode_spec():
@@ -40,7 +41,7 @@ def get_outputnode_spec():
     'anat2std_xfm', 'std2anat_xfm',
     't1w_aseg', 't1w_aparc',
     't1w2fsnative_xfm', 'fsnative2t1w_xfm',
-    'surfaces', 'morphometrics']
+    'surfaces', 'morphometrics', 'anat_ribbon']
 
     """
     spec = loads(Path(pkgrf("smriprep", "data/io_spec.json")).read_text())["queries"]
@@ -101,9 +102,7 @@ def predict_derivatives(subject_id, output_spaces, freesurfer):
             query["to"] = output_spaces
         return query
 
-    queries = [
-        _normalize_q(q, space=None) for q in spec["queries"]["baseline"].values()
-    ]
+    queries = [_normalize_q(q, space=None) for q in spec["queries"]["baseline"].values()]
 
     queries += [
         _normalize_q(q, space=s)
@@ -238,10 +237,11 @@ def write_derivative_description(bids_dir, deriv_dir):
 
 
     """
+    import json
     import os
     from pathlib import Path
-    import json
-    from ..__about__ import __version__, DOWNLOAD_URL
+
+    from ..__about__ import DOWNLOAD_URL, __version__
 
     bids_dir = Path(bids_dir)
     deriv_dir = Path(deriv_dir)

--- a/smriprep/workflows/anatomical.py
+++ b/smriprep/workflows/anatomical.py
@@ -21,20 +21,14 @@
 #     https://www.nipreps.org/community/licensing/
 #
 """Anatomical reference preprocessing workflows."""
-from pkg_resources import resource_filename as pkgr
-
 from nipype import logging
-from nipype.pipeline import engine as pe
-from nipype.interfaces import (
-    utility as niu,
-    freesurfer as fs,
-    fsl,
-    image,
-)
-
-from nipype.interfaces.ants.base import Info as ANTsInfo
+from nipype.interfaces import freesurfer as fs
+from nipype.interfaces import fsl, image
+from nipype.interfaces import utility as niu
 from nipype.interfaces.ants import N4BiasFieldCorrection
-
+from nipype.interfaces.ants.base import Info as ANTsInfo
+from nipype.pipeline import engine as pe
+from niworkflows.anat.ants import init_brain_extraction_wf, init_n4_only_wf
 from niworkflows.engine.workflows import LiterateWorkflow as Workflow
 from niworkflows.interfaces.fixes import FixHeaderApplyTransforms as ApplyTransforms
 from niworkflows.interfaces.freesurfer import (
@@ -42,16 +36,18 @@ from niworkflows.interfaces.freesurfer import (
     PatchedLTAConvert as LTAConvert,
 )
 from niworkflows.interfaces.header import ValidateImage
-from niworkflows.interfaces.images import TemplateDimensions, Conform
+from niworkflows.interfaces.images import Conform, TemplateDimensions
 from niworkflows.interfaces.nitransforms import ConcatenateXFMs
 from niworkflows.interfaces.utility import KeySelect
-from niworkflows.utils.misc import fix_multi_T1w_source_name, add_suffix
-from niworkflows.anat.ants import init_brain_extraction_wf, init_n4_only_wf
+from niworkflows.utils.misc import add_suffix, fix_multi_T1w_source_name
+from pkg_resources import resource_filename as pkgr
+
 from ..utils.bids import get_outputnode_spec
-from ..utils.misc import apply_lut as _apply_bids_lut, fs_isRunning as _fs_isRunning
+from ..utils.misc import apply_lut as _apply_bids_lut
+from ..utils.misc import fs_isRunning as _fs_isRunning
 from .norm import init_anat_norm_wf
-from .outputs import init_anat_reports_wf, init_anat_derivatives_wf
-from .surfaces import init_surface_recon_wf
+from .outputs import init_anat_derivatives_wf, init_anat_reports_wf
+from .surfaces import init_anat_ribbon_wf, init_surface_recon_wf
 
 LOGGER = logging.getLogger("nipype.workflow")
 
@@ -223,9 +219,7 @@ BIDS dataset.""".format(
     )
 
     inputnode = pe.Node(
-        niu.IdentityInterface(
-            fields=["t1w", "t2w", "roi", "flair", "subjects_dir", "subject_id"]
-        ),
+        niu.IdentityInterface(fields=["t1w", "t2w", "roi", "flair", "subjects_dir", "subject_id"]),
         name="inputnode",
     )
 
@@ -254,8 +248,7 @@ BIDS dataset.""".format(
     if existing_derivatives is not None:
         LOGGER.log(
             25,
-            "Anatomical workflow will reuse prior derivatives found in the "
-            "output folder (%s).",
+            "Anatomical workflow will reuse prior derivatives found in the " "output folder (%s).",
             output_dir,
         )
         desc += """
@@ -263,18 +256,14 @@ Anatomical preprocessing was reused from previously existing derivative objects.
         workflow.__desc__ = desc
 
         templates = existing_derivatives.pop("template")
-        templatesource = pe.Node(
-            niu.IdentityInterface(fields=["template"]), name="templatesource"
-        )
+        templatesource = pe.Node(niu.IdentityInterface(fields=["template"]), name="templatesource")
         templatesource.iterables = [("template", templates)]
         outputnode.inputs.template = templates
 
         for field, value in existing_derivatives.items():
             setattr(outputnode.inputs, field, value)
 
-        anat_reports_wf.inputs.inputnode.source_file = [
-            existing_derivatives["t1w_preproc"]
-        ]
+        anat_reports_wf.inputs.inputnode.source_file = [existing_derivatives["t1w_preproc"]]
 
         stdselect = pe.Node(
             KeySelect(fields=["std_preproc", "std_mask"], keys=templates),
@@ -313,11 +302,7 @@ The T1-weighted (T1w) image was corrected for intensity non-uniformity (INU)
     desc += """\
 with `N4BiasFieldCorrection` [@n4], distributed with ANTs {ants_ver} \
 [@ants, RRID:SCR_004757]"""
-    desc += (
-        ".\n"
-        if num_t1w > 1
-        else ", and used as T1w-reference throughout the workflow.\n"
-    )
+    desc += ".\n" if num_t1w > 1 else ", and used as T1w-reference throughout the workflow.\n"
 
     desc += """\
 The T1w-reference was then skull-stripped with a *Nipype* implementation of
@@ -348,14 +333,12 @@ the brain-extracted T1w using `fast` [FSL {fsl_ver}, RRID:SCR_002823,
         contrast="T1w",
     )
 
-    anat_validate = pe.Node(
-        ValidateImage(), name="anat_validate", run_without_submitting=True
-    )
+    anat_validate = pe.Node(ValidateImage(), name="anat_validate", run_without_submitting=True)
 
     # 2. Brain-extraction and INU (bias field) correction.
     if skull_strip_mode == "auto":
-        import numpy as np
         import nibabel as nb
+        import numpy as np
 
         def _is_skull_stripped(imgs):
             """Check if T1w images are skull-stripped."""
@@ -582,6 +565,8 @@ the brain-extracted T1w using `fast` [FSL {fsl_ver}, RRID:SCR_002823,
         ])
         # fmt:on
 
+    # Anatomical ribbon file using HCP signed-distance volume method
+    anat_ribbon_wf = init_anat_ribbon_wf()
     # fmt:off
     workflow.connect([
         (inputnode, fs_isrunning, [
@@ -610,6 +595,11 @@ the brain-extracted T1w using `fast` [FSL {fsl_ver}, RRID:SCR_002823,
             ('outputnode.morphometrics', 'morphometrics'),
             ('outputnode.out_aseg', 't1w_aseg'),
             ('outputnode.out_aparc', 't1w_aparc')]),
+        (surface_recon_wf, anat_ribbon_wf, [
+            ('outputnode.surfaces', 'inputnode.surfaces'),
+            ('outputnode.out_brainmask', 'inputnode.t1w_mask')]),
+        (anat_ribbon_wf, outputnode, [
+            ("outputnode.anat_ribbon", "anat_ribbon")]),
         (applyrefined, buffernode, [('out_file', 't1w_brain')]),
         (surface_recon_wf, buffernode, [
             ('outputnode.out_brainmask', 't1w_mask')]),
@@ -626,9 +616,11 @@ the brain-extracted T1w using `fast` [FSL {fsl_ver}, RRID:SCR_002823,
             ('surfaces', 'inputnode.surfaces'),
             ('morphometrics', 'inputnode.morphometrics'),
         ]),
+        (anat_ribbon_wf, anat_derivatives_wf, [
+            ("outputnode.anat_ribbon", "inputnode.anat_ribbon"),
+        ]),
     ])
     # fmt:on
-
     return workflow
 
 
@@ -856,8 +848,9 @@ def _aseg_to_three():
 
 def _split_segments(in_file):
     from pathlib import Path
-    import numpy as np
+
     import nibabel as nb
+    import numpy as np
 
     segimg = nb.load(in_file)
     data = np.int16(segimg.dataobj)

--- a/smriprep/workflows/base.py
+++ b/smriprep/workflows/base.py
@@ -188,9 +188,7 @@ def init_smriprep_wf(
         for node in single_subject_wf._get_all_nodes():
             node.config = deepcopy(single_subject_wf.config)
         if freesurfer:
-            smriprep_wf.connect(
-                fsdir, "subjects_dir", single_subject_wf, "inputnode.subjects_dir"
-            )
+            smriprep_wf.connect(fsdir, "subjects_dir", single_subject_wf, "inputnode.subjects_dir")
         else:
             smriprep_wf.add_nodes([single_subject_wf])
 
@@ -351,13 +349,9 @@ to workflows in *sMRIPrep*'s documentation]\
             Path(output_dir) / "smriprep", subject_id, std_spaces, freesurfer
         )
 
-    inputnode = pe.Node(
-        niu.IdentityInterface(fields=["subjects_dir"]), name="inputnode"
-    )
+    inputnode = pe.Node(niu.IdentityInterface(fields=["subjects_dir"]), name="inputnode")
 
-    bidssrc = pe.Node(
-        BIDSDataGrabber(subject_data=subject_data, anat_only=True), name="bidssrc"
-    )
+    bidssrc = pe.Node(BIDSDataGrabber(subject_data=subject_data, anat_only=True), name="bidssrc")
 
     bids_info = pe.Node(
         BIDSInfo(bids_dir=layout.root), name="bids_info", run_without_submitting=True

--- a/smriprep/workflows/norm.py
+++ b/smriprep/workflows/norm.py
@@ -135,9 +135,7 @@ The following template{tpls} selected for spatial normalization:
             ants_ver=ANTsInfo.version() or "(version unknown)",
             targets="%s standard space%s"
             % (
-                defaultdict(
-                    "several".format, {1: "one", 2: "two", 3: "three", 4: "four"}
-                )[ntpls],
+                defaultdict("several".format, {1: "one", 2: "two", 3: "three", 4: "four"})[ntpls],
                 "s" * (ntpls != 1),
             ),
             targets_id=", ".join(templates),
@@ -227,9 +225,7 @@ The following template{tpls} selected for spatial normalization:
     std_dseg = pe.Node(ApplyTransforms(interpolation="MultiLabel"), name="std_dseg")
 
     std_tpms = pe.MapNode(
-        ApplyTransforms(
-            dimension=3, default_value=0, float=True, interpolation="Gaussian"
-        ),
+        ApplyTransforms(dimension=3, default_value=0, float=True, interpolation="Gaussian"),
         iterfield=["input_image"],
         name="std_tpms",
     )

--- a/smriprep/workflows/outputs.py
+++ b/smriprep/workflows/outputs.py
@@ -21,10 +21,10 @@
 #     https://www.nipreps.org/community/licensing/
 #
 """Writing outputs."""
-from nipype.pipeline import engine as pe
 from nipype.interfaces import utility as niu
-from niworkflows.interfaces.nibabel import ApplyMask
+from nipype.pipeline import engine as pe
 from niworkflows.engine.workflows import LiterateWorkflow as Workflow
+from niworkflows.interfaces.nibabel import ApplyMask
 
 from ..interfaces import DerivativesDataSink
 
@@ -69,10 +69,10 @@ def init_anat_reports_wf(*, freesurfer, output_dir, name="anat_reports_wf"):
         Template space and specifications
 
     """
-    from niworkflows.interfaces.reportlets.registration import (
-        SimpleBeforeAfterRPT as SimpleBeforeAfter,
-    )
     from niworkflows.interfaces.reportlets.masks import ROIsPlot
+    from niworkflows.interfaces.reportlets.registration import \
+        SimpleBeforeAfterRPT as SimpleBeforeAfter
+
     from ..interfaces.templateflow import TemplateFlowSelect
 
     workflow = Workflow(name=name)
@@ -91,9 +91,7 @@ def init_anat_reports_wf(*, freesurfer, output_dir, name="anat_reports_wf"):
     ]
     inputnode = pe.Node(niu.IdentityInterface(fields=inputfields), name="inputnode")
 
-    seg_rpt = pe.Node(
-        ROIsPlot(colors=["b", "magenta"], levels=[1.5, 2.5]), name="seg_rpt"
-    )
+    seg_rpt = pe.Node(ROIsPlot(colors=["b", "magenta"], levels=[1.5, 2.5]), name="seg_rpt")
 
     t1w_conform_check = pe.Node(
         niu.Function(function=_empty_report),
@@ -102,17 +100,13 @@ def init_anat_reports_wf(*, freesurfer, output_dir, name="anat_reports_wf"):
     )
 
     ds_t1w_conform_report = pe.Node(
-        DerivativesDataSink(
-            base_directory=output_dir, desc="conform", datatype="figures"
-        ),
+        DerivativesDataSink(base_directory=output_dir, desc="conform", datatype="figures"),
         name="ds_t1w_conform_report",
         run_without_submitting=True,
     )
 
     ds_t1w_dseg_mask_report = pe.Node(
-        DerivativesDataSink(
-            base_directory=output_dir, suffix="dseg", datatype="figures"
-        ),
+        DerivativesDataSink(base_directory=output_dir, suffix="dseg", datatype="figures"),
         name="ds_t1w_dseg_mask_report",
         run_without_submitting=True,
     )
@@ -146,9 +140,7 @@ def init_anat_reports_wf(*, freesurfer, output_dir, name="anat_reports_wf"):
     norm_rpt.inputs.after_label = "Participant"  # after
 
     ds_std_t1w_report = pe.Node(
-        DerivativesDataSink(
-            base_directory=output_dir, suffix="T1w", datatype="figures"
-        ),
+        DerivativesDataSink(base_directory=output_dir, suffix="T1w", datatype="figures"),
         name="ds_std_t1w_report",
         run_without_submitting=True,
     )
@@ -178,9 +170,7 @@ def init_anat_reports_wf(*, freesurfer, output_dir, name="anat_reports_wf"):
         recon_report.interface._always_run = True
 
         ds_recon_report = pe.Node(
-            DerivativesDataSink(
-                base_directory=output_dir, desc="reconall", datatype="figures"
-            ),
+            DerivativesDataSink(base_directory=output_dir, desc="reconall", datatype="figures"),
             name="ds_recon_report",
             run_without_submitting=True,
         )
@@ -267,6 +257,8 @@ def init_anat_derivatives_wf(
         GIFTI surfaces (gray/white boundary, midthickness, pial, inflated)
     morphometrics
         GIFTIs of cortical thickness, curvature, and sulcal depth
+    anat_ribbon
+        Cortical ribbon volume in T1w space
     t1w_fs_aseg
         FreeSurfer's aseg segmentation, in native T1w space
     t1w_fs_aparc
@@ -294,6 +286,7 @@ def init_anat_derivatives_wf(
                 "fsnative2t1w_xfm",
                 "surfaces",
                 "morphometrics",
+                "anat_ribbon",
                 "t1w_fs_aseg",
                 "t1w_fs_aparc",
             ]
@@ -312,9 +305,7 @@ def init_anat_derivatives_wf(
     ds_t1w_preproc.inputs.SkullStripped = False
 
     ds_t1w_mask = pe.Node(
-        DerivativesDataSink(
-            base_directory=output_dir, desc="brain", suffix="mask", compress=True
-        ),
+        DerivativesDataSink(base_directory=output_dir, desc="brain", suffix="mask", compress=True),
         name="ds_t1w_mask",
         run_without_submitting=True,
     )
@@ -351,9 +342,7 @@ def init_anat_derivatives_wf(
     # Transforms
     if spaces.get_spaces(nonstandard=False, dim=(3,)):
         ds_std2t1w_xfm = pe.MapNode(
-            DerivativesDataSink(
-                base_directory=output_dir, to="T1w", mode="image", suffix="xfm"
-            ),
+            DerivativesDataSink(base_directory=output_dir, to="T1w", mode="image", suffix="xfm"),
             iterfield=("in_file", "from"),
             name="ds_std2t1w_xfm",
             run_without_submitting=True,
@@ -406,17 +395,14 @@ def init_anat_derivatives_wf(
 
     # Write derivatives in standard spaces specified by --output-spaces
     if getattr(spaces, "_cached") is not None and spaces.cached.references:
-        from niworkflows.interfaces.space import SpaceDataSource
+        from niworkflows.interfaces.fixes import \
+            FixHeaderApplyTransforms as ApplyTransforms
         from niworkflows.interfaces.nibabel import GenerateSamplingReference
-        from niworkflows.interfaces.fixes import (
-            FixHeaderApplyTransforms as ApplyTransforms,
-        )
+        from niworkflows.interfaces.space import SpaceDataSource
 
         from ..interfaces.templateflow import TemplateFlowSelect
 
-        spacesource = pe.Node(
-            SpaceDataSource(), name="spacesource", run_without_submitting=True
-        )
+        spacesource = pe.Node(SpaceDataSource(), name="spacesource", run_without_submitting=True)
         spacesource.iterables = (
             "in_tuple",
             [(s.fullname, s.spec) for s in spaces.cached.get_standard(dim=(3,))],
@@ -433,9 +419,7 @@ def init_anat_derivatives_wf(
             name="select_xfm",
             run_without_submitting=True,
         )
-        select_tpl = pe.Node(
-            TemplateFlowSelect(), name="select_tpl", run_without_submitting=True
-        )
+        select_tpl = pe.Node(TemplateFlowSelect(), name="select_tpl", run_without_submitting=True)
 
         gen_ref = pe.Node(GenerateSamplingReference(), name="gen_ref", mem_gb=0.01)
 
@@ -453,16 +437,10 @@ def init_anat_derivatives_wf(
             name="anat2std_t1w",
         )
 
-        anat2std_mask = pe.Node(
-            ApplyTransforms(interpolation="MultiLabel"), name="anat2std_mask"
-        )
-        anat2std_dseg = pe.Node(
-            ApplyTransforms(interpolation="MultiLabel"), name="anat2std_dseg"
-        )
+        anat2std_mask = pe.Node(ApplyTransforms(interpolation="MultiLabel"), name="anat2std_mask")
+        anat2std_dseg = pe.Node(ApplyTransforms(interpolation="MultiLabel"), name="anat2std_dseg")
         anat2std_tpms = pe.MapNode(
-            ApplyTransforms(
-                dimension=3, default_value=0, float=True, interpolation="Gaussian"
-            ),
+            ApplyTransforms(dimension=3, default_value=0, float=True, interpolation="Gaussian"),
             iterfield=["input_image"],
             name="anat2std_tpms",
         )
@@ -488,17 +466,13 @@ def init_anat_derivatives_wf(
         ds_std_mask.inputs.Type = "Brain"
 
         ds_std_dseg = pe.Node(
-            DerivativesDataSink(
-                base_directory=output_dir, suffix="dseg", compress=True
-            ),
+            DerivativesDataSink(base_directory=output_dir, suffix="dseg", compress=True),
             name="ds_std_dseg",
             run_without_submitting=True,
         )
 
         ds_std_tpms = pe.Node(
-            DerivativesDataSink(
-                base_directory=output_dir, suffix="probseg", compress=True
-            ),
+            DerivativesDataSink(base_directory=output_dir, suffix="probseg", compress=True),
             name="ds_std_tpms",
             run_without_submitting=True,
         )
@@ -587,12 +561,8 @@ def init_anat_derivatives_wf(
     from niworkflows.interfaces.surf import Path2BIDS
 
     # FS native space transforms
-    lta2itk_fwd = pe.Node(
-        ConcatenateXFMs(), name="lta2itk_fwd", run_without_submitting=True
-    )
-    lta2itk_inv = pe.Node(
-        ConcatenateXFMs(), name="lta2itk_inv", run_without_submitting=True
-    )
+    lta2itk_fwd = pe.Node(ConcatenateXFMs(), name="lta2itk_fwd", run_without_submitting=True)
+    lta2itk_inv = pe.Node(ConcatenateXFMs(), name="lta2itk_inv", run_without_submitting=True)
     ds_t1w_fsnative = pe.Node(
         DerivativesDataSink(
             base_directory=output_dir,
@@ -629,7 +599,10 @@ def init_anat_derivatives_wf(
     )
     # Morphometrics
     name_morphs = pe.MapNode(
-        Path2BIDS(), iterfield="in_file", name="name_morphs", run_without_submitting=True,
+        Path2BIDS(),
+        iterfield="in_file",
+        name="name_morphs",
+        run_without_submitting=True,
     )
     ds_morphs = pe.MapNode(
         DerivativesDataSink(base_directory=output_dir, extension=".shape.gii"),
@@ -637,11 +610,21 @@ def init_anat_derivatives_wf(
         name="ds_morphs",
         run_without_submitting=True,
     )
+    # Ribbon volume
+    ds_anat_ribbon = pe.Node(
+        DerivativesDataSink(
+            base_directory=output_dir,
+            desc="ribbon",
+            suffix="mask",
+            extension=".nii.gz",
+            compress=True,
+        ),
+        name="ds_anat_ribbon",
+        run_without_submitting=True,
+    )
     # Parcellations
     ds_t1w_fsaseg = pe.Node(
-        DerivativesDataSink(
-            base_directory=output_dir, desc="aseg", suffix="dseg", compress=True
-        ),
+        DerivativesDataSink(base_directory=output_dir, desc="aseg", suffix="dseg", compress=True),
         name="ds_t1w_fsaseg",
         run_without_submitting=True,
     )
@@ -675,6 +658,9 @@ def init_anat_derivatives_wf(
                                     ('source_files', 'source_file')]),
         (inputnode, ds_t1w_fsparc, [('t1w_fs_aparc', 'in_file'),
                                     ('source_files', 'source_file')]),
+        (inputnode, ds_anat_ribbon, [('anat_ribbon', 'in_file'),
+                                    ('source_files', 'source_file')]),
+
     ])
     # fmt:on
     return workflow
@@ -691,20 +677,17 @@ def _bids_relative(in_files, bids_root):
 
 def _rpt_masks(mask_file, before, after, after_mask=None):
     from os.path import abspath
+
     import nibabel as nb
 
     msk = nb.load(mask_file).get_fdata() > 0
     bnii = nb.load(before)
-    nb.Nifti1Image(bnii.get_fdata() * msk, bnii.affine, bnii.header).to_filename(
-        "before.nii.gz"
-    )
+    nb.Nifti1Image(bnii.get_fdata() * msk, bnii.affine, bnii.header).to_filename("before.nii.gz")
     if after_mask is not None:
         msk = nb.load(after_mask).get_fdata() > 0
 
     anii = nb.load(after)
-    nb.Nifti1Image(anii.get_fdata() * msk, anii.affine, anii.header).to_filename(
-        "after.nii.gz"
-    )
+    nb.Nifti1Image(anii.get_fdata() * msk, anii.affine, anii.header).to_filename("after.nii.gz")
     return abspath("before.nii.gz"), abspath("after.nii.gz")
 
 
@@ -730,6 +713,7 @@ def _fmt(in_template):
 
 def _empty_report(in_file=None):
     from pathlib import Path
+
     from nipype.interfaces.base import isdefined
 
     if in_file is not None and isdefined(in_file):
@@ -757,6 +741,7 @@ def _no_native(value):
 
 def _drop_path(in_path):
     from pathlib import Path
+
     from templateflow.conf import TF_HOME
 
     return str(Path(in_path).relative_to(TF_HOME))

--- a/smriprep/workflows/outputs.py
+++ b/smriprep/workflows/outputs.py
@@ -70,8 +70,9 @@ def init_anat_reports_wf(*, freesurfer, output_dir, name="anat_reports_wf"):
 
     """
     from niworkflows.interfaces.reportlets.masks import ROIsPlot
-    from niworkflows.interfaces.reportlets.registration import \
-        SimpleBeforeAfterRPT as SimpleBeforeAfter
+    from niworkflows.interfaces.reportlets.registration import (
+        SimpleBeforeAfterRPT as SimpleBeforeAfter,
+    )
 
     from ..interfaces.templateflow import TemplateFlowSelect
 
@@ -395,8 +396,7 @@ def init_anat_derivatives_wf(
 
     # Write derivatives in standard spaces specified by --output-spaces
     if getattr(spaces, "_cached") is not None and spaces.cached.references:
-        from niworkflows.interfaces.fixes import \
-            FixHeaderApplyTransforms as ApplyTransforms
+        from niworkflows.interfaces.fixes import FixHeaderApplyTransforms as ApplyTransforms
         from niworkflows.interfaces.nibabel import GenerateSamplingReference
         from niworkflows.interfaces.space import SpaceDataSource
 

--- a/smriprep/workflows/surfaces.py
+++ b/smriprep/workflows/surfaces.py
@@ -34,12 +34,13 @@ from nipype.interfaces import utility as niu
 from nipype.interfaces.base import Undefined
 from nipype.pipeline import engine as pe
 from niworkflows.engine.workflows import LiterateWorkflow as Workflow
-from niworkflows.interfaces.freesurfer import (FSDetectInputs,
-                                               FSInjectBrainExtracted,
-                                               MakeMidthickness)
+from niworkflows.interfaces.freesurfer import (
+    FSDetectInputs,
+    FSInjectBrainExtracted,
+    MakeMidthickness,
+)
 from niworkflows.interfaces.freesurfer import PatchedLTAConvert as LTAConvert
-from niworkflows.interfaces.freesurfer import \
-    PatchedRobustRegister as RobustRegister
+from niworkflows.interfaces.freesurfer import PatchedRobustRegister as RobustRegister
 from niworkflows.interfaces.freesurfer import RefineBrainMask
 
 from ..interfaces.freesurfer import ReconAll


### PR DESCRIPTION
- Adds interface CreateSignedDistanceVolume for Workbench's wb_command -create-signed-distance-volume

- Adds init_anat_ribbon_wf to surfaces.py, which makes a cortical ribbon volume based on the signed distance function of the white and pial surfaces, as in HCP pipelines. 

- Ribbon volume is output as anat derivative named  "*_desc-ribbon_mask.nii.gz". 

