### PR TITLE
ENH: Enable resampling morphometrics to fsLR CIFTI-2 files

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ python_requires = >=3.8
 install_requires =
     indexed_gzip >= 0.8.8
     lockfile
+    looseversion
     matplotlib >= 2.2.0
     nibabel >= 4.0.1
     nipype >= 1.7.0

--- a/smriprep/conftest.py
+++ b/smriprep/conftest.py
@@ -1,3 +1,22 @@
 import os
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import pytest
 
 os.environ['NO_ET'] = '1'
+
+
+@pytest.fixture(autouse=True, scope="session")
+def default_cwd():
+    cwd = os.getcwd()
+    with TemporaryDirectory(prefix="smriprepTest") as tmpdir:
+        try:
+            os.chdir(tmpdir)
+            yield Path(tmpdir)
+        finally:
+            os.chdir(cwd)
+
+
+@pytest.fixture(autouse=True, scope="session")
+def populate_default_cwd(default_cwd):
+    Path.write_bytes(default_cwd / 'lh.white', b'')

--- a/smriprep/interfaces/cifti.py
+++ b/smriprep/interfaces/cifti.py
@@ -1,0 +1,196 @@
+import json
+from pathlib import Path
+import typing as ty
+
+import nibabel as nb
+import numpy as np
+
+from nibabel import cifti2 as ci
+from nipype.interfaces.base import TraitedSpec, traits, File, SimpleInterface
+from templateflow import api as tf
+
+
+class _GenerateDScalarInputSpec(TraitedSpec):
+    surface_target = traits.Enum(
+        "fsLR",
+        usedefault=True,
+        desc="CIFTI surface target space",
+    )
+    grayordinates = traits.Enum(
+        "91k", "170k", usedefault=True, desc="Final CIFTI grayordinates"
+    )
+    scalar_surfs = traits.List(
+        File(exists=True),
+        mandatory=True,
+        desc="list of surface BOLD GIFTI files (length 2 with order [L,R])",
+    )
+    scalar_name = traits.Str(mandatory=True, desc="Name of scalar")
+
+
+class _GenerateDScalarOutputSpec(TraitedSpec):
+    out_file = File(desc="generated CIFTI file")
+    out_metadata = File(desc="CIFTI metadata JSON")
+
+
+class GenerateDScalar(SimpleInterface):
+    """
+    Generate a HCP-style CIFTI-2 image from scalar surface files.
+    """
+    input_spec = _GenerateDScalarInputSpec
+    output_spec = _GenerateDScalarOutputSpec
+
+    def _run_interface(self, runtime):
+
+        surface_labels, metadata = _prepare_cifti(self.inputs.grayordinates)
+        self._results["out_file"] = _create_cifti_image(
+            self.inputs.scalar_surfs,
+            surface_labels,
+            self.inputs.scalar_name,
+            metadata,
+        )
+        metadata_file = Path("dscalar.json").absolute()
+        metadata_file.write_text(json.dumps(metadata, indent=2))
+        self._results["out_metadata"] = str(metadata_file)
+        return runtime
+
+
+def _prepare_cifti(grayordinates: str) -> ty.Tuple[list, dict]:
+    """
+    Fetch the required templates needed for CIFTI-2 generation, based on input surface density.
+
+    Parameters
+    ----------
+    grayordinates :
+        Total CIFTI grayordinates (91k, 170k)
+
+    Returns
+    -------
+    surface_labels
+        Surface label files for vertex inclusion/exclusion.
+    metadata
+        Dictionary with BIDS metadata.
+
+    Examples
+    --------
+    >>> surface_labels, metadata = _prepare_cifti('91k')
+    >>> surface_labels  # doctest: +ELLIPSIS
+    ['.../tpl-fsLR_hemi-L_den-32k_desc-nomedialwall_dparc.label.gii', \
+     '.../tpl-fsLR_hemi-R_den-32k_desc-nomedialwall_dparc.label.gii']
+    >>> metadata # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+    {'Density': '91,282 grayordinates corresponding to all of the grey matter sampled at a \
+2mm average vertex spacing...', 'SpatialReference': {'CIFTI_STRUCTURE_CORTEX_LEFT': ...}}
+
+    """
+
+    grayord_key = {
+        "91k": {
+            "surface-den": "32k",
+            "tf-res": "02",
+            "grayords": "91,282",
+            "res-mm": "2mm"
+        },
+        "170k": {
+            "surface-den": "59k",
+            "tf-res": "06",
+            "grayords": "170,494",
+            "res-mm": "1.6mm"
+        }
+    }
+    if grayordinates not in grayord_key:
+        raise NotImplementedError(f"Grayordinates {grayordinates} is not supported.")
+
+    total_grayords = grayord_key[grayordinates]['grayords']
+    res_mm = grayord_key[grayordinates]['res-mm']
+    surface_density = grayord_key[grayordinates]['surface-den']
+    # Fetch templates
+    surface_labels = [
+        str(
+            tf.get(
+                "fsLR",
+                density=surface_density,
+                hemi=hemi,
+                desc="nomedialwall",
+                suffix="dparc",
+                raise_empty=True,
+            )
+        )
+        for hemi in ("L", "R")
+    ]
+
+    tf_url = "https://templateflow.s3.amazonaws.com"
+    surfaces_url = (  # midthickness is the default, but varying levels of inflation are all valid
+        f"{tf_url}/tpl-fsLR/tpl-fsLR_den-{surface_density}_hemi-%s_midthickness.surf.gii"
+    )
+    metadata = {
+        "Density": (
+            f"{total_grayords} grayordinates corresponding to all of the grey matter sampled at a "
+            f"{res_mm} average vertex spacing on the surface"
+        ),
+        "SpatialReference": {
+            "CIFTI_STRUCTURE_CORTEX_LEFT": surfaces_url % "L",
+            "CIFTI_STRUCTURE_CORTEX_RIGHT": surfaces_url % "R",
+        }
+    }
+    return surface_labels, metadata
+
+
+def _create_cifti_image(
+    scalar_surfs: ty.Tuple[str, str],
+    surface_labels: ty.Tuple[str, str],
+    scalar_name: str,
+    metadata: ty.Optional[dict] = None,
+):
+    """
+    Generate CIFTI image in target space.
+
+    Parameters
+    ----------
+    scalar_surfs
+        Surface scalar files (L,R)
+    surface_labels
+        Surface label files used to remove medial wall (L,R)
+    metadata
+        Metadata to include in CIFTI header
+    scalar_name
+        Name to apply to scalar map
+
+    Returns
+    -------
+    out :
+        BOLD data saved as CIFTI dtseries
+    """
+    brainmodels = []
+    arrays = []
+
+    for idx, hemi in enumerate(('left', 'right')):
+        labels = nb.load(surface_labels[idx])
+        mask = np.bool_(labels.darrays[0].data)
+
+        struct = f'cortex_{hemi}'
+        brainmodels.append(
+            ci.BrainModelAxis(struct, vertex=np.nonzero(mask)[0], nvertices={struct: len(mask)})
+        )
+
+        morph_scalar = nb.load(scalar_surfs[idx])
+        arrays.append(morph_scalar.darrays[0].data[mask].astype("float32"))
+
+    # provide some metadata to CIFTI matrix
+    if not metadata:
+        metadata = {
+            "surface": "fsLR",
+        }
+
+    # generate and save CIFTI image
+    hdr = ci.Cifti2Header.from_axes(
+        (ci.ScalarAxis([scalar_name]), brainmodels[0] + brainmodels[1])
+    )
+    hdr.matrix.metadata = ci.Cifti2MetaData(metadata)
+
+    img = ci.Cifti2Image(dataobj=np.atleast_2d(np.concatenate(arrays)), header=hdr)
+    img.nifti_header.set_intent("NIFTI_INTENT_CONNECTIVITY_DENSE_SCALARS")
+
+    stem = Path(scalar_surfs[0]).name.split(".")[0]
+    cifti_stem = "_".join(ent for ent in stem.split("_") if not ent.startswith("hemi-"))
+    out_file = Path.cwd() / f"{cifti_stem}.dscalar.nii"
+    img.to_filename(out_file)
+    return out_file

--- a/smriprep/interfaces/freesurfer.py
+++ b/smriprep/interfaces/freesurfer.py
@@ -22,6 +22,7 @@
 #
 """Nipype's recon-all replacement."""
 import os
+from looseversion import LooseVersion
 from nipype import logging
 from nipype.utils.filemanip import check_depends
 from nipype.interfaces.base import traits, InputMultiObject, isdefined, File
@@ -173,6 +174,11 @@ class ReconAll(fs.ReconAll):
             elif flag in cmd:
                 no_run = False
                 continue
+
+            # FreeSurfer changed the meaning and order of -apas2aseg without
+            # updating the recon table on the wiki. Hack it until fixed in nipype.
+            if step == 'apas2aseg' and fs.Info.looseversion() >= LooseVersion("7.3.0"):
+                infiles = []
 
             subj_dir = os.path.join(subjects_dir, self.inputs.subject_id)
             if check_depends(

--- a/smriprep/workflows/base.py
+++ b/smriprep/workflows/base.py
@@ -414,6 +414,7 @@ to workflows in *sMRIPrep*'s documentation]\
         skull_strip_mode=skull_strip_mode,
         skull_strip_template=skull_strip_template,
         spaces=spaces,
+        cifti_output=False,  # Enabling this needs a CLI flag
     )
 
     # fmt:off

