### PR TITLE
MNT: update target Python version for black

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ version-file = "smriprep/_version.py"
 
 [tool.black]
 line-length = 99
-target-version = ['py39']
+target-version = ['py310']
 skip-string-normalization = true
 
 [tool.isort]


### PR DESCRIPTION
Match required Python version, which is currently 3.10:
https://github.com/nipreps/smriprep/blob/a3df930f9fa84f1a8a1bd1ebb35ad2a1c0fe6348/pyproject.toml#L20