### PR TITLE
FIX: Update surfaces with fsnative2t1w_xfm

### DIFF
--- a/smriprep/interfaces/surf.py
+++ b/smriprep/interfaces/surf.py
@@ -199,18 +199,18 @@ def normalize_surfs(
 
     img = nb.load(in_file)
     if transform_file is None:
-        transform = np.eye(4)
+        transform = nt.linear.Affine()
     else:
         xfm_fmt = {
             ".txt": "itk",
             ".mat": "fsl",
             ".lta": "fs",
         }[Path(transform_file).suffix]
-        transform = nt.linear.load(transform_file, fmt=xfm_fmt).matrix
+        transform = nt.linear.load(transform_file, fmt=xfm_fmt)
     pointset = img.get_arrays_from_intent("NIFTI_INTENT_POINTSET")[0]
 
-    if not np.allclose(transform, np.eye(4)):
-        pointset.data = nb.affines.apply_affine(transform, pointset.data)
+    if not np.allclose(transform.matrix, np.eye(4)):
+        pointset.data = transform.map(pointset.data, inverse=True)
 
     fname = os.path.basename(in_file)
     if "graymid" in fname.lower():

--- a/smriprep/workflows/surfaces.py
+++ b/smriprep/workflows/surfaces.py
@@ -919,10 +919,14 @@ def init_gifti_surfaces_wf(
         run_without_submitting=True,
     )
 
-    # fmt:off
     workflow.connect([
-        (inputnode, get_surfaces, [('subjects_dir', 'subjects_dir'),
-                                   ('subject_id', 'subject_id')]),
+        (inputnode, get_surfaces, [
+            ('subjects_dir', 'subjects_dir'),
+            ('subject_id', 'subject_id'),
+        ]),
+        (inputnode, fix_surfs, [
+            ('fsnative2t1w_xfm', 'transform_file'),
+        ]),
         (get_surfaces, surface_list, [
             (surf, f'in{i}') for i, surf in enumerate(surfaces, start=1)
         ]),
@@ -933,8 +937,7 @@ def init_gifti_surfaces_wf(
         (surface_groups, outputnode, [
             (f'out{i}', surf) for i, surf in enumerate(surfaces, start=1)
         ]),
-    ])
-    # fmt:on
+    ])  # fmt:skip
     return workflow
 
 


### PR DESCRIPTION
We weren't applying the fsnative2t1w_xfm to the surfaces when converting. Also updated the transform to nitransforms directly, and invert the fsnative2t1w mapping, since that mapping maps points in T1w space to fsnative and we need to go the other way.

Confirmed that surfaces now align. This is needed to get CIFTI resampling working correctly, as that depends on GIFTIs.