### PR TITLE
MNT: Add `sloppy` argument to workflows, distinguish from `debug`

### DIFF
--- a/smriprep/cli/run.py
+++ b/smriprep/cli/run.py
@@ -579,7 +579,8 @@ def build_workflow(opts, retval):
 
     # Build main workflow
     retval["workflow"] = init_smriprep_wf(
-        debug=opts.sloppy,
+        sloppy=opts.sloppy,
+        debug=False,
         fast_track=opts.fast_track,
         freesurfer=opts.run_reconall,
         fs_subjects_dir=opts.fs_subjects_dir,

--- a/smriprep/workflows/anatomical.py
+++ b/smriprep/workflows/anatomical.py
@@ -76,6 +76,7 @@ def init_anat_preproc_wf(
     spaces,
     cifti_output=False,
     debug=False,
+    sloppy=False,
     existing_derivatives=None,
     name="anat_preproc_wf",
     skull_strip_fixed_seed=False,
@@ -142,6 +143,8 @@ def init_anat_preproc_wf(
         Object containing standard and nonstandard space specifications.
     debug : :obj:`bool`
         Enable debugging outputs
+    sloppy: :obj:`bool`
+        Quick, impercise operations. Used to decrease workflow duration.
     name : :obj:`str`, optional
         Workflow name (default: anat_preproc_wf)
     skull_strip_mode : :obj:`str`
@@ -393,12 +396,12 @@ the brain-extracted T1w using `fast` [FSL {fsl_ver}, RRID:SCR_002823,
             template_spec=skull_strip_template.spec,
             atropos_use_random_seed=not skull_strip_fixed_seed,
             omp_nthreads=omp_nthreads,
-            normalization_quality="precise" if not debug else "testing",
+            normalization_quality="precise" if not sloppy else "testing",
         )
 
     # 4. Spatial normalization
     anat_norm_wf = init_anat_norm_wf(
-        debug=debug,
+        sloppy=sloppy,
         omp_nthreads=omp_nthreads,
         templates=spaces.get_spaces(nonstandard=False, dim=(3,)),
     )

--- a/smriprep/workflows/base.py
+++ b/smriprep/workflows/base.py
@@ -43,6 +43,7 @@ from .anatomical import init_anat_preproc_wf
 
 def init_smriprep_wf(
     *,
+    sloppy,
     debug,
     fast_track,
     freesurfer,
@@ -80,6 +81,7 @@ def init_smriprep_wf(
             from smriprep.workflows.base import init_smriprep_wf
             from niworkflows.utils.spaces import SpatialReferences, Reference
             wf = init_smriprep_wf(
+                sloppy=False,
                 debug=False,
                 fast_track=False,
                 freesurfer=True,
@@ -102,6 +104,8 @@ def init_smriprep_wf(
 
     Parameters
     ----------
+    sloppy: :obj:`bool`
+        Quick, impercise operations. Used to decrease workflow duration.
     debug : :obj:`bool`
         Enable debugging outputs
     fast_track : :obj:`bool`
@@ -164,6 +168,7 @@ def init_smriprep_wf(
 
     for subject_id in subject_list:
         single_subject_wf = init_single_subject_wf(
+            sloppy=sloppy,
             debug=debug,
             freesurfer=freesurfer,
             fast_track=fast_track,
@@ -199,6 +204,7 @@ def init_smriprep_wf(
 
 def init_single_subject_wf(
     *,
+    sloppy,
     debug,
     fast_track,
     freesurfer,
@@ -238,6 +244,7 @@ def init_single_subject_wf(
             from smriprep.workflows.base import init_single_subject_wf
             BIDSLayout = namedtuple('BIDSLayout', ['root'])
             wf = init_single_subject_wf(
+                sloppy=False,
                 debug=False,
                 freesurfer=True,
                 fast_track=False,
@@ -258,6 +265,8 @@ def init_single_subject_wf(
 
     Parameters
     ----------
+    sloppy: :obj:`bool`
+        Quick, impercise operations. Used to decrease workflow duration.
     debug : :obj:`bool`
         Enable debugging outputs
     fast_track : :obj:`bool`
@@ -400,6 +409,7 @@ to workflows in *sMRIPrep*'s documentation]\
     # Preprocessing of T1w (includes registration to MNI)
     anat_preproc_wf = init_anat_preproc_wf(
         bids_root=layout.root,
+        sloppy=sloppy,
         debug=debug,
         existing_derivatives=deriv_cache,
         freesurfer=freesurfer,

--- a/smriprep/workflows/norm.py
+++ b/smriprep/workflows/norm.py
@@ -38,7 +38,7 @@ from ..interfaces.templateflow import TemplateFlowSelect, TemplateDesc
 
 def init_anat_norm_wf(
     *,
-    debug,
+    sloppy,
     omp_nthreads,
     templates,
     name="anat_norm_wf",
@@ -53,7 +53,7 @@ def init_anat_norm_wf(
 
             from smriprep.workflows.norm import init_anat_norm_wf
             wf = init_anat_norm_wf(
-                debug=False,
+                sloppy=False,
                 omp_nthreads=1,
                 templates=['MNI152NLin2009cAsym', 'MNI152NLin6Asym'],
             )
@@ -70,7 +70,7 @@ def init_anat_norm_wf(
 
     Parameters
     ----------
-    debug : :obj:`bool`
+    sloppy : :obj:`bool`
         Apply sloppy arguments to speed up processing. Use with caution,
         registration processes will be very inaccurate.
     omp_nthreads : :obj:`int`
@@ -194,7 +194,7 @@ and accessed with *TemplateFlow* [{tf_ver}, @templateflow]:
     split_desc = pe.Node(TemplateDesc(), run_without_submitting=True, name="split_desc")
 
     tf_select = pe.Node(
-        TemplateFlowSelect(resolution=1 + debug),
+        TemplateFlowSelect(resolution=1 + sloppy),
         name="tf_select",
         run_without_submitting=True,
     )
@@ -208,7 +208,7 @@ and accessed with *TemplateFlow* [{tf_ver}, @templateflow]:
     registration = pe.Node(
         SpatialNormalization(
             float=True,
-            flavor=["precise", "testing"][debug],
+            flavor=["precise", "testing"][sloppy],
         ),
         name="registration",
         n_procs=omp_nthreads,


### PR DESCRIPTION
This adds `sloppy` to the anatomical workflow (and all necessary children), and distinguishes between `debug`, which produces intermediate outputs to facilitate debug certain preprocessing steps (currently none), and `sloppy`, which sacrifices algorithmic performance for speed.

ATM, `debug` has no options, but I left it open to future additions.

Needed for https://github.com/nipreps/nibabies/pull/290