### PR TITLE
ENH: Add sphere registration to fit workflow, check for precomputed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,9 @@ _machine_defaults: &machine_defaults
 _python_defaults: &python_defaults
   docker:
     - image: cimg/python:3.10.9
+      auth:
+        username: $DOCKER_USER
+        password: $DOCKER_PAT
   working_directory: /tmp/src/smriprep
 
 _docker_auth: &docker_auth
@@ -43,6 +46,9 @@ _pull_from_registry: &pull_from_registry
 docs_deploy: &docs
   docker:
     - image: node:8.10.0
+      auth:
+        username: $DOCKER_USER
+        password: $DOCKER_PAT
   working_directory: /tmp/gh-pages
   steps:
     - run:

--- a/.circleci/ds005_outputs.txt
+++ b/.circleci/ds005_outputs.txt
@@ -16,6 +16,7 @@ smriprep/sub-01/anat/sub-01_desc-brain_mask.json
 smriprep/sub-01/anat/sub-01_desc-brain_mask.nii.gz
 smriprep/sub-01/anat/sub-01_desc-preproc_T1w.json
 smriprep/sub-01/anat/sub-01_desc-preproc_T1w.nii.gz
+smriprep/sub-01/anat/sub-01_desc-ribbon_mask.json
 smriprep/sub-01/anat/sub-01_desc-ribbon_mask.nii.gz
 smriprep/sub-01/anat/sub-01_dseg.nii.gz
 smriprep/sub-01/anat/sub-01_from-fsnative_to-T1w_mode-image_xfm.txt

--- a/.circleci/ds005_outputs.txt
+++ b/.circleci/ds005_outputs.txt
@@ -27,6 +27,7 @@ smriprep/sub-01/anat/sub-01_hemi-L_midthickness.surf.gii
 smriprep/sub-01/anat/sub-01_hemi-L_pial.surf.gii
 smriprep/sub-01/anat/sub-01_hemi-L_space-fsLR_desc-msmsulc_sphere.surf.gii
 smriprep/sub-01/anat/sub-01_hemi-L_space-fsLR_desc-reg_sphere.surf.gii
+smriprep/sub-01/anat/sub-01_hemi-L_sphere.surf.gii
 smriprep/sub-01/anat/sub-01_hemi-L_sulc.shape.gii
 smriprep/sub-01/anat/sub-01_hemi-L_thickness.shape.gii
 smriprep/sub-01/anat/sub-01_hemi-L_white.surf.gii
@@ -37,6 +38,7 @@ smriprep/sub-01/anat/sub-01_hemi-R_midthickness.surf.gii
 smriprep/sub-01/anat/sub-01_hemi-R_pial.surf.gii
 smriprep/sub-01/anat/sub-01_hemi-R_space-fsLR_desc-msmsulc_sphere.surf.gii
 smriprep/sub-01/anat/sub-01_hemi-R_space-fsLR_desc-reg_sphere.surf.gii
+smriprep/sub-01/anat/sub-01_hemi-R_sphere.surf.gii
 smriprep/sub-01/anat/sub-01_hemi-R_sulc.shape.gii
 smriprep/sub-01/anat/sub-01_hemi-R_thickness.shape.gii
 smriprep/sub-01/anat/sub-01_hemi-R_white.surf.gii

--- a/smriprep/data/io_spec.json
+++ b/smriprep/data/io_spec.json
@@ -70,24 +70,6 @@
         "mode": "image"
       }
     },
