### PR TITLE
RF: Split template and fsLR resampling and sinking into isolated workflows

### DIFF
--- a/smriprep/workflows/anatomical.py
+++ b/smriprep/workflows/anatomical.py
@@ -56,6 +56,7 @@ from .fit.registration import init_register_template_wf
 from .outputs import (
     init_anat_reports_wf,
     init_ds_anat_volumes_wf,
+    init_ds_grayord_metrics_wf,
     init_ds_surface_metrics_wf,
     init_ds_surfaces_wf,
     init_ds_template_wf,
@@ -374,6 +375,13 @@ def init_anat_preproc_wf(
                 grayord_density=cifti_output, omp_nthreads=omp_nthreads
             )
 
+            ds_grayord_metrics_wf = init_ds_grayord_metrics_wf(
+                bids_root=bids_root,
+                output_dir=output_dir,
+                metrics=['curv', 'thickness', 'sulc'],
+                cifti_output=cifti_output,
+            )
+
             workflow.connect([
                 (anat_fit_wf, hcp_morphometrics_wf, [
                     ('outputnode.subject_id', 'inputnode.subject_id'),
@@ -406,6 +414,17 @@ def init_anat_preproc_wf(
                 ]),
                 (resample_midthickness_wf, morph_grayords_wf, [
                     ('outputnode.midthickness_fsLR', 'inputnode.midthickness_fsLR'),
+                ]),
+                (anat_fit_wf, ds_grayord_metrics_wf, [
+                    ('outputnode.t1w_valid_list', 'inputnode.source_files'),
+                ]),
+                (morph_grayords_wf, ds_grayord_metrics_wf, [
+                    ('outputnode.curv_fsLR', 'inputnode.curv'),
+                    ('outputnode.curv_metadata', 'inputnode.curv_metadata'),
+                    ('outputnode.thickness_fsLR', 'inputnode.thickness'),
+                    ('outputnode.thickness_metadata', 'inputnode.thickness_metadata'),
+                    ('outputnode.sulc_fsLR', 'inputnode.sulc'),
+                    ('outputnode.sulc_metadata', 'inputnode.sulc_metadata'),
                 ]),
             ])  # fmt:skip
 

--- a/smriprep/workflows/anatomical.py
+++ b/smriprep/workflows/anatomical.py
@@ -117,6 +117,8 @@ def init_anat_preproc_wf(
 
             from niworkflows.utils.spaces import SpatialReferences, Reference
             from smriprep.workflows.anatomical import init_anat_preproc_wf
+            spaces = SpatialReferences(spaces=['MNI152NLin2009cAsym', 'fsaverage5'])
+            spaces.checkpoint()
             wf = init_anat_preproc_wf(
                 bids_root='.',
                 output_dir='.',
@@ -128,7 +130,7 @@ def init_anat_preproc_wf(
                 t2w=[],
                 skull_strip_mode='force',
                 skull_strip_template=Reference('OASIS30ANTs'),
-                spaces=SpatialReferences(spaces=['MNI152NLin2009cAsym', 'fsaverage5']),
+                spaces=spaces,
                 precomputed={},
                 omp_nthreads=1,
             )

--- a/smriprep/workflows/anatomical.py
+++ b/smriprep/workflows/anatomical.py
@@ -377,6 +377,7 @@ def init_anat_preproc_wf(
                     ('outputnode.subject_id', 'inputnode.subject_id'),
                     ('outputnode.sulc', 'inputnode.sulc'),
                     ('outputnode.thickness', 'inputnode.thickness'),
+                    ('outputnode.midthickness', 'inputnode.midthickness'),
                 ]),
                 (surface_derivatives_wf, hcp_morphometrics_wf, [
                     ('outputnode.curv', 'inputnode.curv'),

--- a/smriprep/workflows/anatomical.py
+++ b/smriprep/workflows/anatomical.py
@@ -1343,7 +1343,7 @@ the brain-extracted T1w using `fast` [FSL {fsl_ver}, RRID:SCR_002823, @fsl_fast]
         # fmt:on
     elif msm_sulc:
         LOGGER.info("ANAT Stage 10: Found pre-computed MSM-Sulc registration sphere")
-        fsLR_buffer.inputs.sphere_reg_msm = sorted(precomputed["sphere_reg_msm"])
+        msm_buffer.inputs.sphere_reg_msm = sorted(precomputed["sphere_reg_msm"])
     else:
         LOGGER.info("ANAT Stage 10: MSM-Sulc disabled")
 

--- a/smriprep/workflows/anatomical.py
+++ b/smriprep/workflows/anatomical.py
@@ -309,7 +309,7 @@ def init_anat_preproc_wf(
         ]),
         (template_iterator_wf, ds_std_volumes_wf, [
             ("outputnode.std_t1w", "inputnode.ref_file"),
-            ("outputnode.std2anat_xfm", "inputnode.std2anat_xfm"),
+            ("outputnode.anat2std_xfm", "inputnode.anat2std_xfm"),
             ("outputnode.space", "inputnode.space"),
             ("outputnode.cohort", "inputnode.cohort"),
             ("outputnode.resolution", "inputnode.resolution"),

--- a/smriprep/workflows/base.py
+++ b/smriprep/workflows/base.py
@@ -81,6 +81,8 @@ def init_smriprep_wf(
             os.environ['FREESURFER_HOME'] = os.getcwd()
             from smriprep.workflows.base import init_smriprep_wf
             from niworkflows.utils.spaces import SpatialReferences, Reference
+            spaces = SpatialReferences(spaces=['MNI152NLin2009cAsym', 'fsaverage5'])
+            spaces.checkpoint()
             wf = init_smriprep_wf(
                 sloppy=False,
                 debug=False,
@@ -98,7 +100,7 @@ def init_smriprep_wf(
                 skull_strip_fixed_seed=False,
                 skull_strip_mode='force',
                 skull_strip_template=Reference('OASIS30ANTs'),
-                spaces=SpatialReferences(spaces=['MNI152NLin2009cAsym', 'fsaverage5']),
+                spaces=spaces,
                 subject_list=['smripreptest'],
                 work_dir='.',
                 bids_filters=None,
@@ -250,6 +252,8 @@ def init_single_subject_wf(
             from niworkflows.utils.spaces import SpatialReferences, Reference
             from smriprep.workflows.base import init_single_subject_wf
             BIDSLayout = namedtuple('BIDSLayout', ['root'])
+            spaces = SpatialReferences(spaces=['MNI152NLin2009cAsym', 'fsaverage5'])
+            spaces.checkpoint()
             wf = init_single_subject_wf(
                 sloppy=False,
                 debug=False,
@@ -266,7 +270,7 @@ def init_single_subject_wf(
                 skull_strip_fixed_seed=False,
                 skull_strip_mode='force',
                 skull_strip_template=Reference('OASIS30ANTs'),
-                spaces=SpatialReferences(spaces=['MNI152NLin2009cAsym', 'fsaverage5']),
+                spaces=spaces,
                 subject_id='test',
                 bids_filters=None,
                 cifti_output=None,

--- a/smriprep/workflows/outputs.py
+++ b/smriprep/workflows/outputs.py
@@ -26,7 +26,7 @@ import typing as ty
 from nipype.pipeline import engine as pe
 from nipype.interfaces import utility as niu
 from niworkflows.interfaces.fixes import FixHeaderApplyTransforms as ApplyTransforms
-from niworkflows.interfaces.nibabel import ApplyMask
+from niworkflows.interfaces.nibabel import ApplyMask, GenerateSamplingReference
 from niworkflows.interfaces.space import SpaceDataSource
 from niworkflows.interfaces.utility import KeySelect
 from niworkflows.engine.workflows import LiterateWorkflow as Workflow
@@ -804,12 +804,150 @@ def init_ds_surface_metrics_wf(
     return workflow
 
 
+def init_ds_anat_volumes_wf(
+    *,
+    bids_root: str,
+    output_dir: str,
+    name="ds_anat_volumes_wf",
+    tpm_labels=BIDS_TISSUE_ORDER,
+) -> pe.Workflow:
+
+    workflow = pe.Workflow(name=name)
+    inputnode = pe.Node(
+        niu.IdentityInterface(
+            fields=[
+                # Original T1w image
+                'source_files',
+                # T1w-space images
+                't1w_preproc',
+                't1w_mask',
+                't1w_dseg',
+                't1w_tpms',
+                # Template
+                'ref_file',
+                'anat2std_xfm',
+                # Entities
+                'space',
+                'cohort',
+                'resolution',
+            ]
+        ),
+        name='inputnode',
+    )
+
+    raw_sources = pe.Node(niu.Function(function=_bids_relative), name='raw_sources')
+    raw_sources.inputs.bids_root = bids_root
+
+    gen_ref = pe.Node(GenerateSamplingReference(), name="gen_ref", mem_gb=0.01)
+
+    # Mask T1w preproc images
+    mask_t1w = pe.Node(ApplyMask(), name='mask_t1w')
+
+    # Resample T1w-space inputs
+    anat2std_t1w = pe.Node(
+        ApplyTransforms(
+            dimension=3,
+            default_value=0,
+            float=True,
+            interpolation="LanczosWindowedSinc",
+        ),
+        name="anat2std_t1w",
+    )
+
+    anat2std_mask = pe.Node(ApplyTransforms(interpolation="MultiLabel"), name="anat2std_mask")
+    anat2std_dseg = pe.Node(ApplyTransforms(interpolation="MultiLabel"), name="anat2std_dseg")
+    anat2std_tpms = pe.MapNode(
+        ApplyTransforms(dimension=3, default_value=0, float=True, interpolation="Gaussian"),
+        iterfield=["input_image"],
+        name="anat2std_tpms",
+    )
+
+    ds_std_t1w = pe.Node(
+        DerivativesDataSink(
+            base_directory=output_dir,
+            desc="preproc",
+            compress=True,
+        ),
+        name="ds_std_t1w",
+        run_without_submitting=True,
+    )
+    ds_std_t1w.inputs.SkullStripped = True
+
+    ds_std_mask = pe.Node(
+        DerivativesDataSink(
+            base_directory=output_dir, desc="brain", suffix="mask", compress=True
+        ),
+        name="ds_std_mask",
+        run_without_submitting=True,
+    )
+    ds_std_mask.inputs.Type = "Brain"
+
+    ds_std_dseg = pe.Node(
+        DerivativesDataSink(base_directory=output_dir, suffix="dseg", compress=True),
+        name="ds_std_dseg",
+        run_without_submitting=True,
+    )
+
+    ds_std_tpms = pe.Node(
+        DerivativesDataSink(base_directory=output_dir, suffix="probseg", compress=True),
+        name="ds_std_tpms",
+        run_without_submitting=True,
+    )
+
+    # CRITICAL: the sequence of labels here (CSF-GM-WM) is that of the output of FSL-FAST
+    #           (intensity mean, per tissue). This order HAS to be matched also by the ``tpms``
+    #           output in the data/io_spec.json file.
+    ds_std_tpms.inputs.label = tpm_labels
+
+    workflow.connect([
+        (inputnode, gen_ref, [
+            ("ref_file", "fixed_image"),
+            (("resolution", _is_native), "keep_native"),
+        ]),
+        (inputnode, mask_t1w, [
+            ("t1w_preproc", "in_file"),
+            ("t1w_mask", "in_mask"),
+        ]),
+        (mask_t1w, anat2std_t1w, [("out_file", "input_image")]),
+        (inputnode, anat2std_mask, [("t1w_mask", "input_image")]),
+        (inputnode, anat2std_dseg, [("t1w_dseg", "input_image")]),
+        (inputnode, anat2std_tpms, [("t1w_tpms", "input_image")]),
+        (inputnode, gen_ref, [("t1w_preproc", "moving_image")]),
+        (anat2std_t1w, ds_std_t1w, [("output_image", "in_file")]),
+        (anat2std_mask, ds_std_mask, [("output_image", "in_file")]),
+        (anat2std_dseg, ds_std_dseg, [("output_image", "in_file")]),
+        (anat2std_tpms, ds_std_tpms, [("output_image", "in_file")]),
+    ])  # fmt:skip
+
+    workflow.connect(
+        # Connect apply transforms nodes
+        [
+            (gen_ref, n, [('out_file', 'reference_image')])
+            for n in (anat2std_t1w, anat2std_mask, anat2std_dseg, anat2std_tpms)
+        ]
+        + [
+            (inputnode, n, [('anat2std_xfm', 'transforms')])
+            for n in (anat2std_t1w, anat2std_mask, anat2std_dseg, anat2std_tpms)
+        ]
+        + [
+            (inputnode, n, [
+                ('source_files', 'source_file'),
+                ('space', 'space'),
+                ('cohort', 'cohort'),
+                ('resolution', 'resolution'),
+            ])
+            for n in (ds_std_t1w, ds_std_mask, ds_std_dseg, ds_std_tpms)
+        ]
+    )  # fmt:skip
+
+    return workflow
+
+
 def init_anat_second_derivatives_wf(
     *,
     bids_root: str,
     output_dir: str,
     freesurfer: bool,
-    spaces: SpatialReferences,
     cifti_output: ty.Literal["91k", "170k", False],
     name="anat_second_derivatives_wf",
     tpm_labels=BIDS_TISSUE_ORDER,
@@ -869,13 +1007,6 @@ def init_anat_second_derivatives_wf(
             fields=[
                 "template",
                 "source_files",
-                "t1w_preproc",
-                "t1w_mask",
-                "t1w_dseg",
-                "t1w_tpms",
-                "anat2std_xfm",
-                "sphere_reg",
-                "sphere_reg_fsLR",
                 "t1w_fs_aseg",
                 "t1w_fs_aparc",
                 "cifti_morph",
@@ -887,128 +1018,6 @@ def init_anat_second_derivatives_wf(
 
     raw_sources = pe.Node(niu.Function(function=_bids_relative), name="raw_sources")
     raw_sources.inputs.bids_root = bids_root
-
-    # Write derivatives in standard spaces specified by --output-spaces
-    if getattr(spaces, "_cached") is not None and spaces.cached.references:
-        from niworkflows.interfaces.nibabel import GenerateSamplingReference
-
-        template_iterator_wf = init_template_iterator_wf(spaces=spaces)
-
-        gen_ref = pe.Node(GenerateSamplingReference(), name="gen_ref", mem_gb=0.01)
-
-        # Mask T1w preproc images
-        mask_t1w = pe.Node(ApplyMask(), name='mask_t1w')
-
-        # Resample T1w-space inputs
-        anat2std_t1w = pe.Node(
-            ApplyTransforms(
-                dimension=3,
-                default_value=0,
-                float=True,
-                interpolation="LanczosWindowedSinc",
-            ),
-            name="anat2std_t1w",
-        )
-
-        anat2std_mask = pe.Node(ApplyTransforms(interpolation="MultiLabel"), name="anat2std_mask")
-        anat2std_dseg = pe.Node(ApplyTransforms(interpolation="MultiLabel"), name="anat2std_dseg")
-        anat2std_tpms = pe.MapNode(
-            ApplyTransforms(dimension=3, default_value=0, float=True, interpolation="Gaussian"),
-            iterfield=["input_image"],
-            name="anat2std_tpms",
-        )
-
-        ds_std_t1w = pe.Node(
-            DerivativesDataSink(
-                base_directory=output_dir,
-                desc="preproc",
-                compress=True,
-            ),
-            name="ds_std_t1w",
-            run_without_submitting=True,
-        )
-        ds_std_t1w.inputs.SkullStripped = True
-
-        ds_std_mask = pe.Node(
-            DerivativesDataSink(
-                base_directory=output_dir, desc="brain", suffix="mask", compress=True
-            ),
-            name="ds_std_mask",
-            run_without_submitting=True,
-        )
-        ds_std_mask.inputs.Type = "Brain"
-
-        ds_std_dseg = pe.Node(
-            DerivativesDataSink(base_directory=output_dir, suffix="dseg", compress=True),
-            name="ds_std_dseg",
-            run_without_submitting=True,
-        )
-
-        ds_std_tpms = pe.Node(
-            DerivativesDataSink(base_directory=output_dir, suffix="probseg", compress=True),
-            name="ds_std_tpms",
-            run_without_submitting=True,
-        )
-
-        # CRITICAL: the sequence of labels here (CSF-GM-WM) is that of the output of FSL-FAST
-        #           (intensity mean, per tissue). This order HAS to be matched also by the ``tpms``
-        #           output in the data/io_spec.json file.
-        ds_std_tpms.inputs.label = tpm_labels
-        # fmt:off
-        workflow.connect([
-            (inputnode, template_iterator_wf, [
-                ("anat2std_xfm", "inputnode.anat2std_xfm"),
-                ("template", "inputnode.template"),
-            ]),
-            (inputnode, mask_t1w, [("t1w_preproc", "in_file"),
-                                   ("t1w_mask", "in_mask")]),
-            (mask_t1w, anat2std_t1w, [("out_file", "input_image")]),
-            (inputnode, anat2std_mask, [("t1w_mask", "input_image")]),
-            (inputnode, anat2std_dseg, [("t1w_dseg", "input_image")]),
-            (inputnode, anat2std_tpms, [("t1w_tpms", "input_image")]),
-            (inputnode, gen_ref, [("t1w_preproc", "moving_image")]),
-            (template_iterator_wf, gen_ref, [
-                ("outputnode.std_t1w", "fixed_image"),
-                (("outputnode.resolution", _is_native), "keep_native"),
-            ]),
-            (anat2std_t1w, ds_std_t1w, [("output_image", "in_file")]),
-            (anat2std_mask, ds_std_mask, [("output_image", "in_file")]),
-            (anat2std_dseg, ds_std_dseg, [("output_image", "in_file")]),
-            (anat2std_tpms, ds_std_tpms, [("output_image", "in_file")]),
-            (template_iterator_wf, ds_std_mask, [
-                (("outputnode.std_mask", _drop_path), "RawSources"),
-            ]),
-        ])
-
-        workflow.connect(
-            # Connect apply transforms nodes
-            [
-                (gen_ref, n, [('out_file', 'reference_image')])
-                for n in (anat2std_t1w, anat2std_mask, anat2std_dseg, anat2std_tpms)
-            ]
-            + [
-                (template_iterator_wf, n, [('outputnode.anat2std_xfm', 'transforms')])
-                for n in (anat2std_t1w, anat2std_mask, anat2std_dseg, anat2std_tpms)
-            ]
-            # Connect the source_file input of these datasinks
-            + [
-                (inputnode, n, [('source_files', 'source_file')])
-                for n in (ds_std_t1w, ds_std_mask, ds_std_dseg, ds_std_tpms)
-            ]
-            # Connect the space input of these datasinks
-            + [
-                (template_iterator_wf, n, [
-                    ('outputnode.space', 'space'),
-                    ('outputnode.cohort', 'cohort'),
-                    ('outputnode.resolution', 'resolution'),
-                ])
-                for n in (ds_std_t1w, ds_std_mask, ds_std_dseg, ds_std_tpms)
-            ]
-        )
-        # fmt:on
-
-    if not freesurfer:
-        return workflow
 
     # Parcellations
     ds_t1w_fsaseg = pe.Node(

--- a/smriprep/workflows/surfaces.py
+++ b/smriprep/workflows/surfaces.py
@@ -1325,7 +1325,7 @@ def init_morph_grayords_wf(
             :simple_form: yes
 
             from smriprep.workflows.surfaces import init_morph_grayords_wf
-            wf = init_morph_grayords_wf(grayord_density="91k")
+            wf = init_morph_grayords_wf(grayord_density="91k", omp_nthreads=1)
 
     Parameters
     ----------


### PR DESCRIPTION
This is necessary to allow fMRIPrep to pick and choose workflows based on user requests.

This also replaces the old morphometry CIFTI-2 files with ones resampled along the lines of HCP.