### PR TITLE
ENH: Save msm registration sphere as desc-msm_sphere.surf.gii

### DIFF
--- a/.circleci/ds005_outputs.txt
+++ b/.circleci/ds005_outputs.txt
@@ -25,6 +25,7 @@ smriprep/sub-01/anat/sub-01_hemi-L_desc-reg_sphere.surf.gii
 smriprep/sub-01/anat/sub-01_hemi-L_inflated.surf.gii
 smriprep/sub-01/anat/sub-01_hemi-L_midthickness.surf.gii
 smriprep/sub-01/anat/sub-01_hemi-L_pial.surf.gii
+smriprep/sub-01/anat/sub-01_hemi-L_space-fsLR_desc-msmsulc_sphere.surf.gii
 smriprep/sub-01/anat/sub-01_hemi-L_space-fsLR_desc-reg_sphere.surf.gii
 smriprep/sub-01/anat/sub-01_hemi-L_sulc.shape.gii
 smriprep/sub-01/anat/sub-01_hemi-L_thickness.shape.gii
@@ -34,6 +35,7 @@ smriprep/sub-01/anat/sub-01_hemi-R_desc-reg_sphere.surf.gii
 smriprep/sub-01/anat/sub-01_hemi-R_inflated.surf.gii
 smriprep/sub-01/anat/sub-01_hemi-R_midthickness.surf.gii
 smriprep/sub-01/anat/sub-01_hemi-R_pial.surf.gii
+smriprep/sub-01/anat/sub-01_hemi-R_space-fsLR_desc-msmsulc_sphere.surf.gii
 smriprep/sub-01/anat/sub-01_hemi-R_space-fsLR_desc-reg_sphere.surf.gii
 smriprep/sub-01/anat/sub-01_hemi-R_sulc.shape.gii
 smriprep/sub-01/anat/sub-01_hemi-R_thickness.shape.gii

--- a/smriprep/workflows/anatomical.py
+++ b/smriprep/workflows/anatomical.py
@@ -297,6 +297,9 @@ def init_anat_preproc_wf(
     # fmt:on
     if freesurfer:
         surfaces = ["white", "pial", "midthickness", "inflated", "sphere_reg", "sphere_reg_fsLR"]
+        if msm_sulc:
+            surfaces.append("sphere_reg_msm")
+
         surface_derivatives_wf = init_surface_derivatives_wf(
             msm_sulc=msm_sulc,
             cifti_output=cifti_output,

--- a/smriprep/workflows/outputs.py
+++ b/smriprep/workflows/outputs.py
@@ -712,9 +712,13 @@ def init_ds_surfaces_wf(
             run_without_submitting=True,
         )
         if surf.startswith("sphere_reg"):
-            ds_surf.inputs.desc = "reg"
-            if surf == "sphere_reg_fsLR":
+            if surf == "sphere_reg_msm":
+                ds_surf.inputs.desc = "msmsulc"
                 ds_surf.inputs.space = "fsLR"
+            else:
+                ds_surf.inputs.desc = "reg"
+                if surf == "sphere_reg_fsLR":
+                    ds_surf.inputs.space = "fsLR"
 
         # fmt:off
         workflow.connect([


### PR DESCRIPTION
Follow-up to #358 in smriprep-next. This continues to save the initial `space-fsLR_desc-reg_sphere.surf.gii` and adds `space-fsLR_desc-msm_sphere.surf.gii`.