### PR TITLE
PATCH: Add security fix to vendored jquery

### DIFF
--- a/docs/_static/jquery-3.2.1.js
+++ b/docs/_static/jquery-3.2.1.js
@@ -10246,7 +10246,10 @@ if ( !noGlobal ) {
 	window.jQuery = window.$ = jQuery;
 }
 
-
+// Workaround for XSS vulnerability (fixed in jQuery 3.5.0)
+jQuery.htmlPrefilter = function( html ) {
+	return html;
+};
 
 
 return jQuery;


### PR DESCRIPTION
Seemed like the least painful way to address the security concern.

Alternatively, we could upgrade to >= 3.5.0, but I didn't check the difficulty of that transition.