-    "std_xfms": {
-      "anat2std_xfm": {
-        "datatype": "anat",
-        "extension": "h5",
-        "from": "T1w",
-        "to": [],
-        "suffix": "xfm",
-        "mode": "image"
-      },
-      "std2anat_xfm": {
-        "datatype": "anat",
-        "extension": "h5",
-        "from": [],
-        "to": "T1w",
-        "suffix": "xfm",
-        "mode": "image"
-      }
-    },
     "surfaces": {
       "white": {
         "datatype": "anat",

--- a/smriprep/data/io_spec.json
+++ b/smriprep/data/io_spec.json
@@ -163,6 +163,17 @@
         "suffix": "sphere",
         "extension": ".surf.gii"
       }
+    },
+    "masks": {
+      "anat_ribbon": {
+        "datatype": "anat",
+        "desc": "ribbon",
+        "suffix": "mask",
+        "extension": [
+          ".nii.gz",
+          ".nii"
+        ]
+      }
     }
   },
   "patterns": [

--- a/smriprep/data/io_spec.json
+++ b/smriprep/data/io_spec.json
@@ -89,49 +89,79 @@
       }
     },
     "surfaces": {
-      "t1w_aseg": {
-        "datatype": "anat",
-        "desc": "aseg",
-        "suffix": "dseg"
-      },
-      "t1w_aparc": {
-        "datatype": "anat",
-        "desc": "aparcaseg",
-        "suffix": "dseg"
-      },
-      "t1w2fsnative_xfm": {
-        "datatype": "anat",
-        "from": "T1w",
-        "to": "fsnative",
-        "extension": "txt",
-        "suffix": "xfm",
-        "mode": "image"
-      },
-      "fsnative2t1w_xfm": {
-        "datatype": "anat",
-        "from": "fsnative",
-        "to": "T1w",
-        "extension": "txt",
-        "suffix": "xfm",
-        "mode": "image"
-      },
-      "surfaces": {
+      "white": {
         "datatype": "anat",
         "hemi": ["L", "R"],
-        "extension": "surf.gii",
-        "suffix": [ "inflated", "midthickness", "pial", "white"]
+        "space": null,
+        "suffix": "white",
+        "extension": ".surf.gii"
       },
-      "morphometrics": {
+      "pial": {
         "datatype": "anat",
         "hemi": ["L", "R"],
-        "extension": "shape.gii",
-        "suffix": ["thickness", "sulc", "curv"]
+        "space": null,
+        "suffix": "pial",
+        "extension": ".surf.gii"
       },
-      "anat_ribbon": {
+      "midthickness": {
         "datatype": "anat",
-        "desc": "ribbon",
-        "suffix": "mask",
-        "extension": "nii.gz"
+        "hemi": ["L", "R"],
+        "space": null,
+        "suffix": "midthickness",
+        "extension": ".surf.gii"
+      },
+      "sphere": {
+        "datatype": "anat",
+        "hemi": ["L", "R"],
+        "space": null,
+        "desc": null,
+        "suffix": "sphere",
+        "extension": ".surf.gii"
+      },
+      "thickness": {
+        "datatype": "anat",
+        "hemi": ["L", "R"],
+        "space": null,
+        "suffix": "thickness",
+        "extension": ".shape.gii"
+      },
+      "sulc": {
+        "datatype": "anat",
+        "hemi": ["L", "R"],
+        "space": null,
+        "suffix": "sulc",
+        "extension": ".shape.gii"
+      },
+      "curv": {
+        "datatype": "anat",
+        "hemi": ["L", "R"],
+        "space": null,
+        "suffix": "curv",
+        "extension": ".shape.gii"
+      },
+      "sphere_reg": {
+        "datatype": "anat",
+        "hemi": ["L", "R"],
+        "space": null,
+        "desc": "reg",
+        "suffix": "sphere",
+        "extension": ".surf.gii"
+      },
+      "sphere_reg_fsLR": {
+        "datatype": "anat",
+        "hemi": ["L", "R"],
+        "space": "fsLR",
+        "desc": "reg",
+        "suffix": "sphere",
+        "extension": ".surf.gii"
+      },
+      "sphere_reg_msm": {
+        "datatype": "anat",
+        "hemi": ["L", "R"],
+        "space": "fsLR",
+        "desc": "msmsulc",
+        "suffix": "sphere",
+        "extension": ".surf.gii"
       }
     }
   },

--- a/smriprep/utils/bids.py
+++ b/smriprep/utils/bids.py
@@ -28,31 +28,6 @@ from pkg_resources import resource_filename as pkgrf
 from bids.layout import BIDSLayout
 
 
-def get_outputnode_spec():
-    """
-    Generate outputnode's fields from I/O spec file.
-
-    Examples
-    --------
-    >>> get_outputnode_spec()  # doctest: +NORMALIZE_WHITESPACE
-    ['t1w_preproc', 't1w_mask', 't1w_dseg', 't1w_tpms',
-    'std_preproc', 'std_mask', 'std_dseg', 'std_tpms',
-    'anat2std_xfm', 'std2anat_xfm',
-    't1w2fsnative_xfm', 'fsnative2t1w_xfm',
-    'white', 'pial', 'midthickness', 'sphere',
-    'thickness', 'sulc', 'curv',
-    'sphere_reg', 'sphere_reg_fsLR', 'sphere_reg_msm',
-    'anat_ribbon']
-
-    """
-    spec = loads(Path(pkgrf("smriprep", "data/io_spec.json")).read_text())["queries"]
-    fields = ["_".join((m, s)) for m in ("t1w", "std") for s in spec["baseline"].keys()]
-    fields += [s for s in spec["std_xfms"].keys()]
-    fields += [s for s in spec["surfaces"].keys()]
-    fields += [s for s in spec["masks"].keys()]
-    return fields
-
-
 def collect_derivatives(derivatives_dir, subject_id, std_spaces, spec=None, patterns=None):
     """Gather existing derivatives and compose a cache."""
     if spec is None or patterns is None:

--- a/smriprep/utils/bids.py
+++ b/smriprep/utils/bids.py
@@ -21,7 +21,6 @@
 #     https://www.nipreps.org/community/licensing/
 #
 """Utilities to handle BIDS inputs."""
-from collections import defaultdict
 from pathlib import Path
 from json import loads
 from pkg_resources import resource_filename as pkgrf
@@ -40,9 +39,9 @@ def collect_derivatives(derivatives_dir, subject_id, std_spaces, spec=None, patt
         if patterns is None:
             patterns = _patterns
 
-    derivs_cache = defaultdict(list)
     layout = BIDSLayout(derivatives_dir, config=["bids", "derivatives"], validate=False)
 
+    derivs_cache = {}
     for k, q in spec["baseline"].items():
         q["subject"] = subject_id
         item = layout.get(return_type='filename', **q)
@@ -50,18 +49,6 @@ def collect_derivatives(derivatives_dir, subject_id, std_spaces, spec=None, patt
             continue
 
         derivs_cache["t1w_%s" % k] = item[0] if len(item) == 1 else item
-
-    for space in std_spaces:
-        for k, q in spec["std_xfms"].items():
-            q["subject"] = subject_id
-            q["from"] = q["from"] or space
-            q["to"] = q["to"] or space
-            item = layout.get(return_type='filename', **q)
-            if not item:
-                continue
-            derivs_cache[k] += item
-
-    derivs_cache = dict(derivs_cache)  # Back to a standard dictionary
 
     transforms = derivs_cache.setdefault('transforms', {})
     for space in std_spaces:

--- a/smriprep/utils/bids.py
+++ b/smriprep/utils/bids.py
@@ -38,15 +38,18 @@ def get_outputnode_spec():
     ['t1w_preproc', 't1w_mask', 't1w_dseg', 't1w_tpms',
     'std_preproc', 'std_mask', 'std_dseg', 'std_tpms',
     'anat2std_xfm', 'std2anat_xfm',
-    't1w_aseg', 't1w_aparc',
     't1w2fsnative_xfm', 'fsnative2t1w_xfm',
-    'surfaces', 'morphometrics', 'anat_ribbon']
+    'white', 'pial', 'midthickness', 'sphere',
+    'thickness', 'sulc', 'curv',
+    'sphere_reg', 'sphere_reg_fsLR', 'sphere_reg_msm',
+    'anat_ribbon']
 
     """
     spec = loads(Path(pkgrf("smriprep", "data/io_spec.json")).read_text())["queries"]
     fields = ["_".join((m, s)) for m in ("t1w", "std") for s in spec["baseline"].keys()]
     fields += [s for s in spec["std_xfms"].keys()]
     fields += [s for s in spec["surfaces"].keys()]
+    fields += [s for s in spec["masks"].keys()]
     return fields
 
 

--- a/smriprep/workflows/anatomical.py
+++ b/smriprep/workflows/anatomical.py
@@ -393,6 +393,7 @@ def init_anat_fit_wf(
                 freesurfer=True,
                 hires=True,
                 longitudinal=False,
+                msm_sulc=True,
                 t1w=['t1w.nii.gz'],
                 t2w=['t2w.nii.gz'],
                 skull_strip_mode='force',

--- a/smriprep/workflows/anatomical.py
+++ b/smriprep/workflows/anatomical.py
@@ -312,6 +312,9 @@ def init_anat_preproc_wf(
         ds_surfaces_wf = init_ds_surfaces_wf(
             bids_root=bids_root, output_dir=output_dir, surfaces=["inflated"]
         )
+        ds_curv_wf = init_ds_surface_metrics_wf(
+            bids_root=bids_root, output_dir=output_dir, metrics=["curv"], name="ds_curv_wf"
+        )
 
         # fmt:off
         workflow.connect([
@@ -320,9 +323,6 @@ def init_anat_preproc_wf(
                 ('outputnode.subjects_dir', 'inputnode.subjects_dir'),
                 ('outputnode.subject_id', 'inputnode.subject_id'),
                 ('outputnode.fsnative2t1w_xfm', 'inputnode.fsnative2t1w_xfm'),
-                # Just for collation. These can probably go away at some point.
-                ('outputnode.thickness', 'inputnode.thickness'),
-                ('outputnode.sulc', 'inputnode.sulc'),
             ]),
             (anat_fit_wf, ds_surfaces_wf, [
                 ('outputnode.t1w_valid_list', 'inputnode.source_files'),
@@ -330,8 +330,13 @@ def init_anat_preproc_wf(
             (surface_derivatives_wf, ds_surfaces_wf, [
                 ('outputnode.inflated', 'inputnode.inflated'),
             ]),
+            (anat_fit_wf, ds_curv_wf, [
+                ('outputnode.t1w_valid_list', 'inputnode.source_files'),
+            ]),
+            (surface_derivatives_wf, ds_curv_wf, [
+                ('outputnode.curv', 'inputnode.curv'),
+            ]),
             (surface_derivatives_wf, anat_second_derivatives_wf, [
-                ('outputnode.morphometrics', 'inputnode.morphometrics'),
                 ('outputnode.out_aseg', 'inputnode.t1w_fs_aseg'),
                 ('outputnode.out_aparc', 'inputnode.t1w_fs_aparc'),
                 ('outputnode.cifti_morph', 'inputnode.cifti_morph'),

--- a/smriprep/workflows/base.py
+++ b/smriprep/workflows/base.py
@@ -366,7 +366,7 @@ to workflows in *sMRIPrep*'s documentation]\
     std_spaces = spaces.get_spaces(nonstandard=False, dim=(3,))
     std_spaces.append("fsnative")
     for deriv_dir in derivatives:
-        deriv_cache.update(collect_derivatives(deriv_dir, subject_id, std_spaces, freesurfer))
+        deriv_cache.update(collect_derivatives(deriv_dir, subject_id, std_spaces))
 
     inputnode = pe.Node(niu.IdentityInterface(fields=["subjects_dir"]), name="inputnode")
 

--- a/smriprep/workflows/outputs.py
+++ b/smriprep/workflows/outputs.py
@@ -876,7 +876,6 @@ def init_anat_second_derivatives_wf(
                 "anat2std_xfm",
                 "sphere_reg",
                 "sphere_reg_fsLR",
-                "morphometrics",
                 "t1w_fs_aseg",
                 "t1w_fs_aparc",
                 "cifti_morph",
@@ -1011,22 +1010,6 @@ def init_anat_second_derivatives_wf(
     if not freesurfer:
         return workflow
 
-    from niworkflows.interfaces.surf import Path2BIDS
-
-    # Morphometrics
-    name_morphs = pe.MapNode(
-        Path2BIDS(),
-        iterfield="in_file",
-        name="name_morphs",
-        run_without_submitting=True,
-    )
-    ds_morphs = pe.MapNode(
-        DerivativesDataSink(base_directory=output_dir, extension=".shape.gii"),
-        iterfield=["in_file", "hemi", "suffix"],
-        name="ds_morphs",
-        run_without_submitting=True,
-    )
-
     # Parcellations
     ds_t1w_fsaseg = pe.Node(
         DerivativesDataSink(base_directory=output_dir, desc="aseg", suffix="dseg", compress=True),
@@ -1043,11 +1026,6 @@ def init_anat_second_derivatives_wf(
 
     # fmt:off
     workflow.connect([
-        (inputnode, name_morphs, [('morphometrics', 'in_file')]),
-        (inputnode, ds_morphs, [('morphometrics', 'in_file'),
-                                ('source_files', 'source_file')]),
-        (name_morphs, ds_morphs, [('hemi', 'hemi'),
-                                  ('suffix', 'suffix')]),
         (inputnode, ds_t1w_fsaseg, [('t1w_fs_aseg', 'in_file'),
                                     ('source_files', 'source_file')]),
         (inputnode, ds_t1w_fsparc, [('t1w_fs_aparc', 'in_file'),

--- a/smriprep/workflows/surfaces.py
+++ b/smriprep/workflows/surfaces.py
@@ -1004,7 +1004,7 @@ def init_gifti_morphometrics_wf(
     workflow = Workflow(name=name)
 
     inputnode = pe.Node(
-        niu.IdentityInterface(["subjects_dir", "subject_id", "fsnative2t1w_xfm"]),
+        niu.IdentityInterface(["subjects_dir", "subject_id"]),
         name="inputnode",
     )
     outputnode = pe.Node(

--- a/smriprep/workflows/surfaces.py
+++ b/smriprep/workflows/surfaces.py
@@ -630,8 +630,6 @@ def init_surface_derivatives_wf(
                 "subject_id",
                 "fsnative2t1w_xfm",
                 "reference",
-                "thickness",
-                "sulc",
             ]
         ),
         name="inputnode",
@@ -640,7 +638,7 @@ def init_surface_derivatives_wf(
         niu.IdentityInterface(
             fields=[
                 "inflated",
-                "morphometrics",
+                "curv",
                 "out_aseg",
                 "out_aparc",
                 "cifti_morph",
@@ -654,8 +652,6 @@ def init_surface_derivatives_wf(
     gifti_morph_wf = init_gifti_morphometrics_wf(morphometrics=["curv"])
     aseg_to_native_wf = init_segs_to_native_wf()
     aparc_to_native_wf = init_segs_to_native_wf(segmentation="aparc_aseg")
-
-    all_morph = pe.Node(niu.Merge(3), name="all_morph")
 
     # fmt:off
     workflow.connect([
@@ -682,15 +678,11 @@ def init_surface_derivatives_wf(
             ('fsnative2t1w_xfm', 'inputnode.fsnative2t1w_xfm'),
         ]),
 
-        # Collate morphometry from inputnode and workflows
-        (inputnode, all_morph, [('thickness', 'in1'), ('sulc', 'in2')]),
-        (gifti_morph_wf, all_morph, [('outputnode.curv', 'in3')]),
-
         # Output
         (gifti_surfaces_wf, outputnode, [('outputnode.inflated', 'inflated')]),
         (aseg_to_native_wf, outputnode, [('outputnode.out_file', 'out_aseg')]),
         (aparc_to_native_wf, outputnode, [('outputnode.out_file', 'out_aparc')]),
-        (all_morph, outputnode, [('out', 'morphometrics')]),
+        (gifti_morph_wf, outputnode, [('outputnode.curv', 'curv')]),
     ])
     # fmt:on
 


### PR DESCRIPTION
Not much to say. Moved some of the surface conversion into first-order fit, even though they are easy to calculate post hoc because they are needed if msmsulc is used. Initially tried to make some of it conditional, but it made it annoying to construct the complement after the fact. A few extra surfaces in the anatomical derivatives are not our biggest problems, space-wise.