--- a/smriprep/workflows/outputs.py
+++ b/smriprep/workflows/outputs.py
@@ -204,6 +204,7 @@ def init_anat_derivatives_wf(
     t2w,
     output_dir,
     spaces,
+    cifti_output,
     name="anat_derivatives_wf",
     tpm_labels=BIDS_TISSUE_ORDER,
 ):
@@ -224,6 +225,8 @@ def init_anat_derivatives_wf(
         Workflow name (default: anat_derivatives_wf)
     tpm_labels : :obj:`tuple`
         Tissue probability maps in order
+    cifti_output : :obj:`bool`
+        Whether the ``--cifti-output`` flag was set.
 
     Inputs
     ------
@@ -273,6 +276,12 @@ def init_anat_derivatives_wf(
         FreeSurfer's aseg segmentation, in native T1w space
     t1w_fs_aparc
         FreeSurfer's aparc+aseg segmentation, in native T1w space
+    cifti_morph
+        Morphometric CIFTI-2 dscalar files
+    cifti_density
+        Grayordinate density
+    cifti_metadata
+        JSON files containing metadata dictionaries
 
     """
     from niworkflows.interfaces.utility import KeySelect
@@ -299,6 +308,9 @@ def init_anat_derivatives_wf(
                 "anat_ribbon",
                 "t1w_fs_aseg",
                 "t1w_fs_aparc",
+                'cifti_metadata',
+                'cifti_density',
+                'cifti_morph',
             ]
         ),
         name="inputnode",
@@ -696,6 +708,27 @@ def init_anat_derivatives_wf(
 
     ])
     # fmt:on
+
+    if cifti_output:
+        ds_cifti_morph = pe.MapNode(
+            DerivativesDataSink(
+                base_directory=output_dir,
+                suffix=['curv', 'sulc', 'thickness'],
+                compress=False,
+                space='fsLR',
+            ),
+            name='ds_cifti_morph',
+            run_without_submitting=True,
+            iterfield=["in_file", "meta_dict", "suffix"],
+        )
+        # fmt:off
+        workflow.connect([
+            (inputnode, ds_cifti_morph, [('cifti_morph', 'in_file'),
+                                         ('source_files', 'source_file'),
+                                         ('cifti_density', 'density'),
+                                         (('cifti_metadata', _read_jsons), 'meta_dict')])
+        ])
+        # fmt:on
     return workflow
 
 
@@ -796,3 +829,10 @@ def _combine_cohort(in_template):
             return template
         return f"{template}+{in_template.split('cohort-')[-1].split(':')[0]}"
     return [_combine_cohort(v) for v in in_template]
+
+
+def _read_jsons(in_file):
+    from json import loads
+    from pathlib import Path
+
+    return [loads(Path(f).read_text()) for f in in_file]

--- a/smriprep/workflows/surfaces.py
+++ b/smriprep/workflows/surfaces.py
@@ -27,6 +27,7 @@ Surface preprocessing workflows.
 structural images.
 
 """
+import typing as ty
 from nipype.pipeline import engine as pe
 from nipype.interfaces.base import Undefined
 from nipype.interfaces import (
@@ -34,6 +35,7 @@ from nipype.interfaces import (
     io as nio,
     utility as niu,
     freesurfer as fs,
+    workbench as wb,
 )
 
 from ..interfaces.freesurfer import ReconAll
@@ -823,6 +825,193 @@ def init_anat_ribbon_wf(name="anat_ribbon_wf"):
     return workflow
 
 
+def init_morph_grayords_wf(
+    grayord_density: ty.Literal['91k', '170k'],
+    name: str = "bold_grayords_wf",
+):
+    """
+    Sample Grayordinates files onto the fsLR atlas.
+
+    Outputs are in CIFTI2 format.
+
+    Workflow Graph
+        .. workflow::
+            :graph2use: colored
+            :simple_form: yes
+
+            from smriprep.workflows.surfaces import init_morph_grayords_wf
+            wf = init_morph_grayords_wf(grayord_density="91k")
+
+    Parameters
+    ----------
+    grayord_density : :obj:`str`
+        Either `91k` or `170k`, representing the total of vertices or *grayordinates*.
+    name : :obj:`str`
+        Unique name for the subworkflow (default: ``"bold_grayords_wf"``)
+
+    Inputs
+    ------
+    subject_id : :obj:`str`
+        FreeSurfer subject ID
+    subjects_dir : :obj:`str`
+        FreeSurfer SUBJECTS_DIR
+
+    Outputs
+    -------
+    cifti_morph : :obj:`list` of :obj:`str`
+        Paths of CIFTI dscalar files
+    cifti_metadata : :obj:`list` of :obj:`str`
+        Paths to JSON files containing metadata corresponding to ``cifti_morph``
+
+    """
+    import templateflow.api as tf
+    from niworkflows.engine.workflows import LiterateWorkflow as Workflow
+    from smriprep.interfaces.cifti import GenerateDScalar
+
+    workflow = Workflow(name=name)
+    workflow.__desc__ = f"""\
+*Grayordinate* "dscalar" files [@hcppipelines] containing {grayord_density} samples were
+also generated using the highest-resolution ``fsaverage`` as an intermediate standardized
+surface space.
+"""
+
+    fslr_density = "32k" if grayord_density == "91k" else "59k"
+
+    inputnode = pe.Node(
+        niu.IdentityInterface(fields=["subject_id", "subjects_dir"]),
+        name="inputnode",
+    )
+
+    outputnode = pe.Node(
+        niu.IdentityInterface(fields=["cifti_morph", "cifti_metadata"]),
+        name="outputnode",
+    )
+
+    get_surfaces = pe.Node(nio.FreeSurferSource(), name="get_surfaces")
+
+    surfmorph_list = pe.Node(
+        niu.Merge(3, ravel_inputs=True),
+        name="surfmorph_list",
+        run_without_submitting=True,
+    )
+
+    surf2surf = pe.MapNode(
+        fs.SurfaceTransform(target_subject="fsaverage", target_type="gii"),
+        iterfield=["source_file", "hemi"],
+        name="surf2surf",
+        mem_gb=0.01,
+    )
+    surf2surf.inputs.hemi = ["lh", "rh"] * 3
+
+    # Setup Workbench command. LR ordering for hemi can be assumed, as it is imposed
+    # by the iterfield of the MapNode in the surface sampling workflow above.
+    resample = pe.MapNode(
+        wb.MetricResample(method="ADAP_BARY_AREA", area_metrics=True),
+        name="resample",
+        iterfield=[
+            "in_file",
+            "out_file",
+            "new_sphere",
+            "new_area",
+            "current_sphere",
+            "current_area",
+        ],
+    )
+    resample.inputs.current_sphere = [
+        str(
+            tf.get(
+                "fsaverage",
+                hemi=hemi,
+                density="164k",
+                desc="std",
+                suffix="sphere",
+                extension=".surf.gii",
+            )
+        )
+        for hemi in "LR"
+    ] * 3
+    resample.inputs.current_area = [
+        str(
+            tf.get(
+                "fsaverage",
+                hemi=hemi,
+                density="164k",
+                desc="vaavg",
+                suffix="midthickness",
+                extension=".shape.gii",
+            )
+        )
+        for hemi in "LR"
+    ] * 3
+    resample.inputs.new_sphere = [
+        str(
+            tf.get(
+                "fsLR",
+                space="fsaverage",
+                hemi=hemi,
+                density=fslr_density,
+                suffix="sphere",
+                extension=".surf.gii",
+            )
+        )
+        for hemi in "LR"
+    ] * 3
+    resample.inputs.new_area = [
+        str(
+            tf.get(
+                "fsLR",
+                hemi=hemi,
+                density=fslr_density,
+                desc="vaavg",
+                suffix="midthickness",
+                extension=".shape.gii",
+            )
+        )
+        for hemi in "LR"
+    ] * 3
+    resample.inputs.out_file = [
+        f"space-fsLR_hemi-{h}_den-{grayord_density}_{morph}.shape.gii"
+        # Order: curv-L, curv-R, sulc-L, sulc-R, thickness-L, thickness-R
+        for morph in ('curv', 'sulc', 'thickness')
+        for h in "LR"
+    ]
+
+    gen_cifti = pe.MapNode(
+        GenerateDScalar(
+            grayordinates=grayord_density,
+        ),
+        iterfield=['scalar_name', 'scalar_surfs'],
+        name="gen_cifti",
+    )
+    gen_cifti.inputs.scalar_name = ['curv', 'sulc', 'thickness']
+
+    # fmt: off
+    workflow.connect([
+        (inputnode, get_surfaces, [
+            ('subject_id', 'subject_id'),
+            ('subjects_dir', 'subjects_dir'),
+        ]),
+        (inputnode, surf2surf, [
+            ('subject_id', 'source_subject'),
+            ('subjects_dir', 'subjects_dir'),
+        ]),
+        (get_surfaces, surfmorph_list, [
+            (('curv', _sorted_by_basename), 'in1'),
+            (('sulc', _sorted_by_basename), 'in2'),
+            (('thickness', _sorted_by_basename), 'in3'),
+        ]),
+        (surfmorph_list, surf2surf, [('out', 'source_file')]),
+        (surf2surf, resample, [('out_file', 'in_file')]),
+        (resample, gen_cifti, [
+            (("out_file", _collate), "scalar_surfs")]),
+        (gen_cifti, outputnode, [("out_file", "cifti_morph"),
+                                 ("out_metadata", "cifti_metadata")]),
+    ])
+    # fmt: on
+
+    return workflow
+
+
 def _check_cw256(in_files, default_flags):
     import numpy as np
     from nibabel.funcs import concat_images
@@ -841,3 +1030,7 @@ def _sorted_by_basename(inlist):
     from os.path import basename
 
     return sorted(inlist, key=lambda x: str(basename(x)))
+
+
+def _collate(files):
+    return [files[i:i + 2] for i in range(0, len(files), 2)]

--- a/smriprep/workflows/surfaces.py
+++ b/smriprep/workflows/surfaces.py
@@ -38,13 +38,12 @@ from nipype.interfaces import (
     workbench as wb,
 )
 
-from ..interfaces.freesurfer import ReconAll
+from ..interfaces.freesurfer import ReconAll, MakeMidthickness
 
 from niworkflows.engine.workflows import LiterateWorkflow as Workflow
 from niworkflows.interfaces.freesurfer import (
     FSDetectInputs,
     FSInjectBrainExtracted,
-    MakeMidthickness,
     PatchedLTAConvert as LTAConvert,
     PatchedRobustRegister as RobustRegister,
     RefineBrainMask,


### PR DESCRIPTION
Currently inaccessible to smriprep itself because I don't want to add and test a CLI option. Could probably go into a bug-fix release if someone cares about it before the next minor release.