### PR TITLE
ENH: Annotate mris_expand with thread usage

### DIFF
--- a/smriprep/interfaces/freesurfer.py
+++ b/smriprep/interfaces/freesurfer.py
@@ -334,7 +334,6 @@ class MakeMidthickness(nwfs.MakeMidthickness, fs.base.FSCommandOpenMP):
         return super()._format_arg(name, trait_spec, value)
 
     def _num_threads_update(self):
-        """mris_expand"""
         if self.inputs.num_threads:
             self.inputs.environ.update(
                 {"OMP_NUM_THREADS": str(self.inputs.num_threads * 3 // 2)}

--- a/smriprep/workflows/surfaces.py
+++ b/smriprep/workflows/surfaces.py
@@ -220,6 +220,7 @@ gray-matter of Mindboggle [RRID:SCR_002438, @mindboggle].
         MakeMidthickness(thickness=True, distance=0.5, out_name="midthickness"),
         iterfield="in_file",
         name="midthickness",
+        n_procs=min(omp_nthreads, 12),
     )
 
     save_midthickness = pe.Node(nio.DataSink(parameterization=False), name="save_midthickness")
@@ -232,7 +233,6 @@ gray-matter of Mindboggle [RRID:SCR_002438, @mindboggle].
         name="sync",
     )
 
-    # fmt:off
     workflow.connect([
         # Configuration
         (inputnode, recon_config, [('t1w', 't1w_list'),
@@ -275,21 +275,18 @@ gray-matter of Mindboggle [RRID:SCR_002438, @mindboggle].
         (save_midthickness, sync, [('out_file', 'filenames')]),
         (sync, outputnode, [('subjects_dir', 'subjects_dir'),
                             ('subject_id', 'subject_id')]),
-    ])
-    # fmt:on
+    ])  # fmt:skip
 
     if "fsnative" not in precomputed.get("transforms", {}):
         fsnative2t1w_xfm = pe.Node(
             RobustRegister(auto_sens=True, est_int_scale=True), name="fsnative2t1w_xfm"
         )
 
-        # fmt:off
         workflow.connect([
             (inputnode, fsnative2t1w_xfm, [('t1w', 'target_file')]),
             (autorecon1, fsnative2t1w_xfm, [('T1', 'source_file')]),
             (fsnative2t1w_xfm, outputnode, [('out_reg_file', 'fsnative2t1w_xfm')]),
-        ])
-        # fmt:on
+        ])  # fmt:skip
 
     return workflow
 


### PR DESCRIPTION
This one's a little weird, due to the multiple inheritance and also the inefficiency of multithreading in `mris_expand`. 

I noticed `midthickness` taking a long time while running tests, and I was pretty sure I'd seen that it could be parallelized. 

From watching `htop` and running `mris_expand` with a set of `OMP_NUM_THREADS` values, I see that generally you get about 65-75% core utilization, generally a bit under. We therefore overallocate threads by about 50% to make the core usage match the desired number of threads, occasionally peaking over but mostly sitting a bit under. This works pretty well for 2-12 desired threads (3-18 `OMP_NUM_THREADS`), but seems almost completely limited after that, with 24 threads utilizing maybe 13 cores at best. Therefore, I set this to max out at 12 for scheduling purposes.

The memory usage of this tool is low and does not seem to increase noticeably with number of threads.

If `n_procs == 1`, `str(1 * 3 // 2) == '1'`, so this does not interfere with people attempting to run things single-threaded.