### PR TITLE
STY: Adopt ruff for linting and formatting

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,6 @@
+# 2023-11-21 - effigies@gmail.com - STY: ruff --fix smriprep [git-blame-ignore-rev]
+3a586cf46cb1bb963b93d9546f20273194d15de5
+# 2023-11-20 - effigies@gmail.com - STY: ruff --fix smriprep [git-blame-ignore-rev]
+c5e8b6b8ddb69284a4cba58e2512b299f1e29464
+# 2023-11-20 - effigies@gmail.com - STY: ruff format smriprep [git-blame-ignore-rev]
+8d62c0f3f3c6a911b1dfe2e9a2016b8de7da051a

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -112,9 +112,10 @@ jobs:
     - uses: codecov/codecov-action@v3
       name: Submit to CodeCov
 
-  flake8:
+  style:
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - run: pipx run flake8 smriprep
+    - run: pipx run ruff smriprep
+    - run: pipx run ruff format --diff smriprep

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,17 +10,8 @@ repos:
       - id: check-added-large-files
       - id: check-toml
       - id: check-json
-  - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.6
     hooks:
-      - id: flake8
-  # - repo: https://github.com/psf/black
-  #   rev: 23.1.0
-  #   hooks:
-  #     - id: black
-  #       files: ^smriprep/|^wrapper/
-  # - repo: https://github.com/pycqa/isort
-  #   rev: 5.12.0
-  #   hooks:
-  #     - id: isort
-  #       files: ^smriprep/|^wrapper/
+      - id: ruff
+      - id: ruff-format

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help docker
+.PHONY: help docker .git-blame-ignore-revs
 .DEFAULT: help
 
 tag="latest"
@@ -15,3 +15,9 @@ docker:
 	--build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
 	--build-arg VCS_REF=`git rev-parse --short HEAD` \
 	--build-arg VERSION=`python setup.py --version` .
+
+
+.git-blame-ignore-revs:
+	git log --grep "\[git-blame-ignore-rev\]" --pretty=format:"# %ad - %ae - %s%n%H" --date short \
+		> .git-blame-ignore-revs
+	echo >> .git-blame-ignore-revs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,11 +145,16 @@ extend-select = [
   "A",
   "I",
   "UP",
+  "YTT",
+  "S",
   "B",
 ]
 
 [tool.ruff.flake8-quotes]
 inline-quotes = "single"
+
+[tool.ruff.extend-per-file-ignores]
+"*/test_*.py" = ["S101"]
 
 [tool.ruff.format]
 quote-style = "single"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,13 +142,21 @@ extend-select = [
   "F",
   "E",
   "W",
-  "A",
   "I",
   "UP",
   "YTT",
   "S",
   "BLE",
   "B",
+  "A",
+  # "CPY",
+  "C4",
+  "DTZ",
+  "T10",
+  # "EM",
+  "EXE",
+  "FA",
+  "ISC",
 ]
 
 [tool.ruff.flake8-quotes]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,6 +159,7 @@ extend-select = [
   "ISC",
   "ICN",
   "PT",
+  "Q",
 ]
 
 [tool.ruff.flake8-quotes]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,6 @@ version-file = "smriprep/_version.py"
 
 [tool.black]
 line-length = 99
-target-version = ['py39']
 skip-string-normalization = true
 
 [tool.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,6 +147,7 @@ extend-select = [
   "UP",
   "YTT",
   "S",
+  "BLE",
   "B",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,6 +157,8 @@ extend-select = [
   "EXE",
   "FA",
   "ISC",
+  "ICN",
+  "PT",
 ]
 
 [tool.ruff.flake8-quotes]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,3 +136,21 @@ source = [
     "smriprep/",
     "*/site-packages/smriprep",
 ]
+
+[tool.ruff]
+line-length = 99
+extend-select = [
+  "F",
+  "E",
+  "W",
+  "A",
+  "I",
+  "UP",
+  "B",
+]
+
+[tool.ruff.flake8-quotes]
+inline-quotes = "single"
+
+[tool.ruff.format]
+quote-style = "single"

--- a/smriprep/__about__.py
+++ b/smriprep/__about__.py
@@ -27,17 +27,17 @@ Base module variables
 try:
     from ._version import __version__
 except ImportError:  # pragma: no cover
-    __version__ = "0+unknown"
+    __version__ = '0+unknown'
 
-__copyright__ = "Copyright 2019, Center for Reproducible Neuroscience, Stanford University"
+__copyright__ = 'Copyright 2019, Center for Reproducible Neuroscience, Stanford University'
 __credits__ = [
-    "Oscar Esteban",
-    "Chris Gorgolewski",
-    "Christopher J. Markiewicz",
-    "Russell A. Poldrack",
+    'Oscar Esteban',
+    'Chris Gorgolewski',
+    'Christopher J. Markiewicz',
+    'Russell A. Poldrack',
 ]
-__url__ = "https://github.com/nipreps/smriprep"
+__url__ = 'https://github.com/nipreps/smriprep'
 
-DOWNLOAD_URL = "https://github.com/nipreps/{name}/archive/{ver}.tar.gz".format(
+DOWNLOAD_URL = 'https://github.com/nipreps/{name}/archive/{ver}.tar.gz'.format(
     name=__package__, ver=__version__
 )

--- a/smriprep/__about__.py
+++ b/smriprep/__about__.py
@@ -38,6 +38,4 @@ __credits__ = [
 ]
 __url__ = 'https://github.com/nipreps/smriprep'
 
-DOWNLOAD_URL = 'https://github.com/nipreps/{name}/archive/{ver}.tar.gz'.format(
-    name=__package__, ver=__version__
-)
+DOWNLOAD_URL = f'https://github.com/nipreps/{__package__}/archive/{__version__}.tar.gz'

--- a/smriprep/__init__.py
+++ b/smriprep/__init__.py
@@ -15,7 +15,7 @@ from .__about__ import (
 )
 
 __all__ = [
-    "__copyright__",
-    "__credits__",
-    "__version__",
+    '__copyright__',
+    '__credits__',
+    '__version__',
 ]

--- a/smriprep/__main__.py
+++ b/smriprep/__main__.py
@@ -22,10 +22,10 @@
 #
 from .cli.run import main
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     import sys
 
     # `python -m smriprep` typically displays the command as __main__.py
-    if "__main__.py" in sys.argv[0]:
-        sys.argv[0] = "%s -m smriprep" % sys.executable
+    if '__main__.py' in sys.argv[0]:
+        sys.argv[0] = '%s -m smriprep' % sys.executable
     main()

--- a/smriprep/cli/run.py
+++ b/smriprep/cli/run.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 #

--- a/smriprep/cli/run.py
+++ b/smriprep/cli/run.py
@@ -37,7 +37,7 @@ def check_deps(workflow):
     return sorted(
         (node.interface.__class__.__name__, node.interface._cmd)
         for node in workflow._get_all_nodes()
-        if (hasattr(node.interface, "_cmd") and which(node.interface._cmd.split()[0]) is None)
+        if (hasattr(node.interface, '_cmd') and which(node.interface._cmd.split()[0]) is None)
     )
 
 
@@ -54,7 +54,7 @@ def get_parser():
     from ..__about__ import __version__
 
     parser = ArgumentParser(
-        description="sMRIPrep: Structural MRI PREProcessing workflows",
+        description='sMRIPrep: Structural MRI PREProcessing workflows',
         formatter_class=RawTextHelpFormatter,
     )
 
@@ -62,255 +62,255 @@ def get_parser():
     # required, positional arguments
     # IMPORTANT: they must go directly with the parser object
     parser.add_argument(
-        "bids_dir",
-        action="store",
+        'bids_dir',
+        action='store',
         type=Path,
-        help="the root folder of a BIDS valid dataset (sub-XXXXX folders should "
-        "be found at the top level in this folder).",
+        help='the root folder of a BIDS valid dataset (sub-XXXXX folders should '
+        'be found at the top level in this folder).',
     )
     parser.add_argument(
-        "output_dir",
-        action="store",
+        'output_dir',
+        action='store',
         type=Path,
-        help="the output path for the outcomes of preprocessing and visual reports",
+        help='the output path for the outcomes of preprocessing and visual reports',
     )
     parser.add_argument(
-        "analysis_level",
-        choices=["participant"],
+        'analysis_level',
+        choices=['participant'],
         help='processing stage to be run, only "participant" in the case of '
-        "sMRIPrep (see BIDS-Apps specification).",
+        'sMRIPrep (see BIDS-Apps specification).',
     )
 
     # optional arguments
-    parser.add_argument("--version", action="version", version=f"smriprep v{__version__}")
+    parser.add_argument('--version', action='version', version=f'smriprep v{__version__}')
 
-    g_bids = parser.add_argument_group("Options for filtering BIDS queries")
+    g_bids = parser.add_argument_group('Options for filtering BIDS queries')
     g_bids.add_argument(
-        "--participant-label",
-        "--participant_label",
-        action="store",
-        nargs="+",
-        help="a space delimited list of participant identifiers or a single "
-        "identifier (the sub- prefix can be removed)",
+        '--participant-label',
+        '--participant_label',
+        action='store',
+        nargs='+',
+        help='a space delimited list of participant identifiers or a single '
+        'identifier (the sub- prefix can be removed)',
     )
     g_bids.add_argument(
-        "-d",
-        "--derivatives",
-        action="store",
-        metavar="PATH",
+        '-d',
+        '--derivatives',
+        action='store',
+        metavar='PATH',
         type=Path,
-        nargs="*",
-        help="Search PATH(s) for pre-computed derivatives.",
+        nargs='*',
+        help='Search PATH(s) for pre-computed derivatives.',
     )
     g_bids.add_argument(
-        "--bids-filter-file",
-        action="store",
+        '--bids-filter-file',
+        action='store',
         type=Path,
-        metavar="PATH",
-        help="a JSON file describing custom BIDS input filters using pybids "
-        "{<suffix>:{<entity>:<filter>,...},...} "
-        "(https://github.com/bids-standard/pybids/blob/master/bids/layout/config/bids.json)",
+        metavar='PATH',
+        help='a JSON file describing custom BIDS input filters using pybids '
+        '{<suffix>:{<entity>:<filter>,...},...} '
+        '(https://github.com/bids-standard/pybids/blob/master/bids/layout/config/bids.json)',
     )
 
-    g_perfm = parser.add_argument_group("Options to handle performance")
+    g_perfm = parser.add_argument_group('Options to handle performance')
     g_perfm.add_argument(
-        "--nprocs",
-        "--ncpus",
-        "--nthreads",
-        "--n_cpus",
-        "-n-cpus",
-        action="store",
+        '--nprocs',
+        '--ncpus',
+        '--nthreads',
+        '--n_cpus',
+        '-n-cpus',
+        action='store',
         type=int,
-        help="number of CPUs to be used.",
+        help='number of CPUs to be used.',
     )
     g_perfm.add_argument(
-        "--omp-nthreads",
-        action="store",
+        '--omp-nthreads',
+        action='store',
         type=int,
         default=0,
-        help="maximum number of threads per-process",
+        help='maximum number of threads per-process',
     )
     g_perfm.add_argument(
-        "--mem-gb",
-        "--mem_gb",
-        action="store",
+        '--mem-gb',
+        '--mem_gb',
+        action='store',
         default=0,
         type=float,
-        help="upper bound memory limit for sMRIPrep processes (in GB).",
+        help='upper bound memory limit for sMRIPrep processes (in GB).',
     )
     g_perfm.add_argument(
-        "--low-mem",
-        action="store_true",
-        help="attempt to reduce memory usage (will increase disk usage in working directory)",
+        '--low-mem',
+        action='store_true',
+        help='attempt to reduce memory usage (will increase disk usage in working directory)',
     )
     g_perfm.add_argument(
-        "--use-plugin",
-        action="store",
+        '--use-plugin',
+        action='store',
         default=None,
-        help="nipype plugin configuration file",
+        help='nipype plugin configuration file',
     )
-    g_perfm.add_argument("--boilerplate", action="store_true", help="generate boilerplate only")
+    g_perfm.add_argument('--boilerplate', action='store_true', help='generate boilerplate only')
     g_perfm.add_argument(
-        "-v",
-        "--verbose",
-        dest="verbose_count",
-        action="count",
+        '-v',
+        '--verbose',
+        dest='verbose_count',
+        action='count',
         default=0,
-        help="increases log verbosity for each occurrence, debug level is -vvv",
+        help='increases log verbosity for each occurrence, debug level is -vvv',
     )
 
-    g_conf = parser.add_argument_group("Workflow configuration")
+    g_conf = parser.add_argument_group('Workflow configuration')
     g_conf.add_argument(
-        "--output-spaces",
-        nargs="*",
+        '--output-spaces',
+        nargs='*',
         action=OutputReferencesAction,
         default=SpatialReferences(),
-        help="paths or keywords prescribing output spaces - "
-        "standard spaces will be extracted for spatial normalization.",
+        help='paths or keywords prescribing output spaces - '
+        'standard spaces will be extracted for spatial normalization.',
     )
     g_conf.add_argument(
-        "--longitudinal",
-        action="store_true",
-        help="treat dataset as longitudinal - may increase runtime",
+        '--longitudinal',
+        action='store_true',
+        help='treat dataset as longitudinal - may increase runtime',
     )
 
     #  ANTs options
-    g_ants = parser.add_argument_group("Specific options for ANTs registrations")
+    g_ants = parser.add_argument_group('Specific options for ANTs registrations')
     g_ants.add_argument(
-        "--skull-strip-template",
-        default="OASIS30ANTs",
+        '--skull-strip-template',
+        default='OASIS30ANTs',
         type=Reference.from_string,
-        help="select a template for skull-stripping with antsBrainExtraction",
+        help='select a template for skull-stripping with antsBrainExtraction',
     )
     g_ants.add_argument(
-        "--skull-strip-fixed-seed",
-        action="store_true",
-        help="do not use a random seed for skull-stripping - will ensure "
-        "run-to-run replicability when used with --omp-nthreads 1",
+        '--skull-strip-fixed-seed',
+        action='store_true',
+        help='do not use a random seed for skull-stripping - will ensure '
+        'run-to-run replicability when used with --omp-nthreads 1',
     )
     g_ants.add_argument(
-        "--skull-strip-mode",
-        action="store",
-        choices=("auto", "skip", "force"),
-        default="auto",
-        help="determiner for T1-weighted skull stripping (force ensures skull "
-        "stripping, skip ignores skull stripping, and auto automatically "
-        "ignores skull stripping if pre-stripped brains are detected).",
+        '--skull-strip-mode',
+        action='store',
+        choices=('auto', 'skip', 'force'),
+        default='auto',
+        help='determiner for T1-weighted skull stripping (force ensures skull '
+        'stripping, skip ignores skull stripping, and auto automatically '
+        'ignores skull stripping if pre-stripped brains are detected).',
     )
 
     # FreeSurfer options
-    g_fs = parser.add_argument_group("Specific options for FreeSurfer preprocessing")
+    g_fs = parser.add_argument_group('Specific options for FreeSurfer preprocessing')
     g_fs.add_argument(
-        "--fs-license-file",
-        metavar="PATH",
+        '--fs-license-file',
+        metavar='PATH',
         type=Path,
-        help="Path to FreeSurfer license key file. Get it (for free) by registering"
-        " at https://surfer.nmr.mgh.harvard.edu/registration.html",
+        help='Path to FreeSurfer license key file. Get it (for free) by registering'
+        ' at https://surfer.nmr.mgh.harvard.edu/registration.html',
     )
     g_fs.add_argument(
-        "--fs-subjects-dir",
-        metavar="PATH",
+        '--fs-subjects-dir',
+        metavar='PATH',
         type=Path,
-        help="Path to existing FreeSurfer subjects directory to reuse. "
-        "(default: OUTPUT_DIR/freesurfer)",
+        help='Path to existing FreeSurfer subjects directory to reuse. '
+        '(default: OUTPUT_DIR/freesurfer)',
     )
     g_fs.add_argument(
-        "--cifti-output",
-        nargs="?",
-        const="91k",
+        '--cifti-output',
+        nargs='?',
+        const='91k',
         default=False,
-        choices=("91k", "170k"),
+        choices=('91k', '170k'),
         type=str,
-        help="Output morphometry as CIFTI dense scalars. "
-        "Optionally, the number of grayordinate can be specified "
-        "(default is 91k, which equates to 2mm resolution)",
+        help='Output morphometry as CIFTI dense scalars. '
+        'Optionally, the number of grayordinate can be specified '
+        '(default is 91k, which equates to 2mm resolution)',
     )
 
     # Surface generation xor
-    g_surfs = parser.add_argument_group("Surface preprocessing options")
+    g_surfs = parser.add_argument_group('Surface preprocessing options')
     g_surfs.add_argument(
-        "--no-submm-recon",
-        action="store_false",
-        dest="hires",
-        help="disable sub-millimeter (hires) reconstruction",
+        '--no-submm-recon',
+        action='store_false',
+        dest='hires',
+        help='disable sub-millimeter (hires) reconstruction',
     )
     g_surfs.add_argument(
-        "--no-msm",
-        action="store_false",
-        dest="msm_sulc",
-        help="Disable Multimodal Surface Matching surface registration."
+        '--no-msm',
+        action='store_false',
+        dest='msm_sulc',
+        help='Disable Multimodal Surface Matching surface registration.',
     )
     g_surfs_xor = g_surfs.add_mutually_exclusive_group()
 
     g_surfs_xor.add_argument(
-        "--fs-no-reconall",
-        action="store_false",
-        dest="run_reconall",
-        help="disable FreeSurfer surface preprocessing.",
+        '--fs-no-reconall',
+        action='store_false',
+        dest='run_reconall',
+        help='disable FreeSurfer surface preprocessing.',
     )
 
-    g_other = parser.add_argument_group("Other options")
+    g_other = parser.add_argument_group('Other options')
     g_other.add_argument(
-        "-w",
-        "--work-dir",
-        action="store",
+        '-w',
+        '--work-dir',
+        action='store',
         type=Path,
-        default=Path("work"),
-        help="path where intermediate results should be stored",
+        default=Path('work'),
+        help='path where intermediate results should be stored',
     )
     g_other.add_argument(
-        "--fast-track",
-        action="store_true",
+        '--fast-track',
+        action='store_true',
         default=False,
-        help="fast-track the workflow by searching for existing derivatives. "
-        "(DEPRECATED for --derivatives).",
+        help='fast-track the workflow by searching for existing derivatives. '
+        '(DEPRECATED for --derivatives).',
     )
     g_other.add_argument(
-        "--resource-monitor",
-        action="store_true",
+        '--resource-monitor',
+        action='store_true',
         default=False,
         help="enable Nipype's resource monitoring to keep track of memory and CPU usage",
     )
     g_other.add_argument(
-        "--reports-only",
-        action="store_true",
+        '--reports-only',
+        action='store_true',
         default=False,
         help="only generate reports, don't run workflows. This will only rerun report "
-        "aggregation, not reportlet generation for specific nodes.",
+        'aggregation, not reportlet generation for specific nodes.',
     )
     g_other.add_argument(
-        "--run-uuid",
-        action="store",
+        '--run-uuid',
+        action='store',
         default=None,
-        help="Specify UUID of previous run, to include error logs in report. "
-        "No effect without --reports-only.",
+        help='Specify UUID of previous run, to include error logs in report. '
+        'No effect without --reports-only.',
     )
     g_other.add_argument(
-        "--write-graph",
-        action="store_true",
+        '--write-graph',
+        action='store_true',
         default=False,
-        help="Write workflow graph.",
+        help='Write workflow graph.',
     )
     g_other.add_argument(
-        "--stop-on-first-crash",
-        action="store_true",
+        '--stop-on-first-crash',
+        action='store_true',
         default=False,
-        help="Force stopping on first crash, even if a work directory was specified.",
+        help='Force stopping on first crash, even if a work directory was specified.',
     )
     g_other.add_argument(
-        "--notrack",
-        action="store_true",
+        '--notrack',
+        action='store_true',
         default=False,
-        help="Opt-out of sending tracking information of this run to "
-        "the sMRIPrep developers. This information helps to "
-        "improve sMRIPrep and provides an indicator of real "
-        "world usage crucial for obtaining funding.",
+        help='Opt-out of sending tracking information of this run to '
+        'the sMRIPrep developers. This information helps to '
+        'improve sMRIPrep and provides an indicator of real '
+        'world usage crucial for obtaining funding.',
     )
     g_other.add_argument(
-        "--sloppy",
-        action="store_true",
+        '--sloppy',
+        action='store_true',
         default=False,
-        help="Use low-quality tools for speed - TESTING ONLY",
+        help='Use low-quality tools for speed - TESTING ONLY',
     )
 
     return parser
@@ -328,38 +328,38 @@ def build_opts(opts):
     from nipype import logging as nlogging
     from niworkflows.utils.misc import check_valid_fs_license
 
-    set_start_method("forkserver")
+    set_start_method('forkserver')
 
-    logging.addLevelName(25, "IMPORTANT")  # Add a new level between INFO and WARNING
-    logging.addLevelName(15, "VERBOSE")  # Add a new level between INFO and DEBUG
-    logger = logging.getLogger("cli")
+    logging.addLevelName(25, 'IMPORTANT')  # Add a new level between INFO and WARNING
+    logging.addLevelName(15, 'VERBOSE')  # Add a new level between INFO and DEBUG
+    logger = logging.getLogger('cli')
 
     def _warn_redirect(message, category, filename, lineno, file=None, line=None):
-        logger.warning("Captured warning (%s): %s", category, message)
+        logger.warning('Captured warning (%s): %s', category, message)
 
     warnings.showwarning = _warn_redirect
 
     # Precedence: --fs-license-file, $FS_LICENSE, default_license
     if opts.fs_license_file is not None:
-        os.environ["FS_LICENSE"] = os.path.abspath(opts.fs_license_file)
+        os.environ['FS_LICENSE'] = os.path.abspath(opts.fs_license_file)
 
     if not check_valid_fs_license():
         raise RuntimeError(
-            "ERROR: a valid license file is required for FreeSurfer to run. "
-            "sMRIPrep looked for an existing license file at several paths, in this "
-            "order: 1) command line argument ``--fs-license-file``; 2) ``$FS_LICENSE`` "
-            "environment variable; and 3) the ``$FREESURFER_HOME/license.txt`` path. "
-            "Get it (for free) by registering at https://"
-            "surfer.nmr.mgh.harvard.edu/registration.html"
+            'ERROR: a valid license file is required for FreeSurfer to run. '
+            'sMRIPrep looked for an existing license file at several paths, in this '
+            'order: 1) command line argument ``--fs-license-file``; 2) ``$FS_LICENSE`` '
+            'environment variable; and 3) the ``$FREESURFER_HOME/license.txt`` path. '
+            'Get it (for free) by registering at https://'
+            'surfer.nmr.mgh.harvard.edu/registration.html'
         )
 
     # Retrieve logging level
     log_level = int(max(25 - 5 * opts.verbose_count, logging.DEBUG))
     # Set logging
     logger.setLevel(log_level)
-    nlogging.getLogger("nipype.workflow").setLevel(log_level)
-    nlogging.getLogger("nipype.interface").setLevel(log_level)
-    nlogging.getLogger("nipype.utils").setLevel(log_level)
+    nlogging.getLogger('nipype.workflow').setLevel(log_level)
+    nlogging.getLogger('nipype.interface').setLevel(log_level)
+    nlogging.getLogger('nipype.utils').setLevel(log_level)
 
     errno = 0
 
@@ -373,19 +373,19 @@ def build_opts(opts):
         if p.exitcode != 0:
             sys.exit(p.exitcode)
 
-        smriprep_wf = retval["workflow"]
-        plugin_settings = retval["plugin_settings"]
-        bids_dir = retval["bids_dir"]
-        output_dir = retval["output_dir"]
-        subject_list = retval["subject_list"]
-        run_uuid = retval["run_uuid"]
-        retcode = retval["return_code"]
+        smriprep_wf = retval['workflow']
+        plugin_settings = retval['plugin_settings']
+        bids_dir = retval['bids_dir']
+        output_dir = retval['output_dir']
+        subject_list = retval['subject_list']
+        run_uuid = retval['run_uuid']
+        retcode = retval['return_code']
 
     if smriprep_wf is None:
         sys.exit(1)
 
     if opts.write_graph:
-        smriprep_wf.write_graph(graph2use="colored", format="svg", simple_form=True)
+        smriprep_wf.write_graph(graph2use='colored', format='svg', simple_form=True)
 
     if opts.reports_only:
         sys.exit(int(retcode > 0))
@@ -396,9 +396,9 @@ def build_opts(opts):
     # Check workflow for missing commands
     missing = check_deps(smriprep_wf)
     if missing:
-        print("Cannot run sMRIPrep. Missing dependencies:")
+        print('Cannot run sMRIPrep. Missing dependencies:')
         for iface, cmd in missing:
-            print(f"\t{cmd} (Interface: {iface})")
+            print(f'\t{cmd} (Interface: {iface})')
         sys.exit(2)
 
     # Clean up master process before running workflow, which may create forks
@@ -412,19 +412,19 @@ def build_opts(opts):
             from templateflow import api
             from niworkflows.utils.misc import _copy_any
 
-            dseg_tsv = str(api.get("fsaverage", suffix="dseg", extension=[".tsv"]))
-            _copy_any(dseg_tsv, str(Path(output_dir) / "smriprep" / "desc-aseg_dseg.tsv"))
-            _copy_any(dseg_tsv, str(Path(output_dir) / "smriprep" / "desc-aparcaseg_dseg.tsv"))
-        logger.log(25, "sMRIPrep finished without errors")
+            dseg_tsv = str(api.get('fsaverage', suffix='dseg', extension=['.tsv']))
+            _copy_any(dseg_tsv, str(Path(output_dir) / 'smriprep' / 'desc-aseg_dseg.tsv'))
+            _copy_any(dseg_tsv, str(Path(output_dir) / 'smriprep' / 'desc-aparcaseg_dseg.tsv'))
+        logger.log(25, 'sMRIPrep finished without errors')
     finally:
         from niworkflows.reports import generate_reports
         from ..utils.bids import write_derivative_description, write_bidsignore
 
-        logger.log(25, "Writing reports for participants: %s", ", ".join(subject_list))
+        logger.log(25, 'Writing reports for participants: %s', ', '.join(subject_list))
         # Generate reports phase
-        errno += generate_reports(subject_list, output_dir, run_uuid, packagename="smriprep")
-        write_derivative_description(bids_dir, str(Path(output_dir) / "smriprep"))
-        write_bidsignore(Path(output_dir) / "smriprep")
+        errno += generate_reports(subject_list, output_dir, run_uuid, packagename='smriprep')
+        write_derivative_description(bids_dir, str(Path(output_dir) / 'smriprep'))
+        write_bidsignore(Path(output_dir) / 'smriprep')
     sys.exit(int(errno > 0))
 
 
@@ -454,7 +454,7 @@ def build_workflow(opts, retval):
     from ..data import load_resource
     from ..workflows.base import init_smriprep_wf
 
-    logger = logging.getLogger("nipype.workflow")
+    logger = logging.getLogger('nipype.workflow')
 
     INIT_MSG = """
     Running sMRIPrep version {version}:
@@ -466,7 +466,7 @@ def build_workflow(opts, retval):
     """.format
 
     # Set up some instrumental utilities
-    run_uuid = "{}_{}".format(strftime("%Y%m%d-%H%M%S"), uuid.uuid4())
+    run_uuid = '{}_{}'.format(strftime('%Y%m%d-%H%M%S'), uuid.uuid4())
 
     # First check that bids_dir looks like a BIDS folder
     bids_dir = opts.bids_dir.resolve()
@@ -481,30 +481,30 @@ def build_workflow(opts, retval):
 
         with open(opts.use_plugin) as f:
             plugin_settings = loadyml(f)
-        plugin_settings.setdefault("plugin_args", {})
+        plugin_settings.setdefault('plugin_args', {})
     else:
         # Defaults
         plugin_settings = {
-            "plugin": "MultiProc",
-            "plugin_args": {
-                "raise_insufficient": False,
-                "maxtasksperchild": 1,
+            'plugin': 'MultiProc',
+            'plugin_args': {
+                'raise_insufficient': False,
+                'maxtasksperchild': 1,
             },
         }
 
     # Resource management options
     # Note that we're making strong assumptions about valid plugin args
     # This may need to be revisited if people try to use batch plugins
-    nprocs = plugin_settings["plugin_args"].get("n_procs")
+    nprocs = plugin_settings['plugin_args'].get('n_procs')
     # Permit overriding plugin config with specific CLI options
     if nprocs is None or opts.nprocs is not None:
         nprocs = opts.nprocs
         if nprocs is None or nprocs < 1:
             nprocs = cpu_count()
-        plugin_settings["plugin_args"]["n_procs"] = nprocs
+        plugin_settings['plugin_args']['n_procs'] = nprocs
 
     if opts.mem_gb:
-        plugin_settings["plugin_args"]["memory_gb"] = opts.mem_gb
+        plugin_settings['plugin_args']['memory_gb'] = opts.mem_gb
 
     omp_nthreads = opts.omp_nthreads
     if omp_nthreads == 0:
@@ -512,15 +512,15 @@ def build_workflow(opts, retval):
 
     if 1 < nprocs < omp_nthreads:
         logger.warning(
-            "Per-process threads (--omp-nthreads=%d) exceed total "
-            "available CPUs (--nprocs/--ncpus=%d)",
+            'Per-process threads (--omp-nthreads=%d) exceed total '
+            'available CPUs (--nprocs/--ncpus=%d)',
             omp_nthreads,
             nprocs,
         )
 
     # Set up directories
     output_dir = opts.output_dir.resolve()
-    log_dir = output_dir / "smriprep" / "logs"
+    log_dir = output_dir / 'smriprep' / 'logs'
     work_dir = opts.work_dir.resolve()
 
     # Check and create output and working directories
@@ -530,17 +530,17 @@ def build_workflow(opts, retval):
     # Nipype config (logs and execution)
     ncfg.update_config(
         {
-            "logging": {"log_directory": str(log_dir), "log_to_file": True},
-            "execution": {
-                "crashdump_dir": str(log_dir),
-                "crashfile_format": "txt",
-                "get_linked_libs": False,
-                "stop_on_first_crash": opts.stop_on_first_crash,
+            'logging': {'log_directory': str(log_dir), 'log_to_file': True},
+            'execution': {
+                'crashdump_dir': str(log_dir),
+                'crashfile_format': 'txt',
+                'get_linked_libs': False,
+                'stop_on_first_crash': opts.stop_on_first_crash,
             },
-            "monitoring": {
-                "enabled": opts.resource_monitor,
-                "sample_frequency": "0.5",
-                "summary_append": True,
+            'monitoring': {
+                'enabled': opts.resource_monitor,
+                'sample_frequency': '0.5',
+                'summary_append': True,
             },
         }
     )
@@ -548,24 +548,24 @@ def build_workflow(opts, retval):
     if opts.resource_monitor:
         ncfg.enable_resource_monitor()
 
-    retval["return_code"] = 0
-    retval["plugin_settings"] = plugin_settings
-    retval["bids_dir"] = str(bids_dir)
-    retval["output_dir"] = str(output_dir)
-    retval["work_dir"] = str(work_dir)
-    retval["subject_list"] = subject_list
-    retval["run_uuid"] = run_uuid
-    retval["workflow"] = None
+    retval['return_code'] = 0
+    retval['plugin_settings'] = plugin_settings
+    retval['bids_dir'] = str(bids_dir)
+    retval['output_dir'] = str(output_dir)
+    retval['work_dir'] = str(work_dir)
+    retval['subject_list'] = subject_list
+    retval['run_uuid'] = run_uuid
+    retval['workflow'] = None
 
     # Called with reports only
     if opts.reports_only:
         from niworkflows.reports import generate_reports
 
-        logger.log(25, "Running --reports-only on participants %s", ", ".join(subject_list))
+        logger.log(25, 'Running --reports-only on participants %s', ', '.join(subject_list))
         if opts.run_uuid is not None:
             run_uuid = opts.run_uuid
-        retval["return_code"] = generate_reports(
-            subject_list, str(output_dir), run_uuid, packagename="smriprep"
+        retval['return_code'] = generate_reports(
+            subject_list, str(output_dir), run_uuid, packagename='smriprep'
         )
         return retval
 
@@ -587,14 +587,14 @@ def build_workflow(opts, retval):
     derivatives = opts.derivatives or []
     if opts.fast_track:
         # XXX Makes strong assumption of legacy layout
-        smriprep_dir = str(output_dir / "smriprep")
+        smriprep_dir = str(output_dir / 'smriprep')
         warnings.warn(
-            f"Received DEPRECATED --fast-track flag. Adding {smriprep_dir} to --derivatives list."
+            f'Received DEPRECATED --fast-track flag. Adding {smriprep_dir} to --derivatives list.'
         )
         derivatives.append(smriprep_dir)
 
     # Build main workflow
-    retval["workflow"] = init_smriprep_wf(
+    retval['workflow'] = init_smriprep_wf(
         sloppy=opts.sloppy,
         debug=False,
         derivatives=derivatives,
@@ -617,59 +617,59 @@ def build_workflow(opts, retval):
         bids_filters=bids_filters,
         cifti_output=opts.cifti_output,
     )
-    retval["return_code"] = 0
+    retval['return_code'] = 0
 
-    boilerplate = retval["workflow"].visit_desc()
-    (log_dir / "CITATION.md").write_text(boilerplate)
+    boilerplate = retval['workflow'].visit_desc()
+    (log_dir / 'CITATION.md').write_text(boilerplate)
     logger.log(
         25,
-        "Works derived from this sMRIPrep execution should "
-        "include the following boilerplate:\n\n%s",
+        'Works derived from this sMRIPrep execution should '
+        'include the following boilerplate:\n\n%s',
         boilerplate,
     )
 
-    boilerplate_bib = load_resource("boilerplate.bib")
+    boilerplate_bib = load_resource('boilerplate.bib')
 
     # Generate HTML file resolving citations
     cmd = [
-        "pandoc",
-        "-s",
-        "--bibliography",
+        'pandoc',
+        '-s',
+        '--bibliography',
         str(boilerplate_bib),
-        "--citeproc",
-        "--metadata",
+        '--citeproc',
+        '--metadata',
         'pagetitle="sMRIPrep citation boilerplate"',
-        str(log_dir / "CITATION.md"),
-        "-o",
-        str(log_dir / "CITATION.html"),
+        str(log_dir / 'CITATION.md'),
+        '-o',
+        str(log_dir / 'CITATION.html'),
     ]
     try:
         check_call(cmd, timeout=10)
     except (FileNotFoundError, CalledProcessError, TimeoutExpired):
-        logger.warning("Could not generate CITATION.html file:\n%s", " ".join(cmd))
+        logger.warning('Could not generate CITATION.html file:\n%s', ' '.join(cmd))
 
     # Generate LaTex file resolving citations
     cmd = [
-        "pandoc",
-        "-s",
-        "--bibliography",
+        'pandoc',
+        '-s',
+        '--bibliography',
         str(boilerplate_bib),
-        "--natbib",
-        str(log_dir / "CITATION.md"),
-        "-o",
-        str(log_dir / "CITATION.tex"),
+        '--natbib',
+        str(log_dir / 'CITATION.md'),
+        '-o',
+        str(log_dir / 'CITATION.tex'),
     ]
     try:
         check_call(cmd, timeout=10)
     except (FileNotFoundError, CalledProcessError, TimeoutExpired):
-        logger.warning("Could not generate CITATION.tex file:\n%s", " ".join(cmd))
+        logger.warning('Could not generate CITATION.tex file:\n%s', ' '.join(cmd))
     else:
-        copyfile(str(boilerplate_bib), str(log_dir / "CITATION.bib"))
+        copyfile(str(boilerplate_bib), str(log_dir / 'CITATION.bib'))
     return retval
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     raise RuntimeError(
-        "smriprep/cli/run.py should not be run directly;\n"
-        "Please `pip install` smriprep and use the `smriprep` command"
+        'smriprep/cli/run.py should not be run directly;\n'
+        'Please `pip install` smriprep and use the `smriprep` command'
     )

--- a/smriprep/cli/run.py
+++ b/smriprep/cli/run.py
@@ -595,6 +595,8 @@ def build_workflow(opts, retval):
         smriprep_dir = str(output_dir / 'smriprep')
         warnings.warn(
             f'Received DEPRECATED --fast-track flag. Adding {smriprep_dir} to --derivatives list.'
+            f'Received DEPRECATED --fast-track flag. Adding {smriprep_dir} to --derivatives list.',
+            stacklevel=1,
         )
         derivatives.append(smriprep_dir)
 

--- a/smriprep/cli/run.py
+++ b/smriprep/cli/run.py
@@ -482,7 +482,7 @@ def build_workflow(opts, retval):
 
     # Load base plugin_settings from file if --use-plugin
     if opts.use_plugin is not None:
-        from yaml import load as loadyml
+        from yaml import safe_load as loadyml
 
         with open(opts.use_plugin) as f:
             plugin_settings = loadyml(f)
@@ -651,7 +651,7 @@ def build_workflow(opts, retval):
         str(log_dir / 'CITATION.html'),
     ]
     try:
-        check_call(cmd, timeout=10)
+        check_call(cmd, timeout=10)  # noqa: S603
     except (FileNotFoundError, CalledProcessError, TimeoutExpired):
         logger.warning('Could not generate CITATION.html file:\n%s', ' '.join(cmd))
 
@@ -667,7 +667,7 @@ def build_workflow(opts, retval):
         str(log_dir / 'CITATION.tex'),
     ]
     try:
-        check_call(cmd, timeout=10)
+        check_call(cmd, timeout=10)  # noqa: S603
     except (FileNotFoundError, CalledProcessError, TimeoutExpired):
         logger.warning('Could not generate CITATION.tex file:\n%s', ' '.join(cmd))
     else:

--- a/smriprep/conf/__init__.py
+++ b/smriprep/conf/__init__.py
@@ -2,4 +2,4 @@
 from templateflow.api import templates as _get_templates
 
 TF_TEMPLATES = tuple(_get_templates())
-LEGACY_SPACES = ("fsnative", "fsaverage4", "fsaverage5", "fsaverage6", "fsaverage")
+LEGACY_SPACES = ('fsnative', 'fsaverage4', 'fsaverage5', 'fsaverage6', 'fsaverage')

--- a/smriprep/conftest.py
+++ b/smriprep/conftest.py
@@ -1,6 +1,6 @@
 import os
 
-import numpy
+import numpy as np
 import pytest
 
 from smriprep.data import load_resource
@@ -9,8 +9,8 @@ os.environ['NO_ET'] = '1'
 
 
 @pytest.fixture(autouse=True)
-def populate_namespace(doctest_namespace, tmp_path):
+def _populate_namespace(doctest_namespace, tmp_path):
     doctest_namespace['os'] = os
-    doctest_namespace['np'] = numpy
+    doctest_namespace['np'] = np
     doctest_namespace['load'] = load_resource
     doctest_namespace['testdir'] = tmp_path

--- a/smriprep/conftest.py
+++ b/smriprep/conftest.py
@@ -1,7 +1,7 @@
 import os
 
-import pytest
 import numpy
+import pytest
 
 from smriprep.data import load_resource
 

--- a/smriprep/data/__init__.py
+++ b/smriprep/data/__init__.py
@@ -12,7 +12,7 @@ try:  # Prefer backport to leave consistency to dependency spec
 except ImportError:
     from importlib.resources import files, as_file
 
-__all__ = ["load_resource"]
+__all__ = ['load_resource']
 
 exit_stack = ExitStack()
 atexit.register(exit_stack.close)

--- a/smriprep/data/__init__.py
+++ b/smriprep/data/__init__.py
@@ -8,9 +8,9 @@ except ImportError:  # PY38
     from functools import lru_cache as cache
 
 try:  # Prefer backport to leave consistency to dependency spec
-    from importlib_resources import files, as_file
+    from importlib_resources import as_file, files
 except ImportError:
-    from importlib.resources import files, as_file
+    from importlib.resources import as_file, files
 
 __all__ = ['load_resource']
 

--- a/smriprep/interfaces/__init__.py
+++ b/smriprep/interfaces/__init__.py
@@ -6,7 +6,7 @@ from niworkflows.interfaces.bids import DerivativesDataSink as DDS
 
 
 class DerivativesDataSink(DDS):
-    out_path_base = "smriprep"
+    out_path_base = 'smriprep'
 
 
 del DDS

--- a/smriprep/interfaces/cifti.py
+++ b/smriprep/interfaces/cifti.py
@@ -1,12 +1,11 @@
 import json
-from pathlib import Path
 import typing as ty
+from pathlib import Path
 
 import nibabel as nb
 import numpy as np
-
 from nibabel import cifti2 as ci
-from nipype.interfaces.base import TraitedSpec, traits, File, SimpleInterface
+from nipype.interfaces.base import File, SimpleInterface, TraitedSpec, traits
 from templateflow import api as tf
 
 
@@ -52,7 +51,7 @@ class GenerateDScalar(SimpleInterface):
         return runtime
 
 
-def _prepare_cifti(grayordinates: str) -> ty.Tuple[list, dict]:
+def _prepare_cifti(grayordinates: str) -> tuple[list, dict]:
     """
     Fetch the required templates needed for CIFTI-2 generation, based on input surface density.
 
@@ -133,8 +132,8 @@ def _prepare_cifti(grayordinates: str) -> ty.Tuple[list, dict]:
 
 
 def _create_cifti_image(
-    scalar_surfs: ty.Tuple[str, str],
-    surface_labels: ty.Tuple[str, str],
+    scalar_surfs: tuple[str, str],
+    surface_labels: tuple[str, str],
     scalar_name: str,
     metadata: ty.Optional[dict] = None,
 ):

--- a/smriprep/interfaces/cifti.py
+++ b/smriprep/interfaces/cifti.py
@@ -1,5 +1,4 @@
 import json
-import typing as ty
 from pathlib import Path
 
 import nibabel as nb
@@ -135,7 +134,7 @@ def _create_cifti_image(
     scalar_surfs: tuple[str, str],
     surface_labels: tuple[str, str],
     scalar_name: str,
-    metadata: ty.Optional[dict] = None,
+    metadata: dict | None = None,
 ):
     """
     Generate CIFTI image in target space.

--- a/smriprep/interfaces/cifti.py
+++ b/smriprep/interfaces/cifti.py
@@ -12,22 +12,22 @@ from templateflow import api as tf
 
 class _GenerateDScalarInputSpec(TraitedSpec):
     surface_target = traits.Enum(
-        "fsLR",
+        'fsLR',
         usedefault=True,
-        desc="CIFTI surface target space",
+        desc='CIFTI surface target space',
     )
-    grayordinates = traits.Enum("91k", "170k", usedefault=True, desc="Final CIFTI grayordinates")
+    grayordinates = traits.Enum('91k', '170k', usedefault=True, desc='Final CIFTI grayordinates')
     scalar_surfs = traits.List(
         File(exists=True),
         mandatory=True,
-        desc="list of surface BOLD GIFTI files (length 2 with order [L,R])",
+        desc='list of surface BOLD GIFTI files (length 2 with order [L,R])',
     )
-    scalar_name = traits.Str(mandatory=True, desc="Name of scalar")
+    scalar_name = traits.Str(mandatory=True, desc='Name of scalar')
 
 
 class _GenerateDScalarOutputSpec(TraitedSpec):
-    out_file = File(desc="generated CIFTI file")
-    out_metadata = File(desc="CIFTI metadata JSON")
+    out_file = File(desc='generated CIFTI file')
+    out_metadata = File(desc='CIFTI metadata JSON')
 
 
 class GenerateDScalar(SimpleInterface):
@@ -40,15 +40,15 @@ class GenerateDScalar(SimpleInterface):
 
     def _run_interface(self, runtime):
         surface_labels, metadata = _prepare_cifti(self.inputs.grayordinates)
-        self._results["out_file"] = _create_cifti_image(
+        self._results['out_file'] = _create_cifti_image(
             self.inputs.scalar_surfs,
             surface_labels,
             self.inputs.scalar_name,
             metadata,
         )
-        metadata_file = Path("dscalar.json").absolute()
+        metadata_file = Path('dscalar.json').absolute()
         metadata_file.write_text(json.dumps(metadata, indent=2))
-        self._results["out_metadata"] = str(metadata_file)
+        self._results['out_metadata'] = str(metadata_file)
         return runtime
 
 
@@ -81,21 +81,21 @@ def _prepare_cifti(grayordinates: str) -> ty.Tuple[list, dict]:
     """
 
     grayord_key = {
-        "91k": {
-            "surface-den": "32k",
-            "tf-res": "02",
-            "grayords": "91,282",
-            "res-mm": "2mm",
+        '91k': {
+            'surface-den': '32k',
+            'tf-res': '02',
+            'grayords': '91,282',
+            'res-mm': '2mm',
         },
-        "170k": {
-            "surface-den": "59k",
-            "tf-res": "06",
-            "grayords": "170,494",
-            "res-mm": "1.6mm",
+        '170k': {
+            'surface-den': '59k',
+            'tf-res': '06',
+            'grayords': '170,494',
+            'res-mm': '1.6mm',
         },
     }
     if grayordinates not in grayord_key:
-        raise NotImplementedError(f"Grayordinates {grayordinates} is not supported.")
+        raise NotImplementedError(f'Grayordinates {grayordinates} is not supported.')
 
     total_grayords = grayord_key[grayordinates]['grayords']
     res_mm = grayord_key[grayordinates]['res-mm']
@@ -104,29 +104,29 @@ def _prepare_cifti(grayordinates: str) -> ty.Tuple[list, dict]:
     surface_labels = [
         str(
             tf.get(
-                "fsLR",
+                'fsLR',
                 density=surface_density,
                 hemi=hemi,
-                desc="nomedialwall",
-                suffix="dparc",
+                desc='nomedialwall',
+                suffix='dparc',
                 raise_empty=True,
             )
         )
-        for hemi in ("L", "R")
+        for hemi in ('L', 'R')
     ]
 
-    tf_url = "https://templateflow.s3.amazonaws.com"
+    tf_url = 'https://templateflow.s3.amazonaws.com'
     surfaces_url = (  # midthickness is the default, but varying levels of inflation are all valid
-        f"{tf_url}/tpl-fsLR/tpl-fsLR_den-{surface_density}_hemi-%s_midthickness.surf.gii"
+        f'{tf_url}/tpl-fsLR/tpl-fsLR_den-{surface_density}_hemi-%s_midthickness.surf.gii'
     )
     metadata = {
-        "Density": (
-            f"{total_grayords} grayordinates corresponding to all of the grey matter sampled at a "
-            f"{res_mm} average vertex spacing on the surface"
+        'Density': (
+            f'{total_grayords} grayordinates corresponding to all of the grey matter sampled at a '
+            f'{res_mm} average vertex spacing on the surface'
         ),
-        "SpatialReference": {
-            "CIFTI_STRUCTURE_CORTEX_LEFT": surfaces_url % "L",
-            "CIFTI_STRUCTURE_CORTEX_RIGHT": surfaces_url % "R",
+        'SpatialReference': {
+            'CIFTI_STRUCTURE_CORTEX_LEFT': surfaces_url % 'L',
+            'CIFTI_STRUCTURE_CORTEX_RIGHT': surfaces_url % 'R',
         },
     }
     return surface_labels, metadata
@@ -170,12 +170,12 @@ def _create_cifti_image(
         )
 
         morph_scalar = nb.load(scalar_surfs[idx])
-        arrays.append(morph_scalar.darrays[0].data[mask].astype("float32"))
+        arrays.append(morph_scalar.darrays[0].data[mask].astype('float32'))
 
     # provide some metadata to CIFTI matrix
     if not metadata:
         metadata = {
-            "surface": "fsLR",
+            'surface': 'fsLR',
         }
 
     # generate and save CIFTI image
@@ -185,10 +185,10 @@ def _create_cifti_image(
     hdr.matrix.metadata = ci.Cifti2MetaData(metadata)
 
     img = ci.Cifti2Image(dataobj=np.atleast_2d(np.concatenate(arrays)), header=hdr)
-    img.nifti_header.set_intent("NIFTI_INTENT_CONNECTIVITY_DENSE_SCALARS")
+    img.nifti_header.set_intent('NIFTI_INTENT_CONNECTIVITY_DENSE_SCALARS')
 
-    stem = Path(scalar_surfs[0]).name.split(".")[0]
-    cifti_stem = "_".join(ent for ent in stem.split("_") if not ent.startswith("hemi-"))
-    out_file = Path.cwd() / f"{cifti_stem}.dscalar.nii"
+    stem = Path(scalar_surfs[0]).name.split('.')[0]
+    cifti_stem = '_'.join(ent for ent in stem.split('_') if not ent.startswith('hemi-'))
+    out_file = Path.cwd() / f'{cifti_stem}.dscalar.nii'
     img.to_filename(out_file)
     return out_file

--- a/smriprep/interfaces/conftest.py
+++ b/smriprep/interfaces/conftest.py
@@ -22,9 +22,9 @@ except ImportError:  # PY310
 @pytest.fixture(autouse=True)
 def _docdir(request, tmp_path):
     # Trigger ONLY for the doctests.
-    doctest_plugin = request.config.pluginmanager.getplugin("doctest")
+    doctest_plugin = request.config.pluginmanager.getplugin('doctest')
     if isinstance(request.node, doctest_plugin.DoctestItem):
-        copytree(Path(__file__).parent / "tests" / "data", tmp_path, dirs_exist_ok=True)
+        copytree(Path(__file__).parent / 'tests' / 'data', tmp_path, dirs_exist_ok=True)
 
         # Chdir only for the duration of the test.
         with _chdir(tmp_path):

--- a/smriprep/interfaces/freesurfer.py
+++ b/smriprep/interfaces/freesurfer.py
@@ -29,93 +29,93 @@ from nipype.interfaces.base import traits, InputMultiObject, isdefined, File
 from nipype.interfaces import freesurfer as fs
 from niworkflows.interfaces import freesurfer as nwfs
 
-iflogger = logging.getLogger("nipype.interface")
+iflogger = logging.getLogger('nipype.interface')
 
 
 class _ReconAllInputSpec(fs.preprocess.ReconAllInputSpec):
     directive = traits.Enum(
-        "all",
-        "autorecon1",
+        'all',
+        'autorecon1',
         # autorecon2 variants
-        "autorecon2",
-        "autorecon2-volonly",
-        "autorecon2-perhemi",
-        "autorecon2-inflate1",
-        "autorecon2-cp",
-        "autorecon2-wm",
+        'autorecon2',
+        'autorecon2-volonly',
+        'autorecon2-perhemi',
+        'autorecon2-inflate1',
+        'autorecon2-cp',
+        'autorecon2-wm',
         # autorecon3 variants
-        "autorecon3",
-        "autorecon3-T2pial",
+        'autorecon3',
+        'autorecon3-T2pial',
         # Mix of autorecon2 and autorecon3 steps
-        "autorecon-pial",
-        "autorecon-hemi",
+        'autorecon-pial',
+        'autorecon-hemi',
         # Not "multi-stage flags"
-        "localGI",
-        "qcache",
-        argstr="-%s",
-        desc="process directive",
+        'localGI',
+        'qcache',
+        argstr='-%s',
+        desc='process directive',
         usedefault=True,
-        xor=["steps"],
+        xor=['steps'],
         position=0,
     )
     steps = InputMultiObject(
         traits.Enum(
             # autorecon1
-            "motioncor",
-            "talairach",
-            "nuintensitycor",
-            "normalization",
-            "skullstrip",
+            'motioncor',
+            'talairach',
+            'nuintensitycor',
+            'normalization',
+            'skullstrip',
             # autorecon2-volonly
-            "gcareg",
-            "canorm",
-            "careg",
-            "careginv",  # 5.3
-            "rmneck",  # 5.3
-            "skull-lta",  # 5.3
-            "calabel",
-            "normalization2",
-            "maskbfs",
-            "segmentation",
+            'gcareg',
+            'canorm',
+            'careg',
+            'careginv',  # 5.3
+            'rmneck',  # 5.3
+            'skull-lta',  # 5.3
+            'calabel',
+            'normalization2',
+            'maskbfs',
+            'segmentation',
             # autorecon2 per-hemi
-            "tessellate",
-            "smooth1",
-            "inflate1",
-            "qsphere",
-            "fix",
-            "white",
-            "smooth2",
-            "inflate2",
-            "curvHK",  # 6.0
-            "curvstats",
+            'tessellate',
+            'smooth1',
+            'inflate1',
+            'qsphere',
+            'fix',
+            'white',
+            'smooth2',
+            'inflate2',
+            'curvHK',  # 6.0
+            'curvstats',
             # autorecon3 per-hemi
-            "sphere",
-            "surfreg",
-            "jacobian_white",
-            "avgcurv",
-            "cortparc",
-            "pial",
-            "pctsurfcon",
-            "parcstats",
-            "cortparc2",
-            "parcstats2",
-            "cortparc3",
-            "parcstats3",
-            "label-exvivo-ec",
+            'sphere',
+            'surfreg',
+            'jacobian_white',
+            'avgcurv',
+            'cortparc',
+            'pial',
+            'pctsurfcon',
+            'parcstats',
+            'cortparc2',
+            'parcstats2',
+            'cortparc3',
+            'parcstats3',
+            'label-exvivo-ec',
             # autorecon vol
-            "cortribbon",
-            "hyporelabel",  # 6.0
-            "segstats",
-            "aparc2aseg",
-            "apas2aseg",  # 6.0
-            "wmparc",
-            "balabels",
+            'cortribbon',
+            'hyporelabel',  # 6.0
+            'segstats',
+            'aparc2aseg',
+            'apas2aseg',  # 6.0
+            'wmparc',
+            'balabels',
         ),
-        desc="specific process directives",
-        xor=["directive"],
+        desc='specific process directives',
+        xor=['directive'],
         position=0,
     )
-    hemi = traits.Enum("lh", "rh", desc="hemisphere to process", argstr="-%s-only")
+    hemi = traits.Enum('lh', 'rh', desc='hemisphere to process', argstr='-%s-only')
 
 
 class ReconAll(fs.ReconAll):
@@ -141,26 +141,26 @@ class ReconAll(fs.ReconAll):
             steps = []
             if isdefined(self.inputs.steps):
                 steps = [step for step in self._steps if step[0] in self.inputs.steps]
-        elif directive == "autorecon1":
+        elif directive == 'autorecon1':
             steps = self._autorecon1_steps
-        elif directive == "autorecon2-volonly":
+        elif directive == 'autorecon2-volonly':
             steps = self._autorecon2_volonly_steps
-        elif directive == "autorecon2-perhemi":
+        elif directive == 'autorecon2-perhemi':
             steps = self._autorecon2_perhemi_steps
-        elif directive.startswith("autorecon2"):
+        elif directive.startswith('autorecon2'):
             if isdefined(self.inputs.hemi):
-                if self.inputs.hemi == "lh":
+                if self.inputs.hemi == 'lh':
                     steps = self._autorecon2_volonly_steps + self._autorecon2_lh_steps
                 else:
                     steps = self._autorecon2_volonly_steps + self._autorecon2_rh_steps
             else:
                 steps = self._autorecon2_steps
-        elif directive == "autorecon-hemi":
-            if self.inputs.hemi == "lh":
+        elif directive == 'autorecon-hemi':
+            if self.inputs.hemi == 'lh':
                 steps = self._autorecon_lh_steps
             else:
                 steps = self._autorecon_rh_steps
-        elif directive == "autorecon3":
+        elif directive == 'autorecon3':
             steps = self._autorecon3_steps
         else:
             steps = self._steps
@@ -168,8 +168,8 @@ class ReconAll(fs.ReconAll):
         no_run = True
         flags = []
         for step, outfiles, infiles in steps:
-            flag = f"-{step}"
-            noflag = f"-no{step}"
+            flag = f'-{step}'
+            noflag = f'-no{step}'
             if noflag in cmd:
                 continue
             elif flag in cmd:
@@ -178,7 +178,7 @@ class ReconAll(fs.ReconAll):
 
             # FreeSurfer changed the meaning and order of -apas2aseg without
             # updating the recon table on the wiki. Hack it until fixed in nipype.
-            if step == 'apas2aseg' and fs.Info.looseversion() >= LooseVersion("7.3.0"):
+            if step == 'apas2aseg' and fs.Info.looseversion() >= LooseVersion('7.3.0'):
                 infiles = []
 
             subj_dir = os.path.join(subjects_dir, self.inputs.subject_id)
@@ -193,17 +193,17 @@ class ReconAll(fs.ReconAll):
                 no_run = False
 
         if no_run and not self.force_run:
-            iflogger.info("recon-all complete : Not running")
-            return "echo recon-all: nothing to do"
+            iflogger.info('recon-all complete : Not running')
+            return 'echo recon-all: nothing to do'
 
-        cmd += " " + " ".join(flags)
-        iflogger.info("resume recon-all : %s", cmd)
+        cmd += ' ' + ' '.join(flags)
+        iflogger.info('resume recon-all : %s', cmd)
         return cmd
 
     def _format_arg(self, name, trait_spec, value):
         # Nipype disables this if -autorecon-hemi is passed
         # We need to use it either way to prevent undesired behavior
-        if name == "hemi":
+        if name == 'hemi':
             return trait_spec.argstr % value
         return super()._format_arg(name, trait_spec, value)
 
@@ -213,48 +213,48 @@ class _MRIsConvertDataInputSpec(fs.utils.MRIsConvertInputSpec):
         exists=True,
         position=-2,
         genfile=True,
-        argstr="%s",
-        desc="Surface file",
+        argstr='%s',
+        desc='Surface file',
     )
     _xor = ('annot_file', 'parcstats_file', 'label_file', 'scalarcurv_file', 'functional_file')
     annot_file = File(
         exists=True,
-        argstr="--annot %s",
+        argstr='--annot %s',
         mandatory=True,
         xor=_xor,
-        desc="input is annotation or gifti label data",
+        desc='input is annotation or gifti label data',
     )
 
     parcstats_file = File(
         exists=True,
-        argstr="--parcstats %s",
+        argstr='--parcstats %s',
         mandatory=True,
         xor=_xor,
-        desc="infile is name of text file containing label/val pairs",
+        desc='infile is name of text file containing label/val pairs',
     )
 
     label_file = File(
         exists=True,
-        argstr="--label %s",
+        argstr='--label %s',
         mandatory=True,
         xor=_xor,
-        desc="infile is .label file, label is name of this label",
+        desc='infile is .label file, label is name of this label',
     )
 
     scalarcurv_file = File(
         exists=True,
-        argstr="-c %s",
+        argstr='-c %s',
         mandatory=True,
         xor=_xor,
-        desc="input is scalar curv overlay file (must still specify surface)",
+        desc='input is scalar curv overlay file (must still specify surface)',
     )
 
     functional_file = File(
         exists=True,
-        argstr="-f %s",
+        argstr='-f %s',
         mandatory=True,
         xor=_xor,
-        desc="input is functional time-series or other multi-frame data (must specify surface)",
+        desc='input is functional time-series or other multi-frame data (must specify surface)',
     )
 
 
@@ -267,27 +267,27 @@ class MRIsConvertData(fs.utils.MRIsConvert):
     input_spec = _MRIsConvertDataInputSpec
 
     def _gen_filename(self, name):
-        if name == "in_file":
+        if name == 'in_file':
             if isdefined(self.inputs.in_file):
                 return self.inputs.in_file
 
             # Find file we're trying to convert
             fname = None
             for opt in ('annot', 'parcstats', 'label', 'scalarcurv', 'functional'):
-                input_file = getattr(self.inputs, f"{opt}_file")
+                input_file = getattr(self.inputs, f'{opt}_file')
                 if isdefined(input_file):
                     fname = input_file
                     break
 
             if fname is None:
-                raise ValueError("Missing file to derive filename from.")
+                raise ValueError('Missing file to derive filename from.')
 
             # $SUB/lh.curv -> $SUB/lh.white, etc
             dirname, basename = os.path.split(fname)
             hemi = basename.split('.', 1)[0]
             if hemi not in ('lh', 'rh'):
                 return None
-            self.inputs.in_file = os.path.join(dirname, f"{hemi}.white")
+            self.inputs.in_file = os.path.join(dirname, f'{hemi}.white')
             return self.inputs.in_file
 
         return super()._gen_filename(name)
@@ -329,12 +329,10 @@ class MakeMidthickness(nwfs.MakeMidthickness, fs.base.FSCommandOpenMP):
     def _format_arg(self, name, trait_spec, value):
         # FreeSurfer at some point changed whether it would add the hemi label onto the
         # surface. Therefore we'll do it ourselves.
-        if name == "out_name":
+        if name == 'out_name':
             value = self._associated_file(self.inputs.in_file, value)
         return super()._format_arg(name, trait_spec, value)
 
     def _num_threads_update(self):
         if self.inputs.num_threads:
-            self.inputs.environ.update(
-                {"OMP_NUM_THREADS": str(self.inputs.num_threads * 3 // 2)}
-            )
+            self.inputs.environ.update({'OMP_NUM_THREADS': str(self.inputs.num_threads * 3 // 2)})

--- a/smriprep/interfaces/freesurfer.py
+++ b/smriprep/interfaces/freesurfer.py
@@ -22,11 +22,12 @@
 #
 """Nipype's recon-all replacement."""
 import os
+
 from looseversion import LooseVersion
 from nipype import logging
-from nipype.utils.filemanip import check_depends
-from nipype.interfaces.base import traits, InputMultiObject, isdefined, File
 from nipype.interfaces import freesurfer as fs
+from nipype.interfaces.base import File, InputMultiObject, isdefined, traits
+from nipype.utils.filemanip import check_depends
 from niworkflows.interfaces import freesurfer as nwfs
 
 iflogger = logging.getLogger('nipype.interface')

--- a/smriprep/interfaces/gifti.py
+++ b/smriprep/interfaces/gifti.py
@@ -8,17 +8,17 @@ from nipype.interfaces.base import File, SimpleInterface, TraitedSpec, isdefined
 class MetricMathInputSpec(TraitedSpec):
     subject_id = traits.Str(desc='subject ID')
     hemisphere = traits.Enum(
-        "L",
-        "R",
+        'L',
+        'R',
         mandatory=True,
         desc='hemisphere',
     )
     metric = traits.Str(desc='name of metric to invert')
     metric_file = File(exists=True, mandatory=True, desc='input GIFTI file')
     operation = traits.Enum(
-        "invert",
-        "abs",
-        "bin",
+        'invert',
+        'abs',
+        'bin',
         mandatory=True,
         desc='operation to perform',
     )
@@ -53,20 +53,20 @@ class MetricMath(SimpleInterface):
 
         img = nb.GiftiImage.from_filename(self.inputs.metric_file)
         # wb_command -set-structure
-        img.meta["AnatomicalStructurePrimary"] = {'L': 'CortexLeft', 'R': 'CortexRight'}[hemi]
+        img.meta['AnatomicalStructurePrimary'] = {'L': 'CortexLeft', 'R': 'CortexRight'}[hemi]
         darray = img.darrays[0]
         # wb_command -set-map-names
         meta = darray.meta
-        meta['Name'] = f"{subject}_{hemi}_{metric}"
+        meta['Name'] = f'{subject}_{hemi}_{metric}'
 
         datatype = darray.datatype
-        if self.inputs.operation == "abs":
+        if self.inputs.operation == 'abs':
             # wb_command -metric-math "abs(var)"
             data = abs(darray.data)
-        elif self.inputs.operation == "invert":
+        elif self.inputs.operation == 'invert':
             # wb_command -metric-math "var * -1"
             data = -darray.data
-        elif self.inputs.operation == "bin":
+        elif self.inputs.operation == 'bin':
             # wb_command -metric-math "var > 0"
             data = darray.data > 0
             datatype = 'uint8'
@@ -83,7 +83,7 @@ class MetricMath(SimpleInterface):
         )
         img.darrays[0] = darray
 
-        out_filename = os.path.join(runtime.cwd, f"{subject}.{hemi}.{metric}.native.shape.gii")
+        out_filename = os.path.join(runtime.cwd, f'{subject}.{hemi}.{metric}.native.shape.gii')
         img.to_filename(out_filename)
-        self._results["metric_file"] = out_filename
+        self._results['metric_file'] = out_filename
         return runtime

--- a/smriprep/interfaces/msm.py
+++ b/smriprep/interfaces/msm.py
@@ -13,99 +13,99 @@ class MSMInputSpec(CommandLineInputSpec):
     in_mesh = File(
         exists=True,
         mandatory=True,
-        argstr="--inmesh=%s",
-        desc="input mesh (available formats: VTK, ASCII, GIFTI). Needs to be a sphere",
+        argstr='--inmesh=%s',
+        desc='input mesh (available formats: VTK, ASCII, GIFTI). Needs to be a sphere',
     )
     out_base = File(
-        name_source=["in_mesh"],
-        name_template="%s_msm",
-        argstr="--out=%s",
-        desc="output basename",
+        name_source=['in_mesh'],
+        name_template='%s_msm',
+        argstr='--out=%s',
+        desc='output basename',
     )
     reference_mesh = File(
         exists=True,
-        argstr="--refmesh=%s",
-        desc="reference mesh (available formats: VTK, ASCII, GIFTI). Needs to be a sphere."
-        "If not included algorithm assumes reference mesh is equivalent input",
+        argstr='--refmesh=%s',
+        desc='reference mesh (available formats: VTK, ASCII, GIFTI). Needs to be a sphere.'
+        'If not included algorithm assumes reference mesh is equivalent input',
     )
     in_data = File(
         exists=True,
-        argstr="--indata=%s",
-        desc="scalar or multivariate data for input - can be ASCII (.asc,.dpv,.txt) "
-        "or GIFTI (.func.gii or .shape.gii)",
+        argstr='--indata=%s',
+        desc='scalar or multivariate data for input - can be ASCII (.asc,.dpv,.txt) '
+        'or GIFTI (.func.gii or .shape.gii)',
     )
     reference_data = File(
         exists=True,
-        argstr="--refdata=%s",
-        desc="scalar or multivariate data for reference - can be ASCII (.asc,.dpv,.txt) "
-        "or GIFTI (.func.gii or .shape.gii)",
+        argstr='--refdata=%s',
+        desc='scalar or multivariate data for reference - can be ASCII (.asc,.dpv,.txt) '
+        'or GIFTI (.func.gii or .shape.gii)',
     )
     transformed_mesh = File(
         exists=True,
-        argstr="--trans=%s",
-        desc="Transformed source mesh (output of a previous registration). "
-        "Use this to initialise the current registration.",
+        argstr='--trans=%s',
+        desc='Transformed source mesh (output of a previous registration). '
+        'Use this to initialise the current registration.',
     )
     in_register = File(
         exists=True,
-        argstr="--in_register=%s",
-        desc="Input mesh at data resolution. Used to resample data onto input mesh if data "
-        "is supplied at a different resolution. Note this mesh HAS to be in alignment with "
-        "either the input_mesh of (if supplied) the transformed source mesh. "
-        "Use with supreme caution.",
+        argstr='--in_register=%s',
+        desc='Input mesh at data resolution. Used to resample data onto input mesh if data '
+        'is supplied at a different resolution. Note this mesh HAS to be in alignment with '
+        'either the input_mesh of (if supplied) the transformed source mesh. '
+        'Use with supreme caution.',
     )
     in_weight = File(
         exists=True,
-        argstr="--inweight=%s",
-        desc="cost function weighting for input - weights data in these vertices when calculating "
-        "similarity (ASCII or GIFTI). Can be multivariate provided dimension equals that of data",
+        argstr='--inweight=%s',
+        desc='cost function weighting for input - weights data in these vertices when calculating '
+        'similarity (ASCII or GIFTI). Can be multivariate provided dimension equals that of data',
     )
     reference_weight = File(
         exists=True,
-        argstr="--refweight=%s",
-        desc="cost function weighting for reference - weights data in these vertices when "
-        "calculating similarity (ASCII or GIFTI). Can be multivariate provided dimension "
-        "equals that of data",
+        argstr='--refweight=%s',
+        desc='cost function weighting for reference - weights data in these vertices when '
+        'calculating similarity (ASCII or GIFTI). Can be multivariate provided dimension '
+        'equals that of data',
     )
     output_format = traits.Enum(
-        "GIFTI",
-        "VTK",
-        "ASCII",
-        "ASCII_MAT",
-        argstr="--format=%s",
-        desc="format of output files",
+        'GIFTI',
+        'VTK',
+        'ASCII',
+        'ASCII_MAT',
+        argstr='--format=%s',
+        desc='format of output files',
     )
     config_file = File(
         exists=True,
-        argstr="--conf=%s",
-        desc="configuration file",
+        argstr='--conf=%s',
+        desc='configuration file',
     )
     levels = traits.Int(
-        argstr="--levels=%d",
-        desc="number of resolution levels (default = number of resolution levels specified "
-        "by --opt in config file)",
+        argstr='--levels=%d',
+        desc='number of resolution levels (default = number of resolution levels specified '
+        'by --opt in config file)',
     )
     smooth_output_sigma = traits.Int(
-        argstr="--smoothout=%d",
-        desc="smooth transformed output with this sigma (default=0)",
+        argstr='--smoothout=%d',
+        desc='smooth transformed output with this sigma (default=0)',
     )
     verbose = traits.Bool(
-        argstr="--verbose",
-        desc="switch on diagnostic messages",
+        argstr='--verbose',
+        desc='switch on diagnostic messages',
     )
 
 
 class MSMOutputSpec(TraitedSpec):
     warped_mesh = File(
-        desc="the warped input mesh (i.e., new vertex locations - this capture the warp field, "
-        "much like a _warp.nii.gz file would for volumetric warps created by FNIRT)."
+        desc='the warped input mesh (i.e., new vertex locations - this capture the warp field, '
+        'much like a _warp.nii.gz file would for volumetric warps created by FNIRT).'
     )
     downsampled_warped_mesh = File(
-        desc="a downsampled version of the warped_mesh where the resolution of this mesh will "
-        "be equivalent to the resolution of the final datamesh"
+        desc='a downsampled version of the warped_mesh where the resolution of this mesh will '
+        'be equivalent to the resolution of the final datamesh'
     )
     warped_data = File(
-        desc="the input data passed through the MSM warp and projected onto the target surface"
+        desc='the input data passed through the MSM warp and projected onto the target surface'
     )
 
 
@@ -145,7 +145,7 @@ class MSM(CommandLine):
 
     input_spec = MSMInputSpec
     output_spec = MSMOutputSpec
-    _cmd = "msm"
+    _cmd = 'msm'
 
     def _list_outputs(self):
         from nipype.utils.filemanip import split_filename

--- a/smriprep/interfaces/reports.py
+++ b/smriprep/interfaces/reports.py
@@ -22,25 +22,23 @@
 #
 """Interfaces to generate reportlets."""
 
-from pathlib import Path
 import time
+from pathlib import Path
 
-from nipype.interfaces.base import (
-    TraitedSpec,
-    BaseInterfaceInputSpec,
-    File,
-    Directory,
-    InputMultiObject,
-    Str,
-    isdefined,
-    SimpleInterface,
-)
 from nipype.interfaces import freesurfer as fs
+from nipype.interfaces.base import (
+    BaseInterfaceInputSpec,
+    Directory,
+    File,
+    InputMultiObject,
+    SimpleInterface,
+    Str,
+    TraitedSpec,
+    isdefined,
+)
 from nipype.interfaces.io import FSSourceInputSpec as _FSSourceInputSpec
 from nipype.interfaces.mixins import reporting
-
 from niworkflows.interfaces.reportlets.base import _SVGReportCapableInputSpec
-
 
 SUBJECT_TEMPLATE = """\
 \t<ul class="elem-desc">
@@ -173,12 +171,12 @@ class FSSurfaceReport(SimpleInterface):
     output_spec = _FSSurfaceReportOutputSpec
 
     def _run_interface(self, runtime):
-        from niworkflows.viz.utils import (
-            plot_registration,
-            cuts_from_bbox,
-            compose_view,
-        )
         from nibabel import load
+        from niworkflows.viz.utils import (
+            compose_view,
+            cuts_from_bbox,
+            plot_registration,
+        )
 
         rootdir = Path(self.inputs.subjects_dir) / self.inputs.subject_id
         _anat_file = str(rootdir / 'mri' / 'brain.mgz')

--- a/smriprep/interfaces/reports.py
+++ b/smriprep/interfaces/reports.py
@@ -61,7 +61,7 @@ ABOUT_TEMPLATE = """\t<ul>
 
 
 class _SummaryOutputSpec(TraitedSpec):
-    out_report = File(exists=True, desc="HTML segment containing summary")
+    out_report = File(exists=True, desc='HTML segment containing summary')
 
 
 class SummaryInterface(SimpleInterface):
@@ -71,9 +71,9 @@ class SummaryInterface(SimpleInterface):
 
     def _run_interface(self, runtime):
         segment = self._generate_segment()
-        path = Path(runtime.cwd) / "report.html"
+        path = Path(runtime.cwd) / 'report.html'
         path.write_text(segment)
-        self._results["out_report"] = str(path)
+        self._results['out_report'] = str(path)
         return runtime
 
     def _generate_segment(self):
@@ -81,17 +81,17 @@ class SummaryInterface(SimpleInterface):
 
 
 class _SubjectSummaryInputSpec(BaseInterfaceInputSpec):
-    t1w = InputMultiObject(File(exists=True), desc="T1w structural images")
-    t2w = InputMultiObject(File(exists=True), desc="T2w structural images")
-    subjects_dir = Directory(desc="FreeSurfer subjects directory")
-    subject_id = Str(desc="Subject ID")
-    output_spaces = InputMultiObject(Str, desc="list of standard spaces")
+    t1w = InputMultiObject(File(exists=True), desc='T1w structural images')
+    t2w = InputMultiObject(File(exists=True), desc='T2w structural images')
+    subjects_dir = Directory(desc='FreeSurfer subjects directory')
+    subject_id = Str(desc='Subject ID')
+    output_spaces = InputMultiObject(Str, desc='list of standard spaces')
 
 
 class _SubjectSummaryOutputSpec(_SummaryOutputSpec):
     # This exists to ensure that the summary is run prior to the first ReconAll
     # call, allowing a determination whether there is a pre-existing directory
-    subject_id = Str(desc="FreeSurfer subject ID")
+    subject_id = Str(desc='FreeSurfer subject ID')
 
 
 class SubjectSummary(SummaryInterface):
@@ -102,33 +102,33 @@ class SubjectSummary(SummaryInterface):
 
     def _run_interface(self, runtime):
         if isdefined(self.inputs.subject_id):
-            self._results["subject_id"] = self.inputs.subject_id
+            self._results['subject_id'] = self.inputs.subject_id
         return super()._run_interface(runtime)
 
     def _generate_segment(self):
         if not isdefined(self.inputs.subjects_dir):
-            freesurfer_status = "Not run"
+            freesurfer_status = 'Not run'
         else:
             recon = fs.ReconAll(
                 subjects_dir=self.inputs.subjects_dir,
                 subject_id=self.inputs.subject_id,
                 T1_files=self.inputs.t1w,
-                flags="-noskullstrip",
+                flags='-noskullstrip',
             )
-            if recon.cmdline.startswith("echo"):
-                freesurfer_status = "Pre-existing directory"
+            if recon.cmdline.startswith('echo'):
+                freesurfer_status = 'Pre-existing directory'
             else:
-                freesurfer_status = "Run by sMRIPrep"
+                freesurfer_status = 'Run by sMRIPrep'
 
-        t2w_seg = ""
+        t2w_seg = ''
         if self.inputs.t2w:
-            t2w_seg = f"(+ {len(self.inputs.t2w):d} T2-weighted)"
+            t2w_seg = f'(+ {len(self.inputs.t2w):d} T2-weighted)'
 
         output_spaces = self.inputs.output_spaces
         if not isdefined(output_spaces):
-            output_spaces = "&lt;none given&gt;"
+            output_spaces = '&lt;none given&gt;'
         else:
-            output_spaces = ", ".join(output_spaces)
+            output_spaces = ', '.join(output_spaces)
 
         return SUBJECT_TEMPLATE.format(
             subject_id=self.inputs.subject_id,
@@ -140,8 +140,8 @@ class SubjectSummary(SummaryInterface):
 
 
 class _AboutSummaryInputSpec(BaseInterfaceInputSpec):
-    version = Str(desc="sMRIPrep version")
-    command = Str(desc="sMRIPrep command")
+    version = Str(desc='sMRIPrep version')
+    command = Str(desc='sMRIPrep command')
     # Date not included - update timestamp only if version or command changes
 
 
@@ -154,7 +154,7 @@ class AboutSummary(SummaryInterface):
         return ABOUT_TEMPLATE.format(
             version=self.inputs.version,
             command=self.inputs.command,
-            date=time.strftime("%Y-%m-%d %H:%M:%S %z"),
+            date=time.strftime('%Y-%m-%d %H:%M:%S %z'),
         )
 
 
@@ -181,8 +181,8 @@ class FSSurfaceReport(SimpleInterface):
         from nibabel import load
 
         rootdir = Path(self.inputs.subjects_dir) / self.inputs.subject_id
-        _anat_file = str(rootdir / "mri" / "brain.mgz")
-        _contour_file = str(rootdir / "mri" / "ribbon.mgz")
+        _anat_file = str(rootdir / 'mri' / 'brain.mgz')
+        _contour_file = str(rootdir / 'mri' / 'ribbon.mgz')
 
         anat = load(_anat_file)
         contour_nii = load(_contour_file)
@@ -190,19 +190,19 @@ class FSSurfaceReport(SimpleInterface):
         n_cuts = 7
         cuts = cuts_from_bbox(contour_nii, cuts=n_cuts)
 
-        self._results["out_report"] = str(Path(runtime.cwd) / self.inputs.out_report)
+        self._results['out_report'] = str(Path(runtime.cwd) / self.inputs.out_report)
 
         # Call composer
         compose_view(
             plot_registration(
                 anat,
-                "fixed-image",
+                'fixed-image',
                 estimate_brightness=True,
                 cuts=cuts,
                 contour=contour_nii,
                 compress=self.inputs.compress_report,
             ),
             [],
-            out_file=self._results["out_report"],
+            out_file=self._results['out_report'],
         )
         return runtime

--- a/smriprep/interfaces/surf.py
+++ b/smriprep/interfaces/surf.py
@@ -23,7 +23,6 @@
 """Handling surfaces."""
 import os
 from pathlib import Path
-from typing import Optional
 
 import nibabel as nb
 import nitransforms as nt
@@ -183,9 +182,7 @@ class MakeRibbon(SimpleInterface):
         return runtime
 
 
-def normalize_surfs(
-    in_file: str, transform_file: str | None, newpath: Optional[str] = None
-) -> str:
+def normalize_surfs(in_file: str, transform_file: str | None, newpath: str | None = None) -> str:
     """
     Update GIFTI metadata and apply rigid coordinate correction.
 
@@ -242,7 +239,7 @@ def normalize_surfs(
     return out_file
 
 
-def fix_gifti_metadata(in_file: str, newpath: Optional[str] = None) -> str:
+def fix_gifti_metadata(in_file: str, newpath: str | None = None) -> str:
     """Fix known incompatible metadata in GIFTI files.
 
     Currently resolves:
@@ -269,7 +266,7 @@ def fix_gifti_metadata(in_file: str, newpath: Optional[str] = None) -> str:
 def make_ribbon(
     white_distvols: list[str],
     pial_distvols: list[str],
-    newpath: Optional[str] = None,
+    newpath: str | None = None,
 ) -> str:
     base_img = nb.load(white_distvols[0])
     header = base_img.header
@@ -277,7 +274,7 @@ def make_ribbon(
 
     ribbons = [
         (np.array(nb.load(white).dataobj) > 0) & (np.array(nb.load(pial).dataobj) < 0)
-        for white, pial in zip(white_distvols, pial_distvols)
+        for white, pial in zip(white_distvols, pial_distvols, strict=True)
     ]
 
     if newpath is None:

--- a/smriprep/interfaces/surf.py
+++ b/smriprep/interfaces/surf.py
@@ -25,17 +25,16 @@ import os
 from pathlib import Path
 from typing import Optional
 
-import numpy as np
 import nibabel as nb
 import nitransforms as nt
-
+import numpy as np
 from nipype.interfaces.base import (
     BaseInterfaceInputSpec,
-    TraitedSpec,
-    SimpleInterface,
     File,
-    isdefined,
     InputMultiObject,
+    SimpleInterface,
+    TraitedSpec,
+    isdefined,
     traits,
 )
 
@@ -140,9 +139,9 @@ class AggregateSurfaces(SimpleInterface):
     output_spec = AggregateSurfacesOutputSpec
 
     def _run_interface(self, runtime):
-        from collections import defaultdict
         import os
         import re
+        from collections import defaultdict
 
         container = defaultdict(list)
         inputs = (self.inputs.surfaces or []) + (self.inputs.morphometrics or [])

--- a/smriprep/interfaces/surf.py
+++ b/smriprep/interfaces/surf.py
@@ -41,12 +41,12 @@ from nipype.interfaces.base import (
 
 
 class _NormalizeSurfInputSpec(BaseInterfaceInputSpec):
-    in_file = File(mandatory=True, exists=True, desc="Freesurfer-generated GIFTI file")
-    transform_file = File(exists=True, desc="FSL, LTA or ITK affine transform file")
+    in_file = File(mandatory=True, exists=True, desc='Freesurfer-generated GIFTI file')
+    transform_file = File(exists=True, desc='FSL, LTA or ITK affine transform file')
 
 
 class _NormalizeSurfOutputSpec(TraitedSpec):
-    out_file = File(desc="output file with re-centered GIFTI coordinates")
+    out_file = File(desc='output file with re-centered GIFTI coordinates')
 
 
 class NormalizeSurf(SimpleInterface):
@@ -88,18 +88,18 @@ class NormalizeSurf(SimpleInterface):
         transform_file = self.inputs.transform_file
         if not isdefined(transform_file):
             transform_file = None
-        self._results["out_file"] = normalize_surfs(
+        self._results['out_file'] = normalize_surfs(
             self.inputs.in_file, transform_file, newpath=runtime.cwd
         )
         return runtime
 
 
 class FixGiftiMetadataInputSpec(TraitedSpec):
-    in_file = File(mandatory=True, exists=True, desc="Freesurfer-generated GIFTI file")
+    in_file = File(mandatory=True, exists=True, desc='Freesurfer-generated GIFTI file')
 
 
 class FixGiftiMetadataOutputSpec(TraitedSpec):
-    out_file = File(desc="output file with fixed metadata")
+    out_file = File(desc='output file with fixed metadata')
 
 
 class FixGiftiMetadata(SimpleInterface):
@@ -114,27 +114,28 @@ class FixGiftiMetadata(SimpleInterface):
     output_spec = FixGiftiMetadataOutputSpec
 
     def _run_interface(self, runtime):
-        self._results["out_file"] = fix_gifti_metadata(self.inputs.in_file, newpath=runtime.cwd)
+        self._results['out_file'] = fix_gifti_metadata(self.inputs.in_file, newpath=runtime.cwd)
         return runtime
 
 
 class AggregateSurfacesInputSpec(TraitedSpec):
-    surfaces = InputMultiObject(File(exists=True), desc="Input surfaces")
-    morphometrics = InputMultiObject(File(exists=True), desc="Input morphometrics")
+    surfaces = InputMultiObject(File(exists=True), desc='Input surfaces')
+    morphometrics = InputMultiObject(File(exists=True), desc='Input morphometrics')
 
 
 class AggregateSurfacesOutputSpec(TraitedSpec):
-    pial = traits.List(File(), maxlen=2, desc="Pial surfaces")
-    white = traits.List(File(), maxlen=2, desc="White surfaces")
-    inflated = traits.List(File(), maxlen=2, desc="Inflated surfaces")
-    midthickness = traits.List(File(), maxlen=2, desc="Midthickness (or graymid) surfaces")
-    thickness = traits.List(File(), maxlen=2, desc="Cortical thickness maps")
-    sulc = traits.List(File(), maxlen=2, desc="Sulcal depth maps")
-    curv = traits.List(File(), maxlen=2, desc="Curvature maps")
+    pial = traits.List(File(), maxlen=2, desc='Pial surfaces')
+    white = traits.List(File(), maxlen=2, desc='White surfaces')
+    inflated = traits.List(File(), maxlen=2, desc='Inflated surfaces')
+    midthickness = traits.List(File(), maxlen=2, desc='Midthickness (or graymid) surfaces')
+    thickness = traits.List(File(), maxlen=2, desc='Cortical thickness maps')
+    sulc = traits.List(File(), maxlen=2, desc='Sulcal depth maps')
+    curv = traits.List(File(), maxlen=2, desc='Curvature maps')
 
 
 class AggregateSurfaces(SimpleInterface):
     """Aggregate and group surfaces & morphometrics into left/right pairs."""
+
     input_spec = AggregateSurfacesInputSpec
     output_spec = AggregateSurfacesOutputSpec
 
@@ -159,15 +160,15 @@ class AggregateSurfaces(SimpleInterface):
 
 class MakeRibbonInputSpec(TraitedSpec):
     white_distvols = traits.List(
-        File(exists=True), minlen=2, maxlen=2, desc="White matter distance volumes"
+        File(exists=True), minlen=2, maxlen=2, desc='White matter distance volumes'
     )
     pial_distvols = traits.List(
-        File(exists=True), minlen=2, maxlen=2, desc="Pial matter distance volumes"
+        File(exists=True), minlen=2, maxlen=2, desc='Pial matter distance volumes'
     )
 
 
 class MakeRibbonOutputSpec(TraitedSpec):
-    ribbon = File(desc="Binary ribbon mask")
+    ribbon = File(desc='Binary ribbon mask')
 
 
 class MakeRibbon(SimpleInterface):
@@ -177,7 +178,7 @@ class MakeRibbon(SimpleInterface):
     output_spec = MakeRibbonOutputSpec
 
     def _run_interface(self, runtime):
-        self._results["ribbon"] = make_ribbon(
+        self._results['ribbon'] = make_ribbon(
             self.inputs.white_distvols, self.inputs.pial_distvols, newpath=runtime.cwd
         )
         return runtime
@@ -202,27 +203,27 @@ def normalize_surfs(
         transform = nt.linear.Affine()
     else:
         xfm_fmt = {
-            ".txt": "itk",
-            ".mat": "fsl",
-            ".lta": "fs",
+            '.txt': 'itk',
+            '.mat': 'fsl',
+            '.lta': 'fs',
         }[Path(transform_file).suffix]
         transform = nt.linear.load(transform_file, fmt=xfm_fmt)
-    pointset = img.get_arrays_from_intent("NIFTI_INTENT_POINTSET")[0]
+    pointset = img.get_arrays_from_intent('NIFTI_INTENT_POINTSET')[0]
 
     if not np.allclose(transform.matrix, np.eye(4)):
         pointset.data = transform.map(pointset.data, inverse=True)
 
     fname = os.path.basename(in_file)
-    if "graymid" in fname.lower():
+    if 'graymid' in fname.lower():
         # Rename graymid to midthickness
-        fname = fname.replace("graymid", "midthickness")
-    if "midthickness" in fname.lower():
-        pointset.meta.setdefault("AnatomicalStructureSecondary", "MidThickness")
-        pointset.meta.setdefault("GeometricType", "Anatomical")
+        fname = fname.replace('graymid', 'midthickness')
+    if 'midthickness' in fname.lower():
+        pointset.meta.setdefault('AnatomicalStructureSecondary', 'MidThickness')
+        pointset.meta.setdefault('GeometricType', 'Anatomical')
 
     # FreeSurfer incorrectly uses "Sphere" for spherical surfaces
-    if pointset.meta.get("GeometricType") == "Sphere":
-        pointset.meta["GeometricType"] = "Spherical"
+    if pointset.meta.get('GeometricType') == 'Sphere':
+        pointset.meta['GeometricType'] = 'Spherical'
     else:
         # mris_convert --to-scanner removes VolGeom transform from coordinates,
         # but not metadata.
@@ -231,9 +232,9 @@ def normalize_surfs(
         # Following the lead of HCP pipelines, we only adjust the coordinates
         # for anatomical surfaces. To ensure consistent treatment by FreeSurfer,
         # we leave the metadata for spherical surfaces intact.
-        for XYZC in "XYZC":
-            for RAS in "RAS":
-                pointset.meta.pop(f"VolGeom{XYZC}_{RAS}", None)
+        for XYZC in 'XYZC':
+            for RAS in 'RAS':
+                pointset.meta.pop(f'VolGeom{XYZC}_{RAS}', None)
 
     if newpath is None:
         newpath = os.getcwd()
@@ -251,13 +252,13 @@ def fix_gifti_metadata(in_file: str, newpath: Optional[str] = None) -> str:
     """
 
     img = nb.GiftiImage.from_filename(in_file)
-    pointset = img.get_arrays_from_intent("NIFTI_INTENT_POINTSET")[0]
+    pointset = img.get_arrays_from_intent('NIFTI_INTENT_POINTSET')[0]
 
     # FreeSurfer incorrectly uses "Sphere" for spherical surfaces
     # This is not fixed as of FreeSurfer 7.4.0
     # https://github.com/freesurfer/freesurfer/pull/1112
-    if pointset.meta.get("GeometricType") == "Sphere":
-        pointset.meta["GeometricType"] = "Spherical"
+    if pointset.meta.get('GeometricType') == 'Sphere':
+        pointset.meta['GeometricType'] = 'Spherical'
 
     if newpath is None:
         newpath = os.getcwd()
@@ -273,7 +274,7 @@ def make_ribbon(
 ) -> str:
     base_img = nb.load(white_distvols[0])
     header = base_img.header
-    header.set_data_dtype("uint8")
+    header.set_data_dtype('uint8')
 
     ribbons = [
         (np.array(nb.load(white).dataobj) > 0) & (np.array(nb.load(pial).dataobj) < 0)
@@ -282,7 +283,7 @@ def make_ribbon(
 
     if newpath is None:
         newpath = os.getcwd()
-    out_file = os.path.join(newpath, "ribbon.nii.gz")
+    out_file = os.path.join(newpath, 'ribbon.nii.gz')
 
     ribbon_data = ribbons[0] | ribbons[1]
     ribbon = base_img.__class__(ribbon_data, base_img.affine, header)

--- a/smriprep/interfaces/templateflow.py
+++ b/smriprep/interfaces/templateflow.py
@@ -33,21 +33,21 @@ from nipype.interfaces.base import (
     InputMultiObject,
 )
 
-LOGGER = logging.getLogger("nipype.interface")
+LOGGER = logging.getLogger('nipype.interface')
 
 
 class _TemplateFlowSelectInputSpec(BaseInterfaceInputSpec):
-    template = traits.Str("MNI152NLin2009cAsym", mandatory=True, desc="Template ID")
-    atlas = InputMultiObject(traits.Str, desc="Specify an atlas")
-    cohort = InputMultiObject(traits.Either(traits.Str, traits.Int), desc="Specify a cohort")
-    resolution = InputMultiObject(traits.Int, desc="Specify a template resolution index")
+    template = traits.Str('MNI152NLin2009cAsym', mandatory=True, desc='Template ID')
+    atlas = InputMultiObject(traits.Str, desc='Specify an atlas')
+    cohort = InputMultiObject(traits.Either(traits.Str, traits.Int), desc='Specify a cohort')
+    resolution = InputMultiObject(traits.Int, desc='Specify a template resolution index')
     template_spec = traits.DictStrAny(
-        {"atlas": None, "cohort": None}, usedefault=True, desc="Template specifications"
+        {'atlas': None, 'cohort': None}, usedefault=True, desc='Template specifications'
     )
 
 
 class _TemplateFlowSelectOutputSpec(TraitedSpec):
-    t1w_file = File(exists=True, desc="T1w template")
+    t1w_file = File(exists=True, desc='T1w template')
     brain_mask = File(exists=True, desc="Template's brain mask")
 
 
@@ -100,19 +100,19 @@ class TemplateFlowSelect(SimpleInterface):
     def _run_interface(self, runtime):
         specs = self.inputs.template_spec
         if isdefined(self.inputs.resolution):
-            specs["resolution"] = self.inputs.resolution
+            specs['resolution'] = self.inputs.resolution
         if isdefined(self.inputs.atlas):
-            specs["atlas"] = self.inputs.atlas
+            specs['atlas'] = self.inputs.atlas
         if isdefined(self.inputs.cohort):
-            specs["cohort"] = self.inputs.cohort
+            specs['cohort'] = self.inputs.cohort
 
-        name = self.inputs.template.strip(":").split(":", 1)
+        name = self.inputs.template.strip(':').split(':', 1)
         if len(name) > 1:
             specs.update(
                 {
                     k: v
-                    for modifier in name[1].split(":")
-                    for k, v in [tuple(modifier.split("-"))]
+                    for modifier in name[1].split(':')
+                    for k, v in [tuple(modifier.split('-'))]
                     if k not in specs
                 }
             )
@@ -121,29 +121,29 @@ class TemplateFlowSelect(SimpleInterface):
             specs['resolution'] = [specs['resolution']]
 
         available_resolutions = tf.TF_LAYOUT.get_resolutions(template=name[0])
-        if specs['resolution'] and not set(specs["resolution"]) & set(available_resolutions):
+        if specs['resolution'] and not set(specs['resolution']) & set(available_resolutions):
             fallback_res = available_resolutions[0] if available_resolutions else None
             LOGGER.warning(
                 f"Template {name[0]} does not have resolution(s): {specs['resolution']}."
                 f"Falling back to resolution: {fallback_res}."
             )
-            specs["resolution"] = fallback_res
+            specs['resolution'] = fallback_res
 
-        self._results["t1w_file"] = tf.get(name[0], desc=None, suffix="T1w", **specs)
+        self._results['t1w_file'] = tf.get(name[0], desc=None, suffix='T1w', **specs)
 
-        self._results["brain_mask"] = tf.get(
-            name[0], desc="brain", suffix="mask", **specs
-        ) or tf.get(name[0], label="brain", suffix="mask", **specs)
+        self._results['brain_mask'] = tf.get(
+            name[0], desc='brain', suffix='mask', **specs
+        ) or tf.get(name[0], label='brain', suffix='mask', **specs)
         return runtime
 
 
 class _TemplateDescInputSpec(BaseInterfaceInputSpec):
-    template = traits.Str(mandatory=True, desc="univocal template identifier")
+    template = traits.Str(mandatory=True, desc='univocal template identifier')
 
 
 class _TemplateDescOutputSpec(TraitedSpec):
-    name = traits.Str(desc="template identifier")
-    spec = traits.Dict(desc="template arguments")
+    name = traits.Str(desc='template identifier')
+    spec = traits.Dict(desc='template arguments')
 
 
 class TemplateDesc(SimpleInterface):
@@ -175,12 +175,12 @@ class TemplateDesc(SimpleInterface):
     output_spec = _TemplateDescOutputSpec
 
     def _run_interface(self, runtime):
-        _split = self.inputs.template.split(":")
-        self._results["name"] = _split[0]
+        _split = self.inputs.template.split(':')
+        self._results['name'] = _split[0]
 
-        self._results["spec"] = {}
+        self._results['spec'] = {}
         if len(_split) > 1:
             for desc in _split[1:]:
-                descsplit = desc.split("-")
-                self._results["spec"][descsplit[0]] = descsplit[1]
+                descsplit = desc.split('-')
+                self._results['spec'][descsplit[0]] = descsplit[1]
         return runtime

--- a/smriprep/interfaces/templateflow.py
+++ b/smriprep/interfaces/templateflow.py
@@ -22,16 +22,17 @@
 #
 """Interfaces to get templates from TemplateFlow."""
 import logging
-from templateflow import api as tf
+
 from nipype.interfaces.base import (
-    SimpleInterface,
     BaseInterfaceInputSpec,
+    File,
+    InputMultiObject,
+    SimpleInterface,
     TraitedSpec,
     isdefined,
     traits,
-    File,
-    InputMultiObject,
 )
+from templateflow import api as tf
 
 LOGGER = logging.getLogger('nipype.interface')
 

--- a/smriprep/interfaces/tests/test_surf.py
+++ b/smriprep/interfaces/tests/test_surf.py
@@ -7,20 +7,20 @@ from ..surf import MakeRibbon
 
 
 def test_MakeRibbon(tmp_path):
-    res_template = "{path}/sub-fsaverage_res-4_hemi-{hemi}_desc-cropped_{surf}dist.nii.gz"
+    res_template = '{path}/sub-fsaverage_res-4_hemi-{hemi}_desc-cropped_{surf}dist.nii.gz'
     white, pial = [
         [
             load_resource(
-                res_template.format(path="../interfaces/tests/data", hemi=hemi, surf=surf)
+                res_template.format(path='../interfaces/tests/data', hemi=hemi, surf=surf)
             )
-            for hemi in "LR"
+            for hemi in 'LR'
         ]
-        for surf in ("wm", "pial")
+        for surf in ('wm', 'pial')
     ]
 
     make_ribbon = pe.Node(
         MakeRibbon(white_distvols=white, pial_distvols=pial),
-        name="make_ribbon",
+        name='make_ribbon',
         base_dir=tmp_path,
     )
 
@@ -28,7 +28,7 @@ def test_MakeRibbon(tmp_path):
 
     ribbon = nb.load(result.outputs.ribbon)
     expected = nb.load(
-        load_resource("../interfaces/tests/data/sub-fsaverage_res-4_desc-cropped_ribbon.nii.gz")
+        load_resource('../interfaces/tests/data/sub-fsaverage_res-4_desc-cropped_ribbon.nii.gz')
     )
 
     assert ribbon.shape == expected.shape

--- a/smriprep/interfaces/tests/test_surf.py
+++ b/smriprep/interfaces/tests/test_surf.py
@@ -1,6 +1,6 @@
 import nibabel as nb
-from nipype.pipeline import engine as pe
 import numpy as np
+from nipype.pipeline import engine as pe
 
 from ...data import load_resource
 from ..surf import MakeRibbon
@@ -8,7 +8,7 @@ from ..surf import MakeRibbon
 
 def test_MakeRibbon(tmp_path):
     res_template = '{path}/sub-fsaverage_res-4_hemi-{hemi}_desc-cropped_{surf}dist.nii.gz'
-    white, pial = [
+    white, pial = (
         [
             load_resource(
                 res_template.format(path='../interfaces/tests/data', hemi=hemi, surf=surf)
@@ -16,7 +16,7 @@ def test_MakeRibbon(tmp_path):
             for hemi in 'LR'
         ]
         for surf in ('wm', 'pial')
-    ]
+    )
 
     make_ribbon = pe.Node(
         MakeRibbon(white_distvols=white, pial_distvols=pial),

--- a/smriprep/interfaces/workbench.py
+++ b/smriprep/interfaces/workbench.py
@@ -6,70 +6,70 @@ class CreateSignedDistanceVolumeInputSpec(CommandLineInputSpec):
     surf_file = File(
         exists=True,
         mandatory=True,
-        argstr="%s",
+        argstr='%s',
         position=0,
-        desc="Input surface GIFTI file (.surf.gii)",
+        desc='Input surface GIFTI file (.surf.gii)',
     )
     ref_file = File(
         exists=True,
         mandatory=True,
-        argstr="%s",
+        argstr='%s',
         position=1,
-        desc="NIfTI volume in the desired output space (dims, spacing, origin)",
+        desc='NIfTI volume in the desired output space (dims, spacing, origin)',
     )
     out_file = File(
-        name_source=["surf_file"],
-        name_template="%s_distvol.nii.gz",
-        argstr="%s",
+        name_source=['surf_file'],
+        name_template='%s_distvol.nii.gz',
+        argstr='%s',
         position=2,
-        desc="Name of output volume containing signed distances",
+        desc='Name of output volume containing signed distances',
     )
     out_mask = File(
-        name_source=["surf_file"],
-        name_template="%s_distmask.nii.gz",
-        argstr="-roi-out %s",
-        desc="Name of file to store a mask where the ``out_file`` has a computed value",
+        name_source=['surf_file'],
+        name_template='%s_distmask.nii.gz',
+        argstr='-roi-out %s',
+        desc='Name of file to store a mask where the ``out_file`` has a computed value',
     )
     fill_value = traits.Float(
         0.0,
         mandatory=False,
         usedefault=True,
-        argstr="-fill-value %f",
+        argstr='-fill-value %f',
         desc="value to put in all voxels that don't get assigned a distance",
     )
     exact_limit = traits.Float(
         5.0,
         usedefault=True,
-        argstr="-exact-limit %f",
-        desc="distance for exact output in mm",
+        argstr='-exact-limit %f',
+        desc='distance for exact output in mm',
     )
     approx_limit = traits.Float(
         20.0,
         usedefault=True,
-        argstr="-approx-limit %f",
-        desc="distance for approximate output in mm",
+        argstr='-approx-limit %f',
+        desc='distance for approximate output in mm',
     )
     approx_neighborhood = traits.Int(
         2,
         usedefault=True,
-        argstr="-approx-neighborhood %d",
-        desc="size of neighborhood cube measured from center to face in voxels, default 2 = 5x5x5",
+        argstr='-approx-neighborhood %d',
+        desc='size of neighborhood cube measured from center to face in voxels, default 2 = 5x5x5',
     )
     winding_method = traits.Enum(
-        "EVEN_ODD",
-        "NEGATIVE",
-        "NONZERO",
-        "NORMALS",
-        argstr="-winding %s",
+        'EVEN_ODD',
+        'NEGATIVE',
+        'NONZERO',
+        'NORMALS',
+        argstr='-winding %s',
         usedefault=True,
-        desc="winding method for point inside surface test",
+        desc='winding method for point inside surface test',
     )
 
 
 class CreateSignedDistanceVolumeOutputSpec(TraitedSpec):
-    out_file = File(desc="Name of output volume containing signed distances")
+    out_file = File(desc='Name of output volume containing signed distances')
     out_mask = File(
-        desc="Name of file to store a mask where the ``out_file`` has a computed value"
+        desc='Name of file to store a mask where the ``out_file`` has a computed value'
     )
 
 
@@ -141,35 +141,35 @@ class CreateSignedDistanceVolume(WBCommand):
 
     input_spec = CreateSignedDistanceVolumeInputSpec
     output_spec = CreateSignedDistanceVolumeOutputSpec
-    _cmd = "wb_command -create-signed-distance-volume"
+    _cmd = 'wb_command -create-signed-distance-volume'
 
 
 class SurfaceAffineRegressionInputSpec(CommandLineInputSpec):
     in_surface = File(
         exists=True,
         mandatory=True,
-        argstr="%s",
+        argstr='%s',
         position=0,
-        desc="Surface to warp",
+        desc='Surface to warp',
     )
     target_surface = File(
         exists=True,
         mandatory=True,
-        argstr="%s",
+        argstr='%s',
         position=1,
-        desc="Surface to match the coordinates of",
+        desc='Surface to match the coordinates of',
     )
     out_affine = File(
-        name_template="%s_xfm",
-        name_source=["in_surface"],
-        argstr="%s",
+        name_template='%s_xfm',
+        name_source=['in_surface'],
+        argstr='%s',
         position=2,
-        desc="the output affine file",
+        desc='the output affine file',
     )
 
 
 class SurfaceAffineRegressionOutputSpec(TraitedSpec):
-    out_affine = File(desc="The output affine file")
+    out_affine = File(desc='The output affine file')
 
 
 class SurfaceAffineRegression(WBCommand):
@@ -195,51 +195,52 @@ class SurfaceAffineRegression(WBCommand):
     tpl-fsaverage_hemi-L_den-164k_sulc.shape.gii \
     sub-01_hemi-L_sulc.shape_xfm'
     """
+
     input_spec = SurfaceAffineRegressionInputSpec
     output_spec = SurfaceAffineRegressionOutputSpec
-    _cmd = "wb_command -surface-affine-regression"
+    _cmd = 'wb_command -surface-affine-regression'
 
 
 class SurfaceApplyAffineInputSpec(CommandLineInputSpec):
     in_surface = File(
         exists=True,
         mandatory=True,
-        argstr="%s",
+        argstr='%s',
         position=0,
-        desc="the surface to transform",
+        desc='the surface to transform',
     )
     in_affine = File(
         exists=True,
         mandatory=True,
-        argstr="%s",
+        argstr='%s',
         position=1,
-        desc="the affine file",
+        desc='the affine file',
     )
     out_surface = File(
-        name_template="%s_xformed.surf.gii",
-        name_source=["in_surface"],
-        argstr="%s",
+        name_template='%s_xformed.surf.gii',
+        name_source=['in_surface'],
+        argstr='%s',
         position=2,
-        desc="the output transformed surface",
+        desc='the output transformed surface',
     )
     flirt_source = File(
         exists=True,
-        requires=["flirt_target"],
-        argstr="-flirt %s",
+        requires=['flirt_target'],
+        argstr='-flirt %s',
         position=3,
-        desc="Source volume (must be used if affine is a flirt affine)",
+        desc='Source volume (must be used if affine is a flirt affine)',
     )
     flirt_target = File(
         exists=True,
-        requires=["flirt_source"],
-        argstr="%s",
+        requires=['flirt_source'],
+        argstr='%s',
         position=4,
-        desc="Target volume (must be used if affine is a flirt affine)",
+        desc='Target volume (must be used if affine is a flirt affine)',
     )
 
 
 class SurfaceApplyAffineOutputSpec(TraitedSpec):
-    out_surface = File(desc="the output transformed surface")
+    out_surface = File(desc='the output transformed surface')
 
 
 class SurfaceApplyAffine(WBCommand):
@@ -279,43 +280,44 @@ class SurfaceApplyAffine(WBCommand):
 
     >>> os.unlink('affine.txt')
     """
+
     input_spec = SurfaceApplyAffineInputSpec
     output_spec = SurfaceApplyAffineOutputSpec
-    _cmd = "wb_command -surface-apply-affine"
+    _cmd = 'wb_command -surface-apply-affine'
 
 
 class SurfaceApplyWarpfieldInputSpec(CommandLineInputSpec):
     in_surface = File(
         exists=True,
         mandatory=True,
-        argstr="%s",
+        argstr='%s',
         position=0,
-        desc="the surface to transform",
+        desc='the surface to transform',
     )
     warpfield = File(
         exists=True,
         mandatory=True,
-        argstr="%s",
+        argstr='%s',
         position=1,
-        desc="the INVERSE warpfield",
+        desc='the INVERSE warpfield',
     )
     out_surface = File(
-        name_template="%s_warped.surf.gii",
-        name_source=["in_surface"],
-        argstr="%s",
+        name_template='%s_warped.surf.gii',
+        name_source=['in_surface'],
+        argstr='%s',
         position=2,
-        desc="the output transformed surface",
+        desc='the output transformed surface',
     )
     fnirt_forward_warp = File(
         exists=True,
-        argstr="-fnirt %s",
+        argstr='-fnirt %s',
         position=3,
-        desc="the forward warpfield (must be used if fnirt warpfield)",
+        desc='the forward warpfield (must be used if fnirt warpfield)',
     )
 
 
 class SurfaceApplyWarpfieldOutputSpec(TraitedSpec):
-    out_surface = File(desc="the output transformed surface")
+    out_surface = File(desc='the output transformed surface')
 
 
 class SurfaceApplyWarpfield(WBCommand):
@@ -347,9 +349,10 @@ class SurfaceApplyWarpfield(WBCommand):
     sub-01_desc-warped_T1w.nii.gz \
     sub-01_hemi-L_sphere.surf_warped.surf.gii'
     """
+
     input_spec = SurfaceApplyWarpfieldInputSpec
     output_spec = SurfaceApplyWarpfieldOutputSpec
-    _cmd = "wb_command -surface-apply-warpfield"
+    _cmd = 'wb_command -surface-apply-warpfield'
 
 
 class SurfaceModifySphereInputSpec(CommandLineInputSpec):
@@ -357,32 +360,29 @@ class SurfaceModifySphereInputSpec(CommandLineInputSpec):
         exists=True,
         mandatory=True,
         position=0,
-        argstr="%s",
-        desc="the sphere to modify",
+        argstr='%s',
+        desc='the sphere to modify',
     )
     radius = traits.Int(
-        mandatory=True,
-        position=1,
-        argstr="%d",
-        desc='the radius the output sphere should have'
+        mandatory=True, position=1, argstr='%d', desc='the radius the output sphere should have'
     )
     out_surface = File(
-        name_template="%s_mod.surf.gii",
-        name_source="in_surface",
+        name_template='%s_mod.surf.gii',
+        name_source='in_surface',
         position=2,
-        argstr="%s",
-        desc="the modified sphere",
+        argstr='%s',
+        desc='the modified sphere',
     )
     recenter = traits.Bool(
         False,
         position=3,
-        argstr="-recenter",
-        desc="recenter the sphere by means of the bounding box",
+        argstr='-recenter',
+        desc='recenter the sphere by means of the bounding box',
     )
 
 
 class SurfaceModifySphereOutputSpec(TraitedSpec):
-    out_surface = File(desc="the modified sphere")
+    out_surface = File(desc='the modified sphere')
 
 
 class SurfaceModifySphere(WBCommand):
@@ -484,37 +484,37 @@ class SurfaceSphereProjectUnprojectInputSpec(TraitedSpec):
        topology."""
 
     sphere_in = File(
-        desc="a sphere with the desired output mesh",
+        desc='a sphere with the desired output mesh',
         exists=True,
         mandatory=True,
-        argstr="%s",
+        argstr='%s',
         position=0,
     )
     sphere_project_to = File(
-        desc="a sphere that aligns with sphere-in",
+        desc='a sphere that aligns with sphere-in',
         exists=True,
         mandatory=True,
-        argstr="%s",
+        argstr='%s',
         position=1,
     )
     sphere_unproject_from = File(
-        desc="<sphere-project-to> deformed to the desired output space",
+        desc='<sphere-project-to> deformed to the desired output space',
         exists=True,
         mandatory=True,
-        argstr="%s",
+        argstr='%s',
         position=2,
     )
     sphere_out = traits.File(
-        name_template="%s_unprojected.surf.gii",
-        name_source=["sphere_in"],
-        desc="the output sphere",
-        argstr="%s",
+        name_template='%s_unprojected.surf.gii',
+        name_source=['sphere_in'],
+        desc='the output sphere',
+        argstr='%s',
         position=3,
     )
 
 
 class SurfaceSphereProjectUnprojectOutputSpec(TraitedSpec):
-    sphere_out = File(desc="the output sphere")
+    sphere_out = File(desc='the output sphere')
 
 
 class SurfaceSphereProjectUnproject(WBCommand):
@@ -535,7 +535,7 @@ class SurfaceSphereProjectUnproject(WBCommand):
 
     input_spec = SurfaceSphereProjectUnprojectInputSpec
     output_spec = SurfaceSphereProjectUnprojectOutputSpec
-    _cmd = "wb_command -surface-sphere-project-unproject"
+    _cmd = 'wb_command -surface-sphere-project-unproject'
 
 
 class SurfaceResampleInputSpec(TraitedSpec):
@@ -580,68 +580,68 @@ class SurfaceResampleInputSpec(TraitedSpec):
     """
 
     surface_in = File(
-        desc="the surface file to resample",
+        desc='the surface file to resample',
         exists=True,
         mandatory=True,
-        argstr="%s",
+        argstr='%s',
         position=0,
     )
     current_sphere = File(
-        desc="a sphere surface with the mesh that the input surface is currently on",
+        desc='a sphere surface with the mesh that the input surface is currently on',
         exists=True,
         mandatory=True,
-        argstr="%s",
+        argstr='%s',
         position=1,
     )
     new_sphere = File(
-        desc="a sphere surface that is in register with <current-sphere> and has the "
-        "desired output mesh",
+        desc='a sphere surface that is in register with <current-sphere> and has the '
+        'desired output mesh',
         exists=True,
         mandatory=True,
-        argstr="%s",
+        argstr='%s',
         position=2,
     )
     method = traits.Enum(
-        "ADAP_BARY_AREA",
-        "BARYCENTRIC",
-        desc="the method name",
+        'ADAP_BARY_AREA',
+        'BARYCENTRIC',
+        desc='the method name',
         mandatory=True,
-        argstr="%s",
+        argstr='%s',
         position=3,
     )
     surface_out = traits.File(
-        name_template="%s_resampled.surf.gii",
-        name_source=["surface_in"],
+        name_template='%s_resampled.surf.gii',
+        name_source=['surface_in'],
         keep_extension=False,
-        desc="the output surface file",
-        argstr="%s",
+        desc='the output surface file',
+        argstr='%s',
         position=4,
     )
     correction_source = traits.Enum(
-        "area_surfs",
-        "area_metrics",
-        desc="specify surfaces or vertex area metrics to do vertex area correction based on",
-        argstr="-%s",
+        'area_surfs',
+        'area_metrics',
+        desc='specify surfaces or vertex area metrics to do vertex area correction based on',
+        argstr='-%s',
         position=5,
     )
     current_area = File(
-        desc="a relevant surface with <current-sphere> mesh",
+        desc='a relevant surface with <current-sphere> mesh',
         exists=True,
-        argstr="%s",
+        argstr='%s',
         position=6,
         requires=['correction_source'],
     )
     new_area = File(
-        desc="a relevant surface with <new-sphere> mesh",
+        desc='a relevant surface with <new-sphere> mesh',
         exists=True,
-        argstr="%s",
+        argstr='%s',
         position=7,
         requires=['correction_source'],
     )
 
 
 class SurfaceResampleOutputSpec(TraitedSpec):
-    surface_out = File(desc="the output surface file")
+    surface_out = File(desc='the output surface file')
 
 
 class SurfaceResample(WBCommand):
@@ -663,4 +663,4 @@ class SurfaceResample(WBCommand):
 
     input_spec = SurfaceResampleInputSpec
     output_spec = SurfaceResampleOutputSpec
-    _cmd = "wb_command -surface-resample"
+    _cmd = 'wb_command -surface-resample'

--- a/smriprep/utils/bids.py
+++ b/smriprep/utils/bids.py
@@ -21,8 +21,9 @@
 #     https://www.nipreps.org/community/licensing/
 #
 """Utilities to handle BIDS inputs."""
-from pathlib import Path
 from json import loads
+from pathlib import Path
+
 from bids.layout import BIDSLayout
 
 from ..data import load_resource
@@ -110,10 +111,11 @@ def write_derivative_description(bids_dir, deriv_dir):
 
 
     """
+    import json
     import os
     from pathlib import Path
-    import json
-    from ..__about__ import __version__, DOWNLOAD_URL
+
+    from ..__about__ import DOWNLOAD_URL, __version__
 
     bids_dir = Path(bids_dir)
     deriv_dir = Path(deriv_dir)

--- a/smriprep/utils/bids.py
+++ b/smriprep/utils/bids.py
@@ -31,38 +31,38 @@ from ..data import load_resource
 def collect_derivatives(derivatives_dir, subject_id, std_spaces, spec=None, patterns=None):
     """Gather existing derivatives and compose a cache."""
     if spec is None or patterns is None:
-        _spec, _patterns = tuple(loads(load_resource("io_spec.json").read_text()).values())
+        _spec, _patterns = tuple(loads(load_resource('io_spec.json').read_text()).values())
 
         if spec is None:
             spec = _spec
         if patterns is None:
             patterns = _patterns
 
-    layout = BIDSLayout(derivatives_dir, config=["bids", "derivatives"], validate=False)
+    layout = BIDSLayout(derivatives_dir, config=['bids', 'derivatives'], validate=False)
 
     derivs_cache = {}
-    for k, q in spec["baseline"].items():
-        q["subject"] = subject_id
+    for k, q in spec['baseline'].items():
+        q['subject'] = subject_id
         item = layout.get(return_type='filename', **q)
         if not item:
             continue
 
-        derivs_cache["t1w_%s" % k] = item[0] if len(item) == 1 else item
+        derivs_cache['t1w_%s' % k] = item[0] if len(item) == 1 else item
 
     transforms = derivs_cache.setdefault('transforms', {})
     for space in std_spaces:
-        for k, q in spec["transforms"].items():
+        for k, q in spec['transforms'].items():
             q = q.copy()
-            q["subject"] = subject_id
-            q["from"] = q["from"] or space
-            q["to"] = q["to"] or space
+            q['subject'] = subject_id
+            q['from'] = q['from'] or space
+            q['to'] = q['to'] or space
             item = layout.get(return_type='filename', **q)
             if not item:
                 continue
             transforms.setdefault(space, {})[k] = item[0] if len(item) == 1 else item
 
-    for k, q in spec["surfaces"].items():
-        q["subject"] = subject_id
+    for k, q in spec['surfaces'].items():
+        q['subject'] = subject_id
         item = layout.get(return_type='filename', **q)
         if not item or len(item) != 2:
             continue
@@ -74,15 +74,15 @@ def collect_derivatives(derivatives_dir, subject_id, std_spaces, spec=None, patt
 
 def write_bidsignore(deriv_dir):
     bids_ignore = [
-        "*.html",
-        "logs/",
-        "figures/",  # Reports
-        "*_xfm.*",  # Unspecified transform files
-        "*.surf.gii",  # Unspecified structural outputs
+        '*.html',
+        'logs/',
+        'figures/',  # Reports
+        '*_xfm.*',  # Unspecified transform files
+        '*.surf.gii',  # Unspecified structural outputs
     ]
-    ignore_file = Path(deriv_dir) / ".bidsignore"
+    ignore_file = Path(deriv_dir) / '.bidsignore'
 
-    ignore_file.write_text("\n".join(bids_ignore) + "\n")
+    ignore_file.write_text('\n'.join(bids_ignore) + '\n')
 
 
 def write_derivative_description(bids_dir, deriv_dir):
@@ -118,48 +118,48 @@ def write_derivative_description(bids_dir, deriv_dir):
     bids_dir = Path(bids_dir)
     deriv_dir = Path(deriv_dir)
     desc = {
-        "Name": "sMRIPrep - Structural MRI PREProcessing workflow",
-        "BIDSVersion": "1.4.0",
-        "DatasetType": "derivative",
-        "GeneratedBy": [
+        'Name': 'sMRIPrep - Structural MRI PREProcessing workflow',
+        'BIDSVersion': '1.4.0',
+        'DatasetType': 'derivative',
+        'GeneratedBy': [
             {
-                "Name": "sMRIPrep",
-                "Version": __version__,
-                "CodeURL": DOWNLOAD_URL,
+                'Name': 'sMRIPrep',
+                'Version': __version__,
+                'CodeURL': DOWNLOAD_URL,
             }
         ],
-        "HowToAcknowledge": "Please cite our paper (https://doi.org/10.1101/306951), and "
-        "include the generated citation boilerplate within the Methods "
-        "section of the text.",
+        'HowToAcknowledge': 'Please cite our paper (https://doi.org/10.1101/306951), and '
+        'include the generated citation boilerplate within the Methods '
+        'section of the text.',
     }
 
     # Keys that can only be set by environment
-    if "SMRIPREP_DOCKER_TAG" in os.environ:
-        desc["GeneratedBy"][0]["Container"] = {
-            "Type": "docker",
-            "Tag": f"poldracklab/smriprep:{os.environ['SMRIPREP_DOCKER_TAG']}",
+    if 'SMRIPREP_DOCKER_TAG' in os.environ:
+        desc['GeneratedBy'][0]['Container'] = {
+            'Type': 'docker',
+            'Tag': f"poldracklab/smriprep:{os.environ['SMRIPREP_DOCKER_TAG']}",
         }
-    if "SMRIPREP_SINGULARITY_URL" in os.environ:
-        desc["GeneratedBy"][0]["Container"] = {
-            "Type": "singularity",
-            "URI": os.environ["SMRIPREP_SINGULARITY_URL"],
+    if 'SMRIPREP_SINGULARITY_URL' in os.environ:
+        desc['GeneratedBy'][0]['Container'] = {
+            'Type': 'singularity',
+            'URI': os.environ['SMRIPREP_SINGULARITY_URL'],
         }
 
     # Keys deriving from source dataset
     orig_desc = {}
-    fname = bids_dir / "dataset_description.json"
+    fname = bids_dir / 'dataset_description.json'
     if fname.exists():
         orig_desc = json.loads(fname.read_text())
 
-    if "DatasetDOI" in orig_desc:
-        doi = orig_desc["DatasetDOI"]
-        desc["SourceDatasets"] = [
+    if 'DatasetDOI' in orig_desc:
+        doi = orig_desc['DatasetDOI']
+        desc['SourceDatasets'] = [
             {
-                "URL": f"https://doi.org/{doi}",
-                "DOI": doi,
+                'URL': f'https://doi.org/{doi}',
+                'DOI': doi,
             }
         ]
-    if "License" in orig_desc:
-        desc["License"] = orig_desc["License"]
+    if 'License' in orig_desc:
+        desc['License'] = orig_desc['License']
 
-    Path.write_text(deriv_dir / "dataset_description.json", json.dumps(desc, indent=4))
+    Path.write_text(deriv_dir / 'dataset_description.json', json.dumps(desc, indent=4))

--- a/smriprep/utils/misc.py
+++ b/smriprep/utils/misc.py
@@ -25,8 +25,8 @@
 
 def apply_lut(in_dseg, lut, newpath=None):
     """Map the input discrete segmentation to a new label set (lookup table, LUT)."""
-    import numpy as np
     import nibabel as nb
+    import numpy as np
     from nipype.utils.filemanip import fname_presuffix
 
     if newpath is None:
@@ -66,8 +66,8 @@ def fs_isRunning(subjects_dir, subject_id, mtime_tol=86400, logger=None):
     subjects_dir : os.PathLike or None
 
     """
-    from pathlib import Path
     import time
+    from pathlib import Path
 
     if subjects_dir is None:
         return subjects_dir

--- a/smriprep/utils/misc.py
+++ b/smriprep/utils/misc.py
@@ -34,14 +34,14 @@ def apply_lut(in_dseg, lut, newpath=None):
 
         newpath = getcwd()
 
-    out_file = fname_presuffix(in_dseg, suffix="_dseg", newpath=newpath)
-    lut = np.array(lut, dtype="int16")
+    out_file = fname_presuffix(in_dseg, suffix='_dseg', newpath=newpath)
+    lut = np.array(lut, dtype='int16')
 
     segm = nb.load(in_dseg)
     hdr = segm.header.copy()
-    hdr.set_data_dtype("int16")
+    hdr.set_data_dtype('int16')
     segm.__class__(
-        lut[np.asanyarray(segm.dataobj, dtype=int)].astype("int16"), segm.affine, hdr
+        lut[np.asanyarray(segm.dataobj, dtype=int)].astype('int16'), segm.affine, hdr
     ).to_filename(out_file)
 
     return out_file
@@ -75,10 +75,10 @@ def fs_isRunning(subjects_dir, subject_id, mtime_tol=86400, logger=None):
     if not subj_dir.exists():
         return subjects_dir
 
-    isrunning = tuple(subj_dir.glob("scripts/IsRunning*"))
+    isrunning = tuple(subj_dir.glob('scripts/IsRunning*'))
     if not isrunning:
         return subjects_dir
-    reconlog = subj_dir / "scripts" / "recon-all.log"
+    reconlog = subj_dir / 'scripts' / 'recon-all.log'
     # if recon log doesn't exist, just clear IsRunning
     mtime = reconlog.stat().st_mtime if reconlog.exists() else 0
     if (time.time() - mtime) < mtime_tol:

--- a/smriprep/utils/tests/test_misc.py
+++ b/smriprep/utils/tests/test_misc.py
@@ -26,17 +26,17 @@ from ..misc import fs_isRunning
 
 
 def _gen_fsdir(tmp_path, isrunning):
-    fsdir = tmp_path / "sample_freesurfer"
-    (fsdir / "sub-01" / "scripts").mkdir(parents=True)
-    (fsdir / "sub-01" / "scripts" / "recon-all.log").write_text("log")
+    fsdir = tmp_path / 'sample_freesurfer'
+    (fsdir / 'sub-01' / 'scripts').mkdir(parents=True)
+    (fsdir / 'sub-01' / 'scripts' / 'recon-all.log').write_text('log')
     if isrunning:
-        (fsdir / "sub-01" / "scripts" / "IsRunning.rh").write_text("running")
-        (fsdir / "sub-01" / "scripts" / "IsRunning.lh").write_text("running")
+        (fsdir / 'sub-01' / 'scripts' / 'IsRunning.rh').write_text('running')
+        (fsdir / 'sub-01' / 'scripts' / 'IsRunning.lh').write_text('running')
     return fsdir
 
 
 @pytest.mark.parametrize(
-    "isrunning,mtime_tol,error",
+    'isrunning,mtime_tol,error',
     [
         (False, 86400, None),
         (True, 86400, RuntimeError),
@@ -46,9 +46,9 @@ def _gen_fsdir(tmp_path, isrunning):
 def test_fs_isRunning(tmp_path, isrunning, mtime_tol, error):
     fs_dir = _gen_fsdir(tmp_path, isrunning)
     if error is None:
-        fs_isRunning(fs_dir, "sub-01", mtime_tol=mtime_tol)
-        assert not tuple(fs_dir.glob("**/IsRunning*"))
+        fs_isRunning(fs_dir, 'sub-01', mtime_tol=mtime_tol)
+        assert not tuple(fs_dir.glob('**/IsRunning*'))
     else:
         with pytest.raises(error):
-            fs_isRunning(fs_dir, "sub-01", mtime_tol=mtime_tol)
-        assert tuple(fs_dir.glob("**/IsRunning*"))
+            fs_isRunning(fs_dir, 'sub-01', mtime_tol=mtime_tol)
+        assert tuple(fs_dir.glob('**/IsRunning*'))

--- a/smriprep/utils/tests/test_misc.py
+++ b/smriprep/utils/tests/test_misc.py
@@ -36,7 +36,7 @@ def _gen_fsdir(tmp_path, isrunning):
 
 
 @pytest.mark.parametrize(
-    'isrunning,mtime_tol,error',
+    ('isrunning', 'mtime_tol', 'error'),
     [
         (False, 86400, None),
         (True, 86400, RuntimeError),

--- a/smriprep/workflows/anatomical.py
+++ b/smriprep/workflows/anatomical.py
@@ -81,7 +81,7 @@ from .surfaces import (
     init_resample_midthickness_wf,
 )
 
-LOGGER = logging.getLogger("nipype.workflow")
+LOGGER = logging.getLogger('nipype.workflow')
 
 
 def init_anat_preproc_wf(
@@ -102,8 +102,8 @@ def init_anat_preproc_wf(
     flair: list = (),  # Remove default after callers start passing it
     debug: bool = False,
     sloppy: bool = False,
-    cifti_output: ty.Literal["91k", "170k", False] = False,
-    name: str = "anat_preproc_wf",
+    cifti_output: ty.Literal['91k', '170k', False] = False,
+    name: str = 'anat_preproc_wf',
     skull_strip_fixed_seed: bool = False,
 ):
     """
@@ -226,29 +226,29 @@ def init_anat_preproc_wf(
     workflow = Workflow(name=name)
 
     inputnode = pe.Node(
-        niu.IdentityInterface(fields=["t1w", "t2w", "roi", "flair", "subjects_dir", "subject_id"]),
-        name="inputnode",
+        niu.IdentityInterface(fields=['t1w', 't2w', 'roi', 'flair', 'subjects_dir', 'subject_id']),
+        name='inputnode',
     )
     outputnode = pe.Node(
         niu.IdentityInterface(
             fields=[
-                "template",
-                "subjects_dir",
-                "subject_id",
-                "t1w_preproc",
-                "t1w_mask",
-                "t1w_dseg",
-                "t1w_tpms",
-                "anat2std_xfm",
-                "std2anat_xfm",
-                "fsnative2t1w_xfm",
-                "t1w_aparc",
-                "t1w_aseg",
-                "sphere_reg",
-                "sphere_reg_fsLR",
+                'template',
+                'subjects_dir',
+                'subject_id',
+                't1w_preproc',
+                't1w_mask',
+                't1w_dseg',
+                't1w_tpms',
+                'anat2std_xfm',
+                'std2anat_xfm',
+                'fsnative2t1w_xfm',
+                't1w_aparc',
+                't1w_aseg',
+                'sphere_reg',
+                'sphere_reg_fsLR',
             ]
         ),
-        name="outputnode",
+        name='outputnode',
     )
 
     anat_fit_wf = init_anat_fit_wf(
@@ -274,7 +274,7 @@ def init_anat_preproc_wf(
     ds_std_volumes_wf = init_ds_anat_volumes_wf(
         bids_root=bids_root,
         output_dir=output_dir,
-        name="ds_std_volumes_wf",
+        name='ds_std_volumes_wf',
     )
 
     workflow.connect([
@@ -331,10 +331,10 @@ def init_anat_preproc_wf(
             cifti_output=cifti_output,
         )
         ds_surfaces_wf = init_ds_surfaces_wf(
-            bids_root=bids_root, output_dir=output_dir, surfaces=["inflated"]
+            bids_root=bids_root, output_dir=output_dir, surfaces=['inflated']
         )
         ds_curv_wf = init_ds_surface_metrics_wf(
-            bids_root=bids_root, output_dir=output_dir, metrics=["curv"], name="ds_curv_wf"
+            bids_root=bids_root, output_dir=output_dir, metrics=['curv'], name='ds_curv_wf'
         )
 
         workflow.connect([
@@ -450,7 +450,7 @@ def init_anat_fit_wf(
     flair: list = (),  # Remove default after callers start passing it
     debug: bool = False,
     sloppy: bool = False,
-    name="anat_fit_wf",
+    name='anat_fit_wf',
     skull_strip_fixed_seed: bool = False,
 ):
     """
@@ -594,11 +594,11 @@ Anatomical data preprocessing
 : A total of {num_t1w} T1-weighted (T1w) images were found within the input
 BIDS dataset."""
 
-    have_t1w = "t1w_preproc" in precomputed
-    have_t2w = "t2w_preproc" in precomputed
-    have_mask = "t1w_mask" in precomputed
-    have_dseg = "t1w_dseg" in precomputed
-    have_tpms = "t1w_tpms" in precomputed
+    have_t1w = 't1w_preproc' in precomputed
+    have_t2w = 't2w_preproc' in precomputed
+    have_mask = 't1w_mask' in precomputed
+    have_dseg = 't1w_dseg' in precomputed
+    have_tpms = 't1w_tpms' in precomputed
 
     # Organization
     # ------------
@@ -611,83 +611,83 @@ BIDS dataset."""
     # All outputnode components should therefore point to files in the input or
     # output directories.
     inputnode = pe.Node(
-        niu.IdentityInterface(fields=["t1w", "t2w", "roi", "flair", "subjects_dir", "subject_id"]),
-        name="inputnode",
+        niu.IdentityInterface(fields=['t1w', 't2w', 'roi', 'flair', 'subjects_dir', 'subject_id']),
+        name='inputnode',
     )
     outputnode = pe.Node(
         niu.IdentityInterface(
             fields=[
                 # Primary derivatives
-                "t1w_preproc",
-                "t2w_preproc",
-                "t1w_mask",
-                "t1w_dseg",
-                "t1w_tpms",
-                "anat2std_xfm",
-                "fsnative2t1w_xfm",
+                't1w_preproc',
+                't2w_preproc',
+                't1w_mask',
+                't1w_dseg',
+                't1w_tpms',
+                'anat2std_xfm',
+                'fsnative2t1w_xfm',
                 # Surface and metric derivatives for fsLR resampling
-                "white",
-                "pial",
-                "midthickness",
-                "sphere",
-                "thickness",
-                "sulc",
-                "sphere_reg",
-                "sphere_reg_fsLR",
-                "sphere_reg_msm",
-                "anat_ribbon",
+                'white',
+                'pial',
+                'midthickness',
+                'sphere',
+                'thickness',
+                'sulc',
+                'sphere_reg',
+                'sphere_reg_fsLR',
+                'sphere_reg_msm',
+                'anat_ribbon',
                 # Reverse transform; not computable from forward transform
-                "std2anat_xfm",
+                'std2anat_xfm',
                 # Metadata
-                "template",
-                "subjects_dir",
-                "subject_id",
-                "t1w_valid_list",
+                'template',
+                'subjects_dir',
+                'subject_id',
+                't1w_valid_list',
             ]
         ),
-        name="outputnode",
+        name='outputnode',
     )
     # If all derivatives exist, inputnode could go unconnected, so add explicitly
     workflow.add_nodes([inputnode])
 
     # Stage 1 inputs (filtered)
     sourcefile_buffer = pe.Node(
-        niu.IdentityInterface(fields=["source_files"]),
-        name="sourcefile_buffer",
+        niu.IdentityInterface(fields=['source_files']),
+        name='sourcefile_buffer',
     )
 
     # Stage 2 results
     t1w_buffer = pe.Node(
-        niu.IdentityInterface(fields=["t1w_preproc", "t1w_mask", "t1w_brain", "ants_seg"]),
-        name="t1w_buffer",
+        niu.IdentityInterface(fields=['t1w_preproc', 't1w_mask', 't1w_brain', 'ants_seg']),
+        name='t1w_buffer',
     )
     # Stage 3 results
     seg_buffer = pe.Node(
-        niu.IdentityInterface(fields=["t1w_dseg", "t1w_tpms"]),
-        name="seg_buffer",
+        niu.IdentityInterface(fields=['t1w_dseg', 't1w_tpms']),
+        name='seg_buffer',
     )
     # Stage 4 results: collated template names, forward and reverse transforms
-    template_buffer = pe.Node(niu.Merge(2), name="template_buffer")
-    anat2std_buffer = pe.Node(niu.Merge(2), name="anat2std_buffer")
-    std2anat_buffer = pe.Node(niu.Merge(2), name="std2anat_buffer")
+    template_buffer = pe.Node(niu.Merge(2), name='template_buffer')
+    anat2std_buffer = pe.Node(niu.Merge(2), name='anat2std_buffer')
+    std2anat_buffer = pe.Node(niu.Merge(2), name='std2anat_buffer')
 
     # Stage 6 results: Refined stage 2 results; may be direct copy if no refinement
     refined_buffer = pe.Node(
-        niu.IdentityInterface(fields=["t1w_mask", "t1w_brain"]),
-        name="refined_buffer",
+        niu.IdentityInterface(fields=['t1w_mask', 't1w_brain']),
+        name='refined_buffer',
     )
 
     # Stage 8 results: GIFTI surfaces
     surfaces_buffer = pe.Node(
         niu.IdentityInterface(
-            fields=["white", "pial", "midthickness", "sphere", "sphere_reg", "thickness", "sulc"]
+            fields=['white', 'pial', 'midthickness', 'sphere', 'sphere_reg', 'thickness', 'sulc']
         ),
-        name="surfaces_buffer",
+        name='surfaces_buffer',
     )
 
     # Stage 9 and 10 results: fsLR sphere registration
-    fsLR_buffer = pe.Node(niu.IdentityInterface(fields=["sphere_reg_fsLR"]), name="fsLR_buffer")
-    msm_buffer = pe.Node(niu.IdentityInterface(fields=["sphere_reg_msm"]), name="msm_buffer")
+    fsLR_buffer = pe.Node(niu.IdentityInterface(fields=['sphere_reg_fsLR']), name='fsLR_buffer')
+    msm_buffer = pe.Node(niu.IdentityInterface(fields=['sphere_reg_msm']), name='msm_buffer')
 
     # fmt:off
     workflow.connect([
@@ -736,22 +736,22 @@ BIDS dataset."""
 
     # Stage 1: Conform images and validate
     # If desc-preproc_T1w.nii.gz is provided, just validate it
-    anat_validate = pe.Node(ValidateImage(), name="anat_validate", run_without_submitting=True)
+    anat_validate = pe.Node(ValidateImage(), name='anat_validate', run_without_submitting=True)
     if not have_t1w:
-        LOGGER.info("ANAT Stage 1: Adding template workflow")
-        ants_ver = ANTsInfo.version() or "(version unknown)"
+        LOGGER.info('ANAT Stage 1: Adding template workflow')
+        ants_ver = ANTsInfo.version() or '(version unknown)'
         desc += f"""\
  {"Each" if num_t1w > 1 else "The"} T1w image was corrected for intensity
 non-uniformity (INU) with `N4BiasFieldCorrection` [@n4], distributed with ANTs {ants_ver}
 [@ants, RRID:SCR_004757]"""
-        desc += ".\n" if num_t1w > 1 else ", and used as T1w-reference throughout the workflow.\n"
+        desc += '.\n' if num_t1w > 1 else ', and used as T1w-reference throughout the workflow.\n'
 
         anat_template_wf = init_anat_template_wf(
             longitudinal=longitudinal,
             omp_nthreads=omp_nthreads,
             num_files=num_t1w,
-            contrast="T1w",
-            name="anat_template_wf",
+            contrast='T1w',
+            name='anat_template_wf',
         )
         ds_template_wf = init_ds_template_wf(output_dir=output_dir, num_t1w=num_t1w)
 
@@ -774,13 +774,13 @@ non-uniformity (INU) with `N4BiasFieldCorrection` [@n4], distributed with ANTs {
         ])
         # fmt:on
     else:
-        LOGGER.info("ANAT Found preprocessed T1w - skipping Stage 1")
+        LOGGER.info('ANAT Found preprocessed T1w - skipping Stage 1')
         desc += """ A preprocessed T1w image was provided as a precomputed input
 and used as T1w-reference throughout the workflow.
 """
 
-        anat_validate.inputs.in_file = precomputed["t1w_preproc"]
-        sourcefile_buffer.inputs.source_files = [precomputed["t1w_preproc"]]
+        anat_validate.inputs.in_file = precomputed['t1w_preproc']
+        sourcefile_buffer.inputs.source_files = [precomputed['t1w_preproc']]
 
         # fmt:off
         workflow.connect([
@@ -793,11 +793,11 @@ and used as T1w-reference throughout the workflow.
     # We always need to generate t1w_brain; how to do that depends on whether we have
     # a pre-corrected T1w or precomputed mask, or are given an already masked image
     if not have_mask:
-        LOGGER.info("ANAT Stage 2: Preparing brain extraction workflow")
-        if skull_strip_mode == "auto":
+        LOGGER.info('ANAT Stage 2: Preparing brain extraction workflow')
+        if skull_strip_mode == 'auto':
             run_skull_strip = not all(_is_skull_stripped(img) for img in t1w)
         else:
-            run_skull_strip = {"force": True, "skip": False}[skull_strip_mode]
+            run_skull_strip = {'force': True, 'skip': False}[skull_strip_mode]
 
         # Brain extraction
         if run_skull_strip:
@@ -811,7 +811,7 @@ as target template.
                 template_spec=skull_strip_template.spec,
                 atropos_use_random_seed=not skull_strip_fixed_seed,
                 omp_nthreads=omp_nthreads,
-                normalization_quality="precise" if not sloppy else "testing",
+                normalization_quality='precise' if not sloppy else 'testing',
             )
             # fmt:off
             workflow.connect([
@@ -831,7 +831,7 @@ as target template.
             # fmt:on
         # Determine mask from T1w and uniformize
         elif not have_t1w:
-            LOGGER.info("ANAT Stage 2: Skipping skull-strip, INU-correction only")
+            LOGGER.info('ANAT Stage 2: Skipping skull-strip, INU-correction only')
             desc += """\
 The provided T1w image was previously skull-stripped; a brain mask was
 derived from the input image.
@@ -853,12 +853,12 @@ derived from the input image.
             # fmt:on
         # Binarize the already uniformized image
         else:
-            LOGGER.info("ANAT Stage 2: Skipping skull-strip, generating mask from input")
+            LOGGER.info('ANAT Stage 2: Skipping skull-strip, generating mask from input')
             desc += """\
 The provided T1w image was previously skull-stripped; a brain mask was
 derived from the input image.
 """
-            binarize = pe.Node(Binarize(thresh_low=2), name="binarize")
+            binarize = pe.Node(Binarize(thresh_low=2), name='binarize')
             # fmt:off
             workflow.connect([
                 (anat_validate, binarize, [("out_file", "in_file")]),
@@ -870,8 +870,8 @@ derived from the input image.
         ds_t1w_mask_wf = init_ds_mask_wf(
             bids_root=bids_root,
             output_dir=output_dir,
-            mask_type="brain",
-            name="ds_t1w_mask_wf",
+            mask_type='brain',
+            name='ds_t1w_mask_wf',
         )
         # fmt:off
         workflow.connect([
@@ -881,17 +881,17 @@ derived from the input image.
         ])
         # fmt:on
     else:
-        LOGGER.info("ANAT Found brain mask")
+        LOGGER.info('ANAT Found brain mask')
         desc += """\
 A pre-computed brain mask was provided as input and used throughout the workflow.
 """
-        t1w_buffer.inputs.t1w_mask = precomputed["t1w_mask"]
+        t1w_buffer.inputs.t1w_mask = precomputed['t1w_mask']
         # If we have a mask, always apply it
-        apply_mask = pe.Node(ApplyMask(in_mask=precomputed["t1w_mask"]), name="apply_mask")
-        workflow.connect([(anat_validate, apply_mask, [("out_file", "in_file")])])
+        apply_mask = pe.Node(ApplyMask(in_mask=precomputed['t1w_mask']), name='apply_mask')
+        workflow.connect([(anat_validate, apply_mask, [('out_file', 'in_file')])])
         # Run N4 if it hasn't been pre-run
         if not have_t1w:
-            LOGGER.info("ANAT Skipping skull-strip, INU-correction only")
+            LOGGER.info('ANAT Skipping skull-strip, INU-correction only')
             n4_only_wf = init_n4_only_wf(
                 omp_nthreads=omp_nthreads,
                 atropos_use_random_seed=not skull_strip_fixed_seed,
@@ -906,14 +906,14 @@ A pre-computed brain mask was provided as input and used throughout the workflow
             ])
             # fmt:on
         else:
-            LOGGER.info("ANAT Skipping Stage 2")
-            workflow.connect([(apply_mask, t1w_buffer, [("out_file", "t1w_brain")])])
-        workflow.connect([(refined_buffer, outputnode, [("t1w_mask", "t1w_mask")])])
+            LOGGER.info('ANAT Skipping Stage 2')
+            workflow.connect([(apply_mask, t1w_buffer, [('out_file', 't1w_brain')])])
+        workflow.connect([(refined_buffer, outputnode, [('t1w_mask', 't1w_mask')])])
 
     # Stage 3: Segmentation
     if not (have_dseg and have_tpms):
-        LOGGER.info("ANAT Stage 3: Preparing segmentation workflow")
-        fsl_ver = fsl.FAST().version or "(version unknown)"
+        LOGGER.info('ANAT Stage 3: Preparing segmentation workflow')
+        fsl_ver = fsl.FAST().version or '(version unknown)'
         desc += f"""\
 Brain tissue segmentation of cerebrospinal fluid (CSF),
 white-matter (WM) and gray-matter (GM) was performed on
@@ -921,17 +921,17 @@ the brain-extracted T1w using `fast` [FSL {fsl_ver}, RRID:SCR_002823, @fsl_fast]
 """
         fast = pe.Node(
             fsl.FAST(segments=True, no_bias=True, probability_maps=True),
-            name="fast",
+            name='fast',
             mem_gb=3,
         )
-        lut_t1w_dseg = pe.Node(niu.Function(function=_apply_bids_lut), name="lut_t1w_dseg")
+        lut_t1w_dseg = pe.Node(niu.Function(function=_apply_bids_lut), name='lut_t1w_dseg')
         lut_t1w_dseg.inputs.lut = (0, 3, 1, 2)  # Maps: 0 -> 0, 3 -> 1, 1 -> 2, 2 -> 3.
         fast2bids = pe.Node(
             niu.Function(function=_probseg_fast2bids),
-            name="fast2bids",
+            name='fast2bids',
             run_without_submitting=True,
         )
-        workflow.connect([(refined_buffer, fast, [("t1w_brain", "in_files")])])
+        workflow.connect([(refined_buffer, fast, [('t1w_brain', 'in_files')])])
 
         # fmt:off
         if not have_dseg:
@@ -952,32 +952,32 @@ the brain-extracted T1w using `fast` [FSL {fsl_ver}, RRID:SCR_002823, @fsl_fast]
             ])
         # fmt:on
     else:
-        LOGGER.info("ANAT Skipping Stage 3")
+        LOGGER.info('ANAT Skipping Stage 3')
     if have_dseg:
-        LOGGER.info("ANAT Found discrete segmentation")
-        desc += "Precomputed discrete tissue segmentations were provided as inputs.\n"
-        seg_buffer.inputs.t1w_dseg = precomputed["t1w_dseg"]
+        LOGGER.info('ANAT Found discrete segmentation')
+        desc += 'Precomputed discrete tissue segmentations were provided as inputs.\n'
+        seg_buffer.inputs.t1w_dseg = precomputed['t1w_dseg']
     if have_tpms:
-        LOGGER.info("ANAT Found tissue probability maps")
-        desc += "Precomputed tissue probabiilty maps were provided as inputs.\n"
-        seg_buffer.inputs.t1w_tpms = precomputed["t1w_tpms"]
+        LOGGER.info('ANAT Found tissue probability maps')
+        desc += 'Precomputed tissue probabiilty maps were provided as inputs.\n'
+        seg_buffer.inputs.t1w_tpms = precomputed['t1w_tpms']
 
     # Stage 4: Normalization
     templates = []
     found_xfms = {}
     for template in spaces.get_spaces(nonstandard=False, dim=(3,)):
-        xfms = precomputed.get("transforms", {}).get(template, {})
-        if set(xfms) != {"forward", "reverse"}:
+        xfms = precomputed.get('transforms', {}).get(template, {})
+        if set(xfms) != {'forward', 'reverse'}:
             templates.append(template)
         else:
             found_xfms[template] = xfms
 
     template_buffer.inputs.in1 = list(found_xfms)
-    anat2std_buffer.inputs.in1 = [xfm["forward"] for xfm in found_xfms.values()]
-    std2anat_buffer.inputs.in1 = [xfm["reverse"] for xfm in found_xfms.values()]
+    anat2std_buffer.inputs.in1 = [xfm['forward'] for xfm in found_xfms.values()]
+    std2anat_buffer.inputs.in1 = [xfm['reverse'] for xfm in found_xfms.values()]
 
     if templates:
-        LOGGER.info(f"ANAT Stage 4: Preparing normalization workflow for {templates}")
+        LOGGER.info(f'ANAT Stage 4: Preparing normalization workflow for {templates}')
         register_template_wf = init_register_template_wf(
             sloppy=sloppy,
             omp_nthreads=omp_nthreads,
@@ -1004,7 +1004,7 @@ the brain-extracted T1w using `fast` [FSL {fsl_ver}, RRID:SCR_002823, @fsl_fast]
         ])
         # fmt:on
     if found_xfms:
-        LOGGER.info(f"ANAT Stage 4: Found pre-computed registrations for {found_xfms}")
+        LOGGER.info(f'ANAT Stage 4: Found pre-computed registrations for {found_xfms}')
 
     # Do not attempt refinement (Stage 6, below)
     if have_mask or not freesurfer:
@@ -1020,24 +1020,24 @@ the brain-extracted T1w using `fast` [FSL {fsl_ver}, RRID:SCR_002823, @fsl_fast]
     workflow.__desc__ = desc
 
     if not freesurfer:
-        LOGGER.info("ANAT Skipping Stages 5+")
+        LOGGER.info('ANAT Skipping Stages 5+')
         return workflow
 
     fs_isrunning = pe.Node(
-        niu.Function(function=_fs_isRunning), overwrite=True, name="fs_isrunning"
+        niu.Function(function=_fs_isRunning), overwrite=True, name='fs_isrunning'
     )
     fs_isrunning.inputs.logger = LOGGER
 
     # Stage 5: Surface reconstruction (--fs-no-reconall not set)
-    LOGGER.info("ANAT Stage 5: Preparing surface reconstruction workflow")
+    LOGGER.info('ANAT Stage 5: Preparing surface reconstruction workflow')
     surface_recon_wf = init_surface_recon_wf(
-        name="surface_recon_wf",
+        name='surface_recon_wf',
         omp_nthreads=omp_nthreads,
         hires=hires,
         precomputed=precomputed,
     )
     if t2w or flair:
-        t2w_or_flair = "T2-weighted" if t2w else "FLAIR"
+        t2w_or_flair = 'T2-weighted' if t2w else 'FLAIR'
         surface_recon_wf.__desc__ += f"""\
 A {t2w_or_flair} image was used to improve pial surface refinement.
 """
@@ -1063,7 +1063,7 @@ A {t2w_or_flair} image was used to improve pial surface refinement.
     ])
     # fmt:on
 
-    fsnative_xfms = precomputed.get("transforms", {}).get("fsnative")
+    fsnative_xfms = precomputed.get('transforms', {}).get('fsnative')
     if not fsnative_xfms:
         ds_fs_registration_wf = init_ds_fs_registration_wf(output_dir=output_dir)
         # fmt:off
@@ -1079,19 +1079,19 @@ A {t2w_or_flair} image was used to improve pial surface refinement.
             ]),
         ])
         # fmt:on
-    elif "reverse" in fsnative_xfms:
-        LOGGER.info("ANAT Found fsnative-T1w transform - skipping registration")
-        outputnode.inputs.fsnative2t1w_xfm = fsnative_xfms["reverse"]
+    elif 'reverse' in fsnative_xfms:
+        LOGGER.info('ANAT Found fsnative-T1w transform - skipping registration')
+        outputnode.inputs.fsnative2t1w_xfm = fsnative_xfms['reverse']
     else:
         raise RuntimeError(
-            "Found a T1w-to-fsnative transform without the reverse. Time to handle this."
+            'Found a T1w-to-fsnative transform without the reverse. Time to handle this.'
         )
 
     if not have_mask:
-        LOGGER.info("ANAT Stage 6: Preparing mask refinement workflow")
+        LOGGER.info('ANAT Stage 6: Preparing mask refinement workflow')
         # Stage 6: Refine ANTs mask with FreeSurfer segmentation
         refinement_wf = init_refinement_wf()
-        applyrefined = pe.Node(fsl.ApplyMask(), name="applyrefined")
+        applyrefined = pe.Node(fsl.ApplyMask(), name='applyrefined')
 
         # fmt:off
         workflow.connect([
@@ -1111,42 +1111,42 @@ A {t2w_or_flair} image was used to improve pial surface refinement.
         ])
         # fmt:on
     else:
-        LOGGER.info("ANAT Found brain mask - skipping Stage 6")
+        LOGGER.info('ANAT Found brain mask - skipping Stage 6')
 
     if t2w and not have_t2w:
-        LOGGER.info("ANAT Stage 7: Creating T2w template")
+        LOGGER.info('ANAT Stage 7: Creating T2w template')
         t2w_template_wf = init_anat_template_wf(
             longitudinal=longitudinal,
             omp_nthreads=omp_nthreads,
             num_files=len(t2w),
-            contrast="T2w",
-            name="t2w_template_wf",
+            contrast='T2w',
+            name='t2w_template_wf',
         )
         bbreg = pe.Node(
             fs.BBRegister(
-                contrast_type="t2",
-                init="coreg",
+                contrast_type='t2',
+                init='coreg',
                 dof=6,
                 out_lta_file=True,
-                args="--gm-proj-abs 2 --wm-proj-abs 1",
+                args='--gm-proj-abs 2 --wm-proj-abs 1',
             ),
-            name="bbreg",
+            name='bbreg',
         )
-        coreg_xfms = pe.Node(niu.Merge(2), name="merge_xfms", run_without_submitting=True)
-        t2wtot1w_xfm = pe.Node(ConcatenateXFMs(), name="t2wtot1w_xfm", run_without_submitting=True)
+        coreg_xfms = pe.Node(niu.Merge(2), name='merge_xfms', run_without_submitting=True)
+        t2wtot1w_xfm = pe.Node(ConcatenateXFMs(), name='t2wtot1w_xfm', run_without_submitting=True)
         t2w_resample = pe.Node(
             ApplyTransforms(
                 dimension=3,
                 default_value=0,
                 float=True,
-                interpolation="LanczosWindowedSinc",
+                interpolation='LanczosWindowedSinc',
             ),
-            name="t2w_resample",
+            name='t2w_resample',
         )
 
         ds_t2w_preproc = pe.Node(
-            DerivativesDataSink(base_directory=output_dir, desc="preproc", compress=True),
-            name="ds_t2w_preproc",
+            DerivativesDataSink(base_directory=output_dir, desc='preproc', compress=True),
+            name='ds_t2w_preproc',
             run_without_submitting=True,
         )
         ds_t2w_preproc.inputs.SkullStripped = False
@@ -1169,9 +1169,9 @@ A {t2w_or_flair} image was used to improve pial surface refinement.
             (ds_t2w_preproc, outputnode, [('out_file', 't2w_preproc')]),
         ])  # fmt:skip
     elif not t2w:
-        LOGGER.info("ANAT No T2w images provided - skipping Stage 7")
+        LOGGER.info('ANAT No T2w images provided - skipping Stage 7')
     else:
-        LOGGER.info("ANAT Found preprocessed T2w - skipping Stage 7")
+        LOGGER.info('ANAT Found preprocessed T2w - skipping Stage 7')
 
     # Stages 8-10: Surface conversion and registration
     # sphere_reg is needed to generate sphere_reg_fsLR
@@ -1179,9 +1179,9 @@ A {t2w_or_flair} image was used to improve pial surface refinement.
     # white, pial, midthickness and thickness are needed to resample in the cortical ribbon
     # TODO: Consider paring down or splitting into a subworkflow that can be called on-demand
     # A subworkflow would still need to check for precomputed outputs
-    needed_anat_surfs = ["white", "pial", "midthickness"]
-    needed_metrics = ["thickness", "sulc"]
-    needed_spheres = ["sphere_reg", "sphere"]
+    needed_anat_surfs = ['white', 'pial', 'midthickness']
+    needed_metrics = ['thickness', 'sulc']
+    needed_spheres = ['sphere_reg', 'sphere']
 
     # Detect pre-computed surfaces
     found_surfs = {
@@ -1190,14 +1190,14 @@ A {t2w_or_flair} image was used to improve pial surface refinement.
         if len(precomputed.get(surf, [])) == 2
     }
     if found_surfs:
-        LOGGER.info(f"ANAT Stage 8: Found pre-converted surfaces for {list(found_surfs)}")
+        LOGGER.info(f'ANAT Stage 8: Found pre-converted surfaces for {list(found_surfs)}')
         surfaces_buffer.inputs.trait_set(**found_surfs)
 
     # Stage 8: Surface conversion
     surfs = [surf for surf in needed_anat_surfs if surf not in found_surfs]
     spheres = [sphere for sphere in needed_spheres if sphere not in found_surfs]
     if surfs or spheres:
-        LOGGER.info(f"ANAT Stage 8: Creating GIFTI surfaces for {surfs + spheres}")
+        LOGGER.info(f'ANAT Stage 8: Creating GIFTI surfaces for {surfs + spheres}')
     if surfs:
         gifti_surfaces_wf = init_gifti_surfaces_wf(surfaces=surfs)
         ds_surfaces_wf = init_ds_surfaces_wf(
@@ -1244,7 +1244,7 @@ A {t2w_or_flair} image was used to improve pial surface refinement.
         # fmt:on
     metrics = [metric for metric in needed_metrics if metric not in found_surfs]
     if metrics:
-        LOGGER.info(f"ANAT Stage 8: Creating GIFTI metrics for {metrics}")
+        LOGGER.info(f'ANAT Stage 8: Creating GIFTI metrics for {metrics}')
         gifti_morph_wf = init_gifti_morphometrics_wf(morphometrics=metrics)
         ds_morph_wf = init_ds_surface_metrics_wf(
             bids_root=bids_root, output_dir=output_dir, metrics=metrics, name='ds_morph_wf'
@@ -1266,14 +1266,14 @@ A {t2w_or_flair} image was used to improve pial surface refinement.
         ])
         # fmt:on
 
-    if "anat_ribbon" not in precomputed:
-        LOGGER.info("ANAT Stage 8a: Creating cortical ribbon mask")
+    if 'anat_ribbon' not in precomputed:
+        LOGGER.info('ANAT Stage 8a: Creating cortical ribbon mask')
         anat_ribbon_wf = init_anat_ribbon_wf()
         ds_ribbon_mask_wf = init_ds_mask_wf(
             bids_root=bids_root,
             output_dir=output_dir,
-            mask_type="ribbon",
-            name="ds_ribbon_mask_wf",
+            mask_type='ribbon',
+            name='ds_ribbon_mask_wf',
         )
         # fmt:off
         workflow.connect([
@@ -1292,17 +1292,17 @@ A {t2w_or_flair} image was used to improve pial surface refinement.
         ])
         # fmt:on
     else:
-        LOGGER.info("ANAT Stage 8a: Found pre-computed cortical ribbon mask")
-        outputnode.inputs.anat_ribbon = precomputed["anat_ribbon"]
+        LOGGER.info('ANAT Stage 8a: Found pre-computed cortical ribbon mask')
+        outputnode.inputs.anat_ribbon = precomputed['anat_ribbon']
 
     # Stage 9: Baseline fsLR registration
-    if len(precomputed.get("sphere_reg_fsLR", [])) < 2:
-        LOGGER.info("ANAT Stage 9: Creating fsLR registration sphere")
+    if len(precomputed.get('sphere_reg_fsLR', [])) < 2:
+        LOGGER.info('ANAT Stage 9: Creating fsLR registration sphere')
         fsLR_reg_wf = init_fsLR_reg_wf()
         ds_fsLR_reg_wf = init_ds_surfaces_wf(
             bids_root=bids_root,
             output_dir=output_dir,
-            surfaces=["sphere_reg_fsLR"],
+            surfaces=['sphere_reg_fsLR'],
             name='ds_fsLR_reg_wf',
         )
 
@@ -1317,17 +1317,17 @@ A {t2w_or_flair} image was used to improve pial surface refinement.
         ])
         # fmt:on
     else:
-        LOGGER.info("ANAT Stage 9: Found pre-computed fsLR registration sphere")
-        fsLR_buffer.inputs.sphere_reg_fsLR = sorted(precomputed["sphere_reg_fsLR"])
+        LOGGER.info('ANAT Stage 9: Found pre-computed fsLR registration sphere')
+        fsLR_buffer.inputs.sphere_reg_fsLR = sorted(precomputed['sphere_reg_fsLR'])
 
     # Stage 10: MSMSulc
-    if msm_sulc and len(precomputed.get("sphere_reg_msm", [])) < 2:
-        LOGGER.info("ANAT Stage 10: Creating MSM-Sulc registration sphere")
+    if msm_sulc and len(precomputed.get('sphere_reg_msm', [])) < 2:
+        LOGGER.info('ANAT Stage 10: Creating MSM-Sulc registration sphere')
         msm_sulc_wf = init_msm_sulc_wf(sloppy=sloppy)
         ds_msmsulc_wf = init_ds_surfaces_wf(
             bids_root=bids_root,
             output_dir=output_dir,
-            surfaces=["sphere_reg_msm"],
+            surfaces=['sphere_reg_msm'],
             name='ds_msmsulc_wf',
         )
 
@@ -1346,10 +1346,10 @@ A {t2w_or_flair} image was used to improve pial surface refinement.
         ])
         # fmt:on
     elif msm_sulc:
-        LOGGER.info("ANAT Stage 10: Found pre-computed MSM-Sulc registration sphere")
-        msm_buffer.inputs.sphere_reg_msm = sorted(precomputed["sphere_reg_msm"])
+        LOGGER.info('ANAT Stage 10: Found pre-computed MSM-Sulc registration sphere')
+        msm_buffer.inputs.sphere_reg_msm = sorted(precomputed['sphere_reg_msm'])
     else:
-        LOGGER.info("ANAT Stage 10: MSM-Sulc disabled")
+        LOGGER.info('ANAT Stage 10: MSM-Sulc disabled')
 
     return workflow
 
@@ -1360,7 +1360,7 @@ def init_anat_template_wf(
     omp_nthreads: int,
     num_files: int,
     contrast: str,
-    name: str = "anat_template_wf",
+    name: str = 'anat_template_wf',
 ):
     """
     Generate a canonically-oriented, structural average from all input images.
@@ -1409,29 +1409,29 @@ def init_anat_template_wf(
     workflow = Workflow(name=name)
 
     if num_files > 1:
-        fs_ver = fs.Info().looseversion() or "(version unknown)"
+        fs_ver = fs.Info().looseversion() or '(version unknown)'
         workflow.__desc__ = f"""\
 An anatomical {contrast}-reference map was computed after registration of
 {num_files} {contrast} images (after INU-correction) using
 `mri_robust_template` [FreeSurfer {fs_ver}, @fs_template].
 """
 
-    inputnode = pe.Node(niu.IdentityInterface(fields=["anat_files"]), name="inputnode")
+    inputnode = pe.Node(niu.IdentityInterface(fields=['anat_files']), name='inputnode')
     outputnode = pe.Node(
         niu.IdentityInterface(
-            fields=["anat_ref", "anat_valid_list", "anat_realign_xfm", "out_report"]
+            fields=['anat_ref', 'anat_valid_list', 'anat_realign_xfm', 'out_report']
         ),
-        name="outputnode",
+        name='outputnode',
     )
 
     # 0. Denoise and reorient T1w image(s) to RAS and resample to common voxel space
-    anat_ref_dimensions = pe.Node(TemplateDimensions(), name="anat_ref_dimensions")
+    anat_ref_dimensions = pe.Node(TemplateDimensions(), name='anat_ref_dimensions')
     denoise = pe.MapNode(
-        DenoiseImage(noise_model="Rician", num_threads=omp_nthreads),
-        iterfield="input_image",
-        name="denoise",
+        DenoiseImage(noise_model='Rician', num_threads=omp_nthreads),
+        iterfield='input_image',
+        name='denoise',
     )
-    anat_conform = pe.MapNode(Conform(), iterfield="in_file", name="anat_conform")
+    anat_conform = pe.MapNode(Conform(), iterfield='in_file', name='anat_conform')
 
     # fmt:off
     workflow.connect([
@@ -1450,8 +1450,8 @@ An anatomical {contrast}-reference map was computed after registration of
     # fmt:on
 
     if num_files == 1:
-        get1st = pe.Node(niu.Select(index=[0]), name="get1st")
-        outputnode.inputs.anat_realign_xfm = [str(load_resource("itkIdentityTransform.txt"))]
+        get1st = pe.Node(niu.Select(index=[0]), name='get1st')
+        outputnode.inputs.anat_realign_xfm = [str(load_resource('itkIdentityTransform.txt'))]
 
         # fmt:off
         workflow.connect([
@@ -1462,9 +1462,9 @@ An anatomical {contrast}-reference map was computed after registration of
         return workflow
 
     anat_conform_xfm = pe.MapNode(
-        LTAConvert(in_lta="identity.nofile", out_lta=True),
-        iterfield=["source_file", "target_file"],
-        name="anat_conform_xfm",
+        LTAConvert(in_lta='identity.nofile', out_lta=True),
+        iterfield=['source_file', 'target_file'],
+        name='anat_conform_xfm',
     )
 
     # 1. Template (only if several T1w images)
@@ -1474,8 +1474,8 @@ An anatomical {contrast}-reference map was computed after registration of
     # 1b. Align and merge if several T1w images are provided
     n4_correct = pe.MapNode(
         N4BiasFieldCorrection(dimension=3, copy_header=True),
-        iterfield="input_image",
-        name="n4_correct",
+        iterfield='input_image',
+        name='n4_correct',
         n_procs=1,
     )  # n_procs=1 for reproducibility
     # StructuralReference is fs.RobustTemplate if > 1 volume, copying otherwise
@@ -1490,22 +1490,22 @@ An anatomical {contrast}-reference map was computed after registration of
             transform_outputs=True,
         ),
         mem_gb=2 * num_files - 1,
-        name="anat_merge",
+        name='anat_merge',
     )
 
     # 2. Reorient template to RAS, if needed (mri_robust_template may set to LIA)
-    anat_reorient = pe.Node(image.Reorient(), name="anat_reorient")
+    anat_reorient = pe.Node(image.Reorient(), name='anat_reorient')
 
     merge_xfm = pe.MapNode(
         niu.Merge(2),
-        name="merge_xfm",
-        iterfield=["in1", "in2"],
+        name='merge_xfm',
+        iterfield=['in1', 'in2'],
         run_without_submitting=True,
     )
     concat_xfms = pe.MapNode(
         ConcatenateXFMs(inverse=True),
-        name="concat_xfms",
-        iterfield=["in_xfms"],
+        name='concat_xfms',
+        iterfield=['in_xfms'],
         run_without_submitting=True,
     )
 
@@ -1556,7 +1556,7 @@ def _aseg_to_three():
     import numpy as np
 
     # Base struct
-    aseg_lut = np.zeros((256,), dtype="int")
+    aseg_lut = np.zeros((256,), dtype='int')
     # GM
     aseg_lut[3] = 1
     aseg_lut[8:14] = 1
@@ -1593,11 +1593,11 @@ def _split_segments(in_file):
     segimg = nb.load(in_file)
     data = np.int16(segimg.dataobj)
     hdr = segimg.header.copy()
-    hdr.set_data_dtype("uint8")
+    hdr.set_data_dtype('uint8')
 
     out_files = []
-    for i, label in enumerate(("GM", "WM", "CSF"), 1):
-        out_fname = str(Path.cwd() / f"aseg_label-{label}_mask.nii.gz")
+    for i, label in enumerate(('GM', 'WM', 'CSF'), 1):
+        out_fname = str(Path.cwd() / f'aseg_label-{label}_mask.nii.gz')
         segimg.__class__(data == i, segimg.affine, hdr).to_filename(out_fname)
         out_files.append(out_fname)
 

--- a/smriprep/workflows/anatomical.py
+++ b/smriprep/workflows/anatomical.py
@@ -1541,7 +1541,7 @@ An anatomical {contrast}-reference map was computed after registration of
 
 
 def _pop(inlist):
-    if isinstance(inlist, (list, tuple)):
+    if isinstance(inlist, list | tuple):
         return inlist[0]
     return inlist
 

--- a/smriprep/workflows/anatomical.py
+++ b/smriprep/workflows/anatomical.py
@@ -285,45 +285,45 @@ def init_anat_preproc_wf(
 
     workflow.connect([
         (inputnode, anat_fit_wf, [
-            ("t1w", "inputnode.t1w"),
-            ("t2w", "inputnode.t2w"),
-            ("roi", "inputnode.roi"),
-            ("flair", "inputnode.flair"),
-            ("subjects_dir", "inputnode.subjects_dir"),
-            ("subject_id", "inputnode.subject_id"),
+            ('t1w', 'inputnode.t1w'),
+            ('t2w', 'inputnode.t2w'),
+            ('roi', 'inputnode.roi'),
+            ('flair', 'inputnode.flair'),
+            ('subjects_dir', 'inputnode.subjects_dir'),
+            ('subject_id', 'inputnode.subject_id'),
         ]),
         (anat_fit_wf, outputnode, [
-            ("outputnode.template", "template"),
-            ("outputnode.subjects_dir", "subjects_dir"),
-            ("outputnode.subject_id", "subject_id"),
-            ("outputnode.t1w_preproc", "t1w_preproc"),
-            ("outputnode.t1w_mask", "t1w_mask"),
-            ("outputnode.t1w_dseg", "t1w_dseg"),
-            ("outputnode.t1w_tpms", "t1w_tpms"),
-            ("outputnode.anat2std_xfm", "anat2std_xfm"),
-            ("outputnode.std2anat_xfm", "std2anat_xfm"),
-            ("outputnode.fsnative2t1w_xfm", "fsnative2t1w_xfm"),
-            ("outputnode.sphere_reg", "sphere_reg"),
-            (f"outputnode.sphere_reg_{'msm' if msm_sulc else 'fsLR'}", "sphere_reg_fsLR"),
-            ("outputnode.anat_ribbon", "anat_ribbon"),
+            ('outputnode.template', 'template'),
+            ('outputnode.subjects_dir', 'subjects_dir'),
+            ('outputnode.subject_id', 'subject_id'),
+            ('outputnode.t1w_preproc', 't1w_preproc'),
+            ('outputnode.t1w_mask', 't1w_mask'),
+            ('outputnode.t1w_dseg', 't1w_dseg'),
+            ('outputnode.t1w_tpms', 't1w_tpms'),
+            ('outputnode.anat2std_xfm', 'anat2std_xfm'),
+            ('outputnode.std2anat_xfm', 'std2anat_xfm'),
+            ('outputnode.fsnative2t1w_xfm', 'fsnative2t1w_xfm'),
+            ('outputnode.sphere_reg', 'sphere_reg'),
+            (f"outputnode.sphere_reg_{'msm' if msm_sulc else 'fsLR'}", 'sphere_reg_fsLR'),
+            ('outputnode.anat_ribbon', 'anat_ribbon'),
         ]),
         (anat_fit_wf, template_iterator_wf, [
-            ("outputnode.template", "inputnode.template"),
-            ("outputnode.anat2std_xfm", "inputnode.anat2std_xfm"),
+            ('outputnode.template', 'inputnode.template'),
+            ('outputnode.anat2std_xfm', 'inputnode.anat2std_xfm'),
         ]),
         (anat_fit_wf, ds_std_volumes_wf, [
             ('outputnode.t1w_valid_list', 'inputnode.source_files'),
-            ("outputnode.t1w_preproc", "inputnode.t1w_preproc"),
-            ("outputnode.t1w_mask", "inputnode.t1w_mask"),
-            ("outputnode.t1w_dseg", "inputnode.t1w_dseg"),
-            ("outputnode.t1w_tpms", "inputnode.t1w_tpms"),
+            ('outputnode.t1w_preproc', 'inputnode.t1w_preproc'),
+            ('outputnode.t1w_mask', 'inputnode.t1w_mask'),
+            ('outputnode.t1w_dseg', 'inputnode.t1w_dseg'),
+            ('outputnode.t1w_tpms', 'inputnode.t1w_tpms'),
         ]),
         (template_iterator_wf, ds_std_volumes_wf, [
-            ("outputnode.std_t1w", "inputnode.ref_file"),
-            ("outputnode.anat2std_xfm", "inputnode.anat2std_xfm"),
-            ("outputnode.space", "inputnode.space"),
-            ("outputnode.cohort", "inputnode.cohort"),
-            ("outputnode.resolution", "inputnode.resolution"),
+            ('outputnode.std_t1w', 'inputnode.ref_file'),
+            ('outputnode.anat2std_xfm', 'inputnode.anat2std_xfm'),
+            ('outputnode.space', 'inputnode.space'),
+            ('outputnode.cohort', 'inputnode.cohort'),
+            ('outputnode.resolution', 'inputnode.resolution'),
         ]),
     ])  # fmt:skip
 
@@ -403,14 +403,14 @@ def init_anat_preproc_wf(
                     ('outputnode.midthickness', 'inputnode.midthickness'),
                     (
                         f"outputnode.sphere_reg_{'msm' if msm_sulc else 'fsLR'}",
-                        "inputnode.sphere_reg_fsLR",
+                        'inputnode.sphere_reg_fsLR',
                     ),
                 ]),
                 (anat_fit_wf, morph_grayords_wf, [
                     ('outputnode.midthickness', 'inputnode.midthickness'),
                     (
                         f"outputnode.sphere_reg_{'msm' if msm_sulc else 'fsLR'}",
-                        "inputnode.sphere_reg_fsLR",
+                        'inputnode.sphere_reg_fsLR',
                     ),
                 ]),
                 (hcp_morphometrics_wf, morph_grayords_wf, [
@@ -698,24 +698,24 @@ BIDS dataset."""
     # fmt:off
     workflow.connect([
         (seg_buffer, outputnode, [
-            ("t1w_dseg", "t1w_dseg"),
-            ("t1w_tpms", "t1w_tpms"),
+            ('t1w_dseg', 't1w_dseg'),
+            ('t1w_tpms', 't1w_tpms'),
         ]),
-        (anat2std_buffer, outputnode, [("out", "anat2std_xfm")]),
-        (std2anat_buffer, outputnode, [("out", "std2anat_xfm")]),
-        (template_buffer, outputnode, [("out", "template")]),
-        (sourcefile_buffer, outputnode, [("source_files", "t1w_valid_list")]),
+        (anat2std_buffer, outputnode, [('out', 'anat2std_xfm')]),
+        (std2anat_buffer, outputnode, [('out', 'std2anat_xfm')]),
+        (template_buffer, outputnode, [('out', 'template')]),
+        (sourcefile_buffer, outputnode, [('source_files', 't1w_valid_list')]),
         (surfaces_buffer, outputnode, [
-            ("white", "white"),
-            ("pial", "pial"),
-            ("midthickness", "midthickness"),
-            ("sphere", "sphere"),
-            ("sphere_reg", "sphere_reg"),
-            ("thickness", "thickness"),
-            ("sulc", "sulc"),
+            ('white', 'white'),
+            ('pial', 'pial'),
+            ('midthickness', 'midthickness'),
+            ('sphere', 'sphere'),
+            ('sphere_reg', 'sphere_reg'),
+            ('thickness', 'thickness'),
+            ('sulc', 'sulc'),
         ]),
-        (fsLR_buffer, outputnode, [("sphere_reg_fsLR", "sphere_reg_fsLR")]),
-        (msm_buffer, outputnode, [("sphere_reg_msm", "sphere_reg_msm")]),
+        (fsLR_buffer, outputnode, [('sphere_reg_fsLR', 'sphere_reg_fsLR')]),
+        (msm_buffer, outputnode, [('sphere_reg_msm', 'sphere_reg_msm')]),
     ])
     # fmt:on
 
@@ -728,14 +728,14 @@ BIDS dataset."""
     # fmt:off
     workflow.connect([
         (outputnode, anat_reports_wf, [
-            ("t1w_valid_list", "inputnode.source_file"),
-            ("t1w_preproc", "inputnode.t1w_preproc"),
-            ("t1w_mask", "inputnode.t1w_mask"),
-            ("t1w_dseg", "inputnode.t1w_dseg"),
-            ("template", "inputnode.template"),
-            ("anat2std_xfm", "inputnode.anat2std_xfm"),
-            ("subjects_dir", "inputnode.subjects_dir"),
-            ("subject_id", "inputnode.subject_id"),
+            ('t1w_valid_list', 'inputnode.source_file'),
+            ('t1w_preproc', 'inputnode.t1w_preproc'),
+            ('t1w_mask', 'inputnode.t1w_mask'),
+            ('t1w_dseg', 'inputnode.t1w_dseg'),
+            ('template', 'inputnode.template'),
+            ('anat2std_xfm', 'inputnode.anat2std_xfm'),
+            ('subjects_dir', 'inputnode.subjects_dir'),
+            ('subject_id', 'inputnode.subject_id'),
         ]),
     ])
     # fmt:on
@@ -763,20 +763,20 @@ non-uniformity (INU) with `N4BiasFieldCorrection` [@n4], distributed with ANTs {
 
         # fmt:off
         workflow.connect([
-            (inputnode, anat_template_wf, [("t1w", "inputnode.anat_files")]),
-            (anat_template_wf, anat_validate, [("outputnode.anat_ref", "in_file")]),
+            (inputnode, anat_template_wf, [('t1w', 'inputnode.anat_files')]),
+            (anat_template_wf, anat_validate, [('outputnode.anat_ref', 'in_file')]),
             (anat_template_wf, sourcefile_buffer, [
-                ("outputnode.anat_valid_list", "source_files"),
+                ('outputnode.anat_valid_list', 'source_files'),
             ]),
             (anat_template_wf, anat_reports_wf, [
-                ("outputnode.out_report", "inputnode.t1w_conform_report"),
+                ('outputnode.out_report', 'inputnode.t1w_conform_report'),
             ]),
             (anat_template_wf, ds_template_wf, [
-                ("outputnode.anat_realign_xfm", "inputnode.t1w_ref_xfms"),
+                ('outputnode.anat_realign_xfm', 'inputnode.t1w_ref_xfms'),
             ]),
-            (sourcefile_buffer, ds_template_wf, [("source_files", "inputnode.source_files")]),
-            (t1w_buffer, ds_template_wf, [("t1w_preproc", "inputnode.t1w_preproc")]),
-            (ds_template_wf, outputnode, [("outputnode.t1w_preproc", "t1w_preproc")]),
+            (sourcefile_buffer, ds_template_wf, [('source_files', 'inputnode.source_files')]),
+            (t1w_buffer, ds_template_wf, [('t1w_preproc', 'inputnode.t1w_preproc')]),
+            (ds_template_wf, outputnode, [('outputnode.t1w_preproc', 't1w_preproc')]),
         ])
         # fmt:on
     else:
@@ -790,8 +790,8 @@ and used as T1w-reference throughout the workflow.
 
         # fmt:off
         workflow.connect([
-            (anat_validate, t1w_buffer, [("out_file", "t1w_preproc")]),
-            (t1w_buffer, outputnode, [("t1w_preproc", "t1w_preproc")]),
+            (anat_validate, t1w_buffer, [('out_file', 't1w_preproc')]),
+            (t1w_buffer, outputnode, [('t1w_preproc', 't1w_preproc')]),
         ])
         # fmt:on
 
@@ -821,17 +821,17 @@ as target template.
             )
             # fmt:off
             workflow.connect([
-                (anat_validate, brain_extraction_wf, [("out_file", "inputnode.in_files")]),
+                (anat_validate, brain_extraction_wf, [('out_file', 'inputnode.in_files')]),
                 (brain_extraction_wf, t1w_buffer, [
-                    ("outputnode.out_mask", "t1w_mask"),
-                    (("outputnode.out_file", _pop), "t1w_brain"),
-                    ("outputnode.out_segm", "ants_seg"),
+                    ('outputnode.out_mask', 't1w_mask'),
+                    (('outputnode.out_file', _pop), 't1w_brain'),
+                    ('outputnode.out_segm', 'ants_seg'),
                 ]),
             ])
             if not have_t1w:
                 workflow.connect([
                     (brain_extraction_wf, t1w_buffer, [
-                        (("outputnode.bias_corrected", _pop), "t1w_preproc"),
+                        (('outputnode.bias_corrected', _pop), 't1w_preproc'),
                     ]),
                 ])
             # fmt:on
@@ -848,12 +848,12 @@ derived from the input image.
             )
             # fmt:off
             workflow.connect([
-                (anat_validate, n4_only_wf, [("out_file", "inputnode.in_files")]),
+                (anat_validate, n4_only_wf, [('out_file', 'inputnode.in_files')]),
                 (n4_only_wf, t1w_buffer, [
-                    (("outputnode.bias_corrected", _pop), "t1w_preproc"),
-                    ("outputnode.out_mask", "t1w_mask"),
-                    (("outputnode.out_file", _pop), "t1w_brain"),
-                    ("outputnode.out_segm", "ants_seg"),
+                    (('outputnode.bias_corrected', _pop), 't1w_preproc'),
+                    ('outputnode.out_mask', 't1w_mask'),
+                    (('outputnode.out_file', _pop), 't1w_brain'),
+                    ('outputnode.out_segm', 'ants_seg'),
                 ]),
             ])
             # fmt:on
@@ -867,9 +867,9 @@ derived from the input image.
             binarize = pe.Node(Binarize(thresh_low=2), name='binarize')
             # fmt:off
             workflow.connect([
-                (anat_validate, binarize, [("out_file", "in_file")]),
-                (anat_validate, t1w_buffer, [("out_file", "t1w_brain")]),
-                (binarize, t1w_buffer, [("out_file", "t1w_mask")]),
+                (anat_validate, binarize, [('out_file', 'in_file')]),
+                (anat_validate, t1w_buffer, [('out_file', 't1w_brain')]),
+                (binarize, t1w_buffer, [('out_file', 't1w_mask')]),
             ])
             # fmt:on
 
@@ -881,9 +881,9 @@ derived from the input image.
         )
         # fmt:off
         workflow.connect([
-            (sourcefile_buffer, ds_t1w_mask_wf, [("source_files", "inputnode.source_files")]),
-            (refined_buffer, ds_t1w_mask_wf, [("t1w_mask", "inputnode.mask_file")]),
-            (ds_t1w_mask_wf, outputnode, [("outputnode.mask_file", "t1w_mask")]),
+            (sourcefile_buffer, ds_t1w_mask_wf, [('source_files', 'inputnode.source_files')]),
+            (refined_buffer, ds_t1w_mask_wf, [('t1w_mask', 'inputnode.mask_file')]),
+            (ds_t1w_mask_wf, outputnode, [('outputnode.mask_file', 't1w_mask')]),
         ])
         # fmt:on
     else:
@@ -904,10 +904,10 @@ A pre-computed brain mask was provided as input and used throughout the workflow
             )
             # fmt:off
             workflow.connect([
-                (apply_mask, n4_only_wf, [("out_file", "inputnode.in_files")]),
+                (apply_mask, n4_only_wf, [('out_file', 'inputnode.in_files')]),
                 (n4_only_wf, t1w_buffer, [
-                    (("outputnode.bias_corrected", _pop), "t1w_preproc"),
-                    (("outputnode.out_file", _pop), "t1w_brain"),
+                    (('outputnode.bias_corrected', _pop), 't1w_preproc'),
+                    (('outputnode.out_file', _pop), 't1w_brain'),
                 ]),
             ])
             # fmt:on
@@ -943,18 +943,18 @@ the brain-extracted T1w using `fast` [FSL {fsl_ver}, RRID:SCR_002823, @fsl_fast]
         if not have_dseg:
             ds_dseg_wf = init_ds_dseg_wf(output_dir=output_dir)
             workflow.connect([
-                (fast, lut_t1w_dseg, [("partial_volume_map", "in_dseg")]),
-                (sourcefile_buffer, ds_dseg_wf, [("source_files", "inputnode.source_files")]),
-                (lut_t1w_dseg, ds_dseg_wf, [("out", "inputnode.t1w_dseg")]),
-                (ds_dseg_wf, seg_buffer, [("outputnode.t1w_dseg", "t1w_dseg")]),
+                (fast, lut_t1w_dseg, [('partial_volume_map', 'in_dseg')]),
+                (sourcefile_buffer, ds_dseg_wf, [('source_files', 'inputnode.source_files')]),
+                (lut_t1w_dseg, ds_dseg_wf, [('out', 'inputnode.t1w_dseg')]),
+                (ds_dseg_wf, seg_buffer, [('outputnode.t1w_dseg', 't1w_dseg')]),
             ])
         if not have_tpms:
             ds_tpms_wf = init_ds_tpms_wf(output_dir=output_dir)
             workflow.connect([
-                (fast, fast2bids, [("partial_volume_files", "inlist")]),
-                (sourcefile_buffer, ds_tpms_wf, [("source_files", "inputnode.source_files")]),
-                (fast2bids, ds_tpms_wf, [("out", "inputnode.t1w_tpms")]),
-                (ds_tpms_wf, seg_buffer, [("outputnode.t1w_tpms", "t1w_tpms")]),
+                (fast, fast2bids, [('partial_volume_files', 'inlist')]),
+                (sourcefile_buffer, ds_tpms_wf, [('source_files', 'inputnode.source_files')]),
+                (fast2bids, ds_tpms_wf, [('out', 'inputnode.t1w_tpms')]),
+                (ds_tpms_wf, seg_buffer, [('outputnode.t1w_tpms', 't1w_tpms')]),
             ])
         # fmt:on
     else:
@@ -997,7 +997,7 @@ the brain-extracted T1w using `fast` [FSL {fsl_ver}, RRID:SCR_002823, @fsl_fast]
             (t1w_buffer, register_template_wf, [('t1w_preproc', 'inputnode.moving_image')]),
             (refined_buffer, register_template_wf, [('t1w_mask', 'inputnode.moving_mask')]),
             (sourcefile_buffer, ds_template_registration_wf, [
-                ("source_files", "inputnode.source_files")
+                ('source_files', 'inputnode.source_files')
             ]),
             (register_template_wf, ds_template_registration_wf, [
                 ('outputnode.template', 'inputnode.template'),
@@ -1017,8 +1017,8 @@ the brain-extracted T1w using `fast` [FSL {fsl_ver}, RRID:SCR_002823, @fsl_fast]
         # fmt:off
         workflow.connect([
             (t1w_buffer, refined_buffer, [
-                ("t1w_mask", "t1w_mask"),
-                ("t1w_brain", "t1w_brain"),
+                ('t1w_mask', 't1w_mask'),
+                ('t1w_brain', 't1w_brain'),
             ]),
         ])
         # fmt:on
@@ -1075,7 +1075,7 @@ A {t2w_or_flair} image was used to improve pial surface refinement.
         # fmt:off
         workflow.connect([
             (sourcefile_buffer, ds_fs_registration_wf, [
-                ("source_files", "inputnode.source_files"),
+                ('source_files', 'inputnode.source_files'),
             ]),
             (surface_recon_wf, ds_fs_registration_wf, [
                 ('outputnode.fsnative2t1w_xfm', 'inputnode.fsnative2t1w_xfm'),
@@ -1219,7 +1219,7 @@ A {t2w_or_flair} image was used to improve pial surface refinement.
             (gifti_surfaces_wf, surfaces_buffer, [
                 (f'outputnode.{surf}', surf) for surf in surfs
             ]),
-            (sourcefile_buffer, ds_surfaces_wf, [("source_files", "inputnode.source_files")]),
+            (sourcefile_buffer, ds_surfaces_wf, [('source_files', 'inputnode.source_files')]),
             (gifti_surfaces_wf, ds_surfaces_wf, [
                 (f'outputnode.{surf}', f'inputnode.{surf}') for surf in surfs
             ]),
@@ -1242,7 +1242,7 @@ A {t2w_or_flair} image was used to improve pial surface refinement.
             (gifti_spheres_wf, surfaces_buffer, [
                 (f'outputnode.{sphere}', sphere) for sphere in spheres
             ]),
-            (sourcefile_buffer, ds_spheres_wf, [("source_files", "inputnode.source_files")]),
+            (sourcefile_buffer, ds_spheres_wf, [('source_files', 'inputnode.source_files')]),
             (gifti_spheres_wf, ds_spheres_wf, [
                 (f'outputnode.{sphere}', f'inputnode.{sphere}') for sphere in spheres
             ]),
@@ -1265,7 +1265,7 @@ A {t2w_or_flair} image was used to improve pial surface refinement.
             (gifti_morph_wf, surfaces_buffer, [
                 (f'outputnode.{metric}', metric) for metric in metrics
             ]),
-            (sourcefile_buffer, ds_morph_wf, [("source_files", "inputnode.source_files")]),
+            (sourcefile_buffer, ds_morph_wf, [('source_files', 'inputnode.source_files')]),
             (gifti_morph_wf, ds_morph_wf, [
                 (f'outputnode.{metric}', f'inputnode.{metric}') for metric in metrics
             ]),
@@ -1284,17 +1284,17 @@ A {t2w_or_flair} image was used to improve pial surface refinement.
         # fmt:off
         workflow.connect([
             (t1w_buffer, anat_ribbon_wf, [
-                ("t1w_preproc", "inputnode.ref_file"),
+                ('t1w_preproc', 'inputnode.ref_file'),
             ]),
             (surfaces_buffer, anat_ribbon_wf, [
-                ("white", "inputnode.white"),
-                ("pial", "inputnode.pial"),
+                ('white', 'inputnode.white'),
+                ('pial', 'inputnode.pial'),
             ]),
-            (sourcefile_buffer, ds_ribbon_mask_wf, [("source_files", "inputnode.source_files")]),
+            (sourcefile_buffer, ds_ribbon_mask_wf, [('source_files', 'inputnode.source_files')]),
             (anat_ribbon_wf, ds_ribbon_mask_wf, [
-                ("outputnode.anat_ribbon", "inputnode.mask_file"),
+                ('outputnode.anat_ribbon', 'inputnode.mask_file'),
             ]),
-            (ds_ribbon_mask_wf, outputnode, [("outputnode.mask_file", "anat_ribbon")]),
+            (ds_ribbon_mask_wf, outputnode, [('outputnode.mask_file', 'anat_ribbon')]),
         ])
         # fmt:on
     else:
@@ -1315,7 +1315,7 @@ A {t2w_or_flair} image was used to improve pial surface refinement.
         # fmt:off
         workflow.connect([
             (surfaces_buffer, fsLR_reg_wf, [('sphere_reg', 'inputnode.sphere_reg')]),
-            (sourcefile_buffer, ds_fsLR_reg_wf, [("source_files", "inputnode.source_files")]),
+            (sourcefile_buffer, ds_fsLR_reg_wf, [('source_files', 'inputnode.source_files')]),
             (fsLR_reg_wf, ds_fsLR_reg_wf, [
                 ('outputnode.sphere_reg_fsLR', 'inputnode.sphere_reg_fsLR')
             ]),
@@ -1344,7 +1344,7 @@ A {t2w_or_flair} image was used to improve pial surface refinement.
                 ('sphere', 'inputnode.sphere'),
             ]),
             (fsLR_buffer, msm_sulc_wf, [('sphere_reg_fsLR', 'inputnode.sphere_reg_fsLR')]),
-            (sourcefile_buffer, ds_msmsulc_wf, [("source_files", "inputnode.source_files")]),
+            (sourcefile_buffer, ds_msmsulc_wf, [('source_files', 'inputnode.source_files')]),
             (msm_sulc_wf, ds_msmsulc_wf, [
                 ('outputnode.sphere_reg_fsLR', 'inputnode.sphere_reg_msm')
             ]),

--- a/smriprep/workflows/base.py
+++ b/smriprep/workflows/base.py
@@ -21,22 +21,20 @@
 #     https://www.nipreps.org/community/licensing/
 #
 """*sMRIPrep* base processing workflows."""
-import sys
 import os
+import sys
 from copy import deepcopy
 
 from nipype import __version__ as nipype_ver
-from nipype.pipeline import engine as pe
 from nipype.interfaces import utility as niu
-
+from nipype.pipeline import engine as pe
 from niworkflows.engine.workflows import LiterateWorkflow as Workflow
-from niworkflows.interfaces.bids import BIDSInfo, BIDSDataGrabber, BIDSFreeSurferDir
+from niworkflows.interfaces.bids import BIDSDataGrabber, BIDSFreeSurferDir, BIDSInfo
 from niworkflows.utils.bids import collect_data
 from niworkflows.utils.misc import fix_multi_T1w_source_name
 
-from ..interfaces import DerivativesDataSink
 from ..__about__ import __version__
-
+from ..interfaces import DerivativesDataSink
 from .anatomical import init_anat_preproc_wf
 
 
@@ -344,14 +342,14 @@ def init_single_subject_wf(
         )
 
     workflow = Workflow(name=name)
-    workflow.__desc__ = """
+    workflow.__desc__ = f"""
 Results included in this manuscript come from preprocessing
-performed using *sMRIPprep* {smriprep_ver}
+performed using *sMRIPprep* {__version__}
 (@fmriprep1; @fmriprep2; RRID:SCR_016216),
 which is based on *Nipype* {nipype_ver}
 (@nipype1; @nipype2; RRID:SCR_002502).
 
-""".format(smriprep_ver=__version__, nipype_ver=nipype_ver)
+"""
     workflow.__postdesc__ = """
 
 For more details of the pipeline, see [the section corresponding

--- a/smriprep/workflows/base.py
+++ b/smriprep/workflows/base.py
@@ -336,9 +336,7 @@ def init_single_subject_wf(
 
     if not subject_data['t1w']:
         raise Exception(
-            'No T1w images found for participant {}. ' 'All workflows require T1w images.'.format(
-                subject_id
-            )
+            f'No T1w images found for participant {subject_id}. All workflows require T1w images.'
         )
 
     workflow = Workflow(name=name)

--- a/smriprep/workflows/base.py
+++ b/smriprep/workflows/base.py
@@ -157,17 +157,17 @@ def init_smriprep_wf(
         A dict with the following structure {<suffix>:{<entity>:<filter>,...},...}
 
     """
-    smriprep_wf = Workflow(name="smriprep_wf")
+    smriprep_wf = Workflow(name='smriprep_wf')
     smriprep_wf.base_dir = work_dir
 
     if freesurfer:
         fsdir = pe.Node(
             BIDSFreeSurferDir(
                 derivatives=output_dir,
-                freesurfer_home=os.getenv("FREESURFER_HOME"),
+                freesurfer_home=os.getenv('FREESURFER_HOME'),
                 spaces=spaces.get_fs_spaces(),
             ),
-            name="fsdir_run_%s" % run_uuid.replace("-", "_"),
+            name='fsdir_run_%s' % run_uuid.replace('-', '_'),
             run_without_submitting=True,
         )
         if fs_subjects_dir is not None:
@@ -184,7 +184,7 @@ def init_smriprep_wf(
             longitudinal=longitudinal,
             low_mem=low_mem,
             msm_sulc=msm_sulc,
-            name="single_subject_%s_wf" % subject_id,
+            name='single_subject_%s_wf' % subject_id,
             omp_nthreads=omp_nthreads,
             output_dir=output_dir,
             skull_strip_fixed_seed=skull_strip_fixed_seed,
@@ -196,13 +196,13 @@ def init_smriprep_wf(
             cifti_output=cifti_output,
         )
 
-        single_subject_wf.config["execution"]["crashdump_dir"] = os.path.join(
-            output_dir, "smriprep", "sub-" + subject_id, "log", run_uuid
+        single_subject_wf.config['execution']['crashdump_dir'] = os.path.join(
+            output_dir, 'smriprep', 'sub-' + subject_id, 'log', run_uuid
         )
         for node in single_subject_wf._get_all_nodes():
             node.config = deepcopy(single_subject_wf.config)
         if freesurfer:
-            smriprep_wf.connect(fsdir, "subjects_dir", single_subject_wf, "inputnode.subjects_dir")
+            smriprep_wf.connect(fsdir, 'subjects_dir', single_subject_wf, 'inputnode.subjects_dir')
         else:
             smriprep_wf.add_nodes([single_subject_wf])
 
@@ -326,20 +326,21 @@ def init_single_subject_wf(
     """
     from ..interfaces.reports import AboutSummary, SubjectSummary
 
-    if name in ("single_subject_wf", "single_subject_smripreptest_wf"):
+    if name in ('single_subject_wf', 'single_subject_smripreptest_wf'):
         # for documentation purposes
         subject_data = {
-            "t1w": ["/completely/made/up/path/sub-01_T1w.nii.gz"],
-            "t2w": [],
-            "flair": [],
+            't1w': ['/completely/made/up/path/sub-01_T1w.nii.gz'],
+            't2w': [],
+            'flair': [],
         }
     else:
         subject_data = collect_data(layout, subject_id, bids_filters=bids_filters)[0]
 
-    if not subject_data["t1w"]:
+    if not subject_data['t1w']:
         raise Exception(
-            "No T1w images found for participant {}. "
-            "All workflows require T1w images.".format(subject_id)
+            'No T1w images found for participant {}. ' 'All workflows require T1w images.'.format(
+                subject_id
+            )
         )
 
     workflow = Workflow(name=name)
@@ -350,9 +351,7 @@ performed using *sMRIPprep* {smriprep_ver}
 which is based on *Nipype* {nipype_ver}
 (@nipype1; @nipype2; RRID:SCR_002502).
 
-""".format(
-        smriprep_ver=__version__, nipype_ver=nipype_ver
-    )
+""".format(smriprep_ver=__version__, nipype_ver=nipype_ver)
     workflow.__postdesc__ = """
 
 For more details of the pipeline, see [the section corresponding
@@ -369,49 +368,49 @@ to workflows in *sMRIPrep*'s documentation]\
 
     deriv_cache = {}
     std_spaces = spaces.get_spaces(nonstandard=False, dim=(3,))
-    std_spaces.append("fsnative")
+    std_spaces.append('fsnative')
     for deriv_dir in derivatives:
         deriv_cache.update(collect_derivatives(deriv_dir, subject_id, std_spaces))
 
-    inputnode = pe.Node(niu.IdentityInterface(fields=["subjects_dir"]), name="inputnode")
+    inputnode = pe.Node(niu.IdentityInterface(fields=['subjects_dir']), name='inputnode')
 
-    bidssrc = pe.Node(BIDSDataGrabber(subject_data=subject_data, anat_only=True), name="bidssrc")
+    bidssrc = pe.Node(BIDSDataGrabber(subject_data=subject_data, anat_only=True), name='bidssrc')
 
     bids_info = pe.Node(
-        BIDSInfo(bids_dir=layout.root), name="bids_info", run_without_submitting=True
+        BIDSInfo(bids_dir=layout.root), name='bids_info', run_without_submitting=True
     )
 
     summary = pe.Node(
         SubjectSummary(output_spaces=spaces.get_spaces(nonstandard=False)),
-        name="summary",
+        name='summary',
         run_without_submitting=True,
     )
 
     about = pe.Node(
-        AboutSummary(version=__version__, command=" ".join(sys.argv)),
-        name="about",
+        AboutSummary(version=__version__, command=' '.join(sys.argv)),
+        name='about',
         run_without_submitting=True,
     )
 
     ds_report_summary = pe.Node(
         DerivativesDataSink(
             base_directory=output_dir,
-            dismiss_entities=("session",),
-            desc="summary",
-            datatype="figures",
+            dismiss_entities=('session',),
+            desc='summary',
+            datatype='figures',
         ),
-        name="ds_report_summary",
+        name='ds_report_summary',
         run_without_submitting=True,
     )
 
     ds_report_about = pe.Node(
         DerivativesDataSink(
             base_directory=output_dir,
-            dismiss_entities=("session",),
-            desc="about",
-            datatype="figures",
+            dismiss_entities=('session',),
+            desc='about',
+            datatype='figures',
         ),
-        name="ds_report_about",
+        name='ds_report_about',
         run_without_submitting=True,
     )
 
@@ -425,10 +424,10 @@ to workflows in *sMRIPrep*'s documentation]\
         hires=hires,
         longitudinal=longitudinal,
         msm_sulc=msm_sulc,
-        name="anat_preproc_wf",
-        t1w=subject_data["t1w"],
-        t2w=subject_data["t2w"],
-        flair=subject_data["flair"],
+        name='anat_preproc_wf',
+        t1w=subject_data['t1w'],
+        t2w=subject_data['t2w'],
+        flair=subject_data['flair'],
         omp_nthreads=omp_nthreads,
         output_dir=output_dir,
         skull_strip_fixed_seed=skull_strip_fixed_seed,
@@ -462,6 +461,6 @@ to workflows in *sMRIPrep*'s documentation]\
 
 
 def _prefix(subid):
-    if subid.startswith("sub-"):
+    if subid.startswith('sub-'):
         return subid
-    return "-".join(("sub", subid))
+    return '-'.join(('sub', subid))

--- a/smriprep/workflows/fit/registration.py
+++ b/smriprep/workflows/fit/registration.py
@@ -22,17 +22,17 @@
 #
 """Spatial normalization workflows."""
 from collections import defaultdict
-from nipype.pipeline import engine as pe
-from nipype.interfaces import utility as niu
 
 from nipype.interfaces import ants
+from nipype.interfaces import utility as niu
 from nipype.interfaces.ants.base import Info as ANTsInfo
-
-from templateflow import __version__ as tf_ver
-from templateflow.api import get_metadata
+from nipype.pipeline import engine as pe
 from niworkflows.engine.workflows import LiterateWorkflow as Workflow
 from niworkflows.interfaces.norm import SpatialNormalization
-from ...interfaces.templateflow import TemplateFlowSelect, TemplateDesc
+from templateflow import __version__ as tf_ver
+from templateflow.api import get_metadata
+
+from ...interfaces.templateflow import TemplateDesc, TemplateFlowSelect
 
 
 def init_register_template_wf(

--- a/smriprep/workflows/fit/registration.py
+++ b/smriprep/workflows/fit/registration.py
@@ -115,8 +115,7 @@ The following template{tpls} were selected for spatial normalization
 and accessed with *TemplateFlow* [{tf_ver}, @templateflow]:
 """.format(
             ants_ver=ANTsInfo.version() or '(version unknown)',
-            targets='%s standard space%s'
-            % (
+            targets='{} standard space{}'.format(
                 defaultdict('several'.format, {1: 'one', 2: 'two', 3: 'three', 4: 'four'})[ntpls],
                 's' * (ntpls != 1),
             ),

--- a/smriprep/workflows/fit/registration.py
+++ b/smriprep/workflows/fit/registration.py
@@ -40,7 +40,7 @@ def init_register_template_wf(
     sloppy,
     omp_nthreads,
     templates,
-    name="register_template_wf",
+    name='register_template_wf',
 ):
     """
     Build an individual spatial normalization workflow using ``antsRegistration``.
@@ -114,74 +114,74 @@ using brain-extracted versions of both T1w reference and the T1w template.
 The following template{tpls} were selected for spatial normalization
 and accessed with *TemplateFlow* [{tf_ver}, @templateflow]:
 """.format(
-            ants_ver=ANTsInfo.version() or "(version unknown)",
-            targets="%s standard space%s"
+            ants_ver=ANTsInfo.version() or '(version unknown)',
+            targets='%s standard space%s'
             % (
-                defaultdict("several".format, {1: "one", 2: "two", 3: "three", 4: "four"})[ntpls],
-                "s" * (ntpls != 1),
+                defaultdict('several'.format, {1: 'one', 2: 'two', 3: 'three', 4: 'four'})[ntpls],
+                's' * (ntpls != 1),
             ),
-            targets_id=", ".join(templates),
+            targets_id=', '.join(templates),
             tf_ver=tf_ver,
-            tpls=(" was", "s were")[ntpls != 1],
+            tpls=(' was', 's were')[ntpls != 1],
         )
 
         # Append template citations to description
         for template in templates:
-            template_meta = get_metadata(template.split(":")[0])
-            template_refs = ["@%s" % template.split(":")[0].lower()]
+            template_meta = get_metadata(template.split(':')[0])
+            template_refs = ['@%s' % template.split(':')[0].lower()]
 
-            if template_meta.get("RRID", None):
-                template_refs += ["RRID:%s" % template_meta["RRID"]]
+            if template_meta.get('RRID', None):
+                template_refs += ['RRID:%s' % template_meta['RRID']]
 
             workflow.__desc__ += """\
 *{template_name}* [{template_refs}; TemplateFlow ID: {template}]""".format(
                 template=template,
-                template_name=template_meta["Name"],
-                template_refs=", ".join(template_refs),
+                template_name=template_meta['Name'],
+                template_refs=', '.join(template_refs),
             )
-            workflow.__desc__ += ".\n" if template == templates[-1] else ", "
+            workflow.__desc__ += '.\n' if template == templates[-1] else ', '
 
     inputnode = pe.Node(
         niu.IdentityInterface(
             fields=[
-                "lesion_mask",
-                "moving_image",
-                "moving_mask",
-                "template",
+                'lesion_mask',
+                'moving_image',
+                'moving_mask',
+                'template',
             ]
         ),
-        name="inputnode",
+        name='inputnode',
     )
-    inputnode.iterables = [("template", templates)]
+    inputnode.iterables = [('template', templates)]
 
     out_fields = [
-        "anat2std_xfm",
-        "std2anat_xfm",
-        "template",
-        "template_spec",
+        'anat2std_xfm',
+        'std2anat_xfm',
+        'template',
+        'template_spec',
     ]
     outputnode = _make_outputnode(workflow, out_fields, joinsource='inputnode')
 
-    split_desc = pe.Node(TemplateDesc(), run_without_submitting=True, name="split_desc")
+    split_desc = pe.Node(TemplateDesc(), run_without_submitting=True, name='split_desc')
 
     tf_select = pe.Node(
         TemplateFlowSelect(resolution=1 + sloppy),
-        name="tf_select",
+        name='tf_select',
         run_without_submitting=True,
     )
 
     # With the improvements from nipreps/niworkflows#342 this truncation is now necessary
     trunc_mov = pe.Node(
-        ants.ImageMath(operation="TruncateImageIntensity", op2="0.01 0.999 256"),
-        name="trunc_mov",
+        ants.ImageMath(operation='TruncateImageIntensity', op2='0.01 0.999 256'),
+        name='trunc_mov',
     )
 
     registration = pe.Node(
         SpatialNormalization(
             float=True,
-            flavor=["precise", "testing"][sloppy],
+            flavor=['precise', 'testing'][sloppy],
         ),
-        name="registration",
+        name='registration',
         n_procs=omp_nthreads,
         mem_gb=2,
     )
@@ -219,10 +219,10 @@ and accessed with *TemplateFlow* [{tf_ver}, @templateflow]:
 
 def _make_outputnode(workflow, out_fields, joinsource):
     if joinsource:
-        pout = pe.Node(niu.IdentityInterface(fields=out_fields), name="poutputnode")
+        pout = pe.Node(niu.IdentityInterface(fields=out_fields), name='poutputnode')
         out = pe.JoinNode(
-            niu.IdentityInterface(fields=out_fields), name="outputnode", joinsource=joinsource
+            niu.IdentityInterface(fields=out_fields), name='outputnode', joinsource=joinsource
         )
         workflow.connect([(pout, out, [(f, f) for f in out_fields])])
         return pout
-    return pe.Node(niu.IdentityInterface(fields=out_fields), name="outputnode")
+    return pe.Node(niu.IdentityInterface(fields=out_fields), name='outputnode')

--- a/smriprep/workflows/outputs.py
+++ b/smriprep/workflows/outputs.py
@@ -1199,7 +1199,7 @@ def init_template_iterator_wf(*, spaces, name='template_iterator_wf'):
 def _bids_relative(in_files, bids_root):
     from pathlib import Path
 
-    if not isinstance(in_files, (list, tuple)):
+    if not isinstance(in_files, list | tuple):
         in_files = [in_files]
     ret = []
     for file in in_files:

--- a/smriprep/workflows/outputs.py
+++ b/smriprep/workflows/outputs.py
@@ -34,10 +34,10 @@ from niworkflows.engine.workflows import LiterateWorkflow as Workflow
 from ..interfaces import DerivativesDataSink
 from ..interfaces.templateflow import TemplateFlowSelect
 
-BIDS_TISSUE_ORDER = ("GM", "WM", "CSF")
+BIDS_TISSUE_ORDER = ('GM', 'WM', 'CSF')
 
 
-def init_anat_reports_wf(*, spaces, freesurfer, output_dir, name="anat_reports_wf"):
+def init_anat_reports_wf(*, spaces, freesurfer, output_dir, name='anat_reports_wf'):
     """
     Set up a battery of datasinks to store reports in the right location.
 
@@ -83,36 +83,36 @@ def init_anat_reports_wf(*, spaces, freesurfer, output_dir, name="anat_reports_w
     workflow = Workflow(name=name)
 
     inputfields = [
-        "source_file",
-        "t1w_preproc",
-        "t1w_mask",
-        "t1w_dseg",
-        "template",
-        "anat2std_xfm",
+        'source_file',
+        't1w_preproc',
+        't1w_mask',
+        't1w_dseg',
+        'template',
+        'anat2std_xfm',
         # May be missing
-        "t1w_conform_report",
-        "subject_id",
-        "subjects_dir",
+        't1w_conform_report',
+        'subject_id',
+        'subjects_dir',
     ]
-    inputnode = pe.Node(niu.IdentityInterface(fields=inputfields), name="inputnode")
+    inputnode = pe.Node(niu.IdentityInterface(fields=inputfields), name='inputnode')
 
-    seg_rpt = pe.Node(ROIsPlot(colors=["b", "magenta"], levels=[1.5, 2.5]), name="seg_rpt")
+    seg_rpt = pe.Node(ROIsPlot(colors=['b', 'magenta'], levels=[1.5, 2.5]), name='seg_rpt')
 
     t1w_conform_check = pe.Node(
         niu.Function(function=_empty_report),
-        name="t1w_conform_check",
+        name='t1w_conform_check',
         run_without_submitting=True,
     )
 
     ds_t1w_conform_report = pe.Node(
-        DerivativesDataSink(base_directory=output_dir, desc="conform", datatype="figures"),
-        name="ds_t1w_conform_report",
+        DerivativesDataSink(base_directory=output_dir, desc='conform', datatype='figures'),
+        name='ds_t1w_conform_report',
         run_without_submitting=True,
     )
 
     ds_t1w_dseg_mask_report = pe.Node(
-        DerivativesDataSink(base_directory=output_dir, suffix="dseg", datatype="figures"),
-        name="ds_t1w_dseg_mask_report",
+        DerivativesDataSink(base_directory=output_dir, suffix='dseg', datatype='figures'),
+        name='ds_t1w_dseg_mask_report',
         run_without_submitting=True,
     )
 
@@ -129,42 +129,42 @@ def init_anat_reports_wf(*, spaces, freesurfer, output_dir, name="anat_reports_w
     ])
     # fmt:on
 
-    if getattr(spaces, "_cached") is not None and spaces.cached.references:
+    if getattr(spaces, '_cached') is not None and spaces.cached.references:
         template_iterator_wf = init_template_iterator_wf(spaces=spaces)
         t1w_std = pe.Node(
             ApplyTransforms(
                 dimension=3,
                 default_value=0,
                 float=True,
-                interpolation="LanczosWindowedSinc",
+                interpolation='LanczosWindowedSinc',
             ),
-            name="t1w_std",
+            name='t1w_std',
         )
         mask_std = pe.Node(
             ApplyTransforms(
                 dimension=3,
                 default_value=0,
                 float=True,
-                interpolation="MultiLabel",
+                interpolation='MultiLabel',
             ),
-            name="mask_std",
+            name='mask_std',
         )
 
         # Generate reportlets showing spatial normalization
         norm_msk = pe.Node(
             niu.Function(
                 function=_rpt_masks,
-                output_names=["before", "after"],
-                input_names=["mask_file", "before", "after", "after_mask"],
+                output_names=['before', 'after'],
+                input_names=['mask_file', 'before', 'after', 'after_mask'],
             ),
-            name="norm_msk",
+            name='norm_msk',
         )
-        norm_rpt = pe.Node(SimpleBeforeAfter(), name="norm_rpt", mem_gb=0.1)
-        norm_rpt.inputs.after_label = "Participant"  # after
+        norm_rpt = pe.Node(SimpleBeforeAfter(), name='norm_rpt', mem_gb=0.1)
+        norm_rpt.inputs.after_label = 'Participant'  # after
 
         ds_std_t1w_report = pe.Node(
-            DerivativesDataSink(base_directory=output_dir, suffix="T1w", datatype="figures"),
-            name="ds_std_t1w_report",
+            DerivativesDataSink(base_directory=output_dir, suffix='T1w', datatype='figures'),
+            name='ds_std_t1w_report',
             run_without_submitting=True,
         )
 
@@ -204,12 +204,12 @@ def init_anat_reports_wf(*, spaces, freesurfer, output_dir, name="anat_reports_w
     if freesurfer:
         from ..interfaces.reports import FSSurfaceReport
 
-        recon_report = pe.Node(FSSurfaceReport(), name="recon_report")
+        recon_report = pe.Node(FSSurfaceReport(), name='recon_report')
         recon_report.interface._always_run = True
 
         ds_recon_report = pe.Node(
-            DerivativesDataSink(base_directory=output_dir, desc="reconall", datatype="figures"),
-            name="ds_recon_report",
+            DerivativesDataSink(base_directory=output_dir, desc='reconall', datatype='figures'),
+            name='ds_recon_report',
             run_without_submitting=True,
         )
         # fmt:off
@@ -228,7 +228,7 @@ def init_ds_template_wf(
     *,
     num_t1w,
     output_dir,
-    name="ds_template_wf",
+    name='ds_template_wf',
 ):
     """
     Save the subject-specific template
@@ -263,18 +263,18 @@ def init_ds_template_wf(
     inputnode = pe.Node(
         niu.IdentityInterface(
             fields=[
-                "source_files",
-                "t1w_ref_xfms",
-                "t1w_preproc",
+                'source_files',
+                't1w_ref_xfms',
+                't1w_preproc',
             ]
         ),
-        name="inputnode",
+        name='inputnode',
     )
-    outputnode = pe.Node(niu.IdentityInterface(fields=["t1w_preproc"]), name="outputnode")
+    outputnode = pe.Node(niu.IdentityInterface(fields=['t1w_preproc']), name='outputnode')
 
     ds_t1w_preproc = pe.Node(
-        DerivativesDataSink(base_directory=output_dir, desc="preproc", compress=True),
-        name="ds_t1w_preproc",
+        DerivativesDataSink(base_directory=output_dir, desc='preproc', compress=True),
+        name='ds_t1w_preproc',
         run_without_submitting=True,
     )
     ds_t1w_preproc.inputs.SkullStripped = False
@@ -293,14 +293,14 @@ def init_ds_template_wf(
         ds_t1w_ref_xfms = pe.MapNode(
             DerivativesDataSink(
                 base_directory=output_dir,
-                to="T1w",
-                mode="image",
-                suffix="xfm",
-                extension="txt",
-                **{"from": "orig"},
+                to='T1w',
+                mode='image',
+                suffix='xfm',
+                extension='txt',
+                **{'from': 'orig'},
             ),
-            iterfield=["source_file", "in_file"],
-            name="ds_t1w_ref_xfms",
+            iterfield=['source_file', 'in_file'],
+            name='ds_t1w_ref_xfms',
             run_without_submitting=True,
         )
         # fmt:off
@@ -318,7 +318,7 @@ def init_ds_mask_wf(
     bids_root: str,
     output_dir: str,
     mask_type: str,
-    name="ds_mask_wf",
+    name='ds_mask_wf',
 ):
     """
     Save the subject brain mask
@@ -348,28 +348,28 @@ def init_ds_mask_wf(
     workflow = Workflow(name=name)
 
     inputnode = pe.Node(
-        niu.IdentityInterface(fields=["source_files", "mask_file"]),
-        name="inputnode",
+        niu.IdentityInterface(fields=['source_files', 'mask_file']),
+        name='inputnode',
     )
-    outputnode = pe.Node(niu.IdentityInterface(fields=["mask_file"]), name="outputnode")
+    outputnode = pe.Node(niu.IdentityInterface(fields=['mask_file']), name='outputnode')
 
-    raw_sources = pe.Node(niu.Function(function=_bids_relative), name="raw_sources")
+    raw_sources = pe.Node(niu.Function(function=_bids_relative), name='raw_sources')
     raw_sources.inputs.bids_root = bids_root
 
     ds_mask = pe.Node(
         DerivativesDataSink(
             base_directory=output_dir,
             desc=mask_type,
-            suffix="mask",
+            suffix='mask',
             compress=True,
         ),
-        name="ds_t1w_mask",
+        name='ds_t1w_mask',
         run_without_submitting=True,
     )
-    if mask_type == "brain":
-        ds_mask.inputs.Type = "Brain"
+    if mask_type == 'brain':
+        ds_mask.inputs.Type = 'Brain'
     else:
-        ds_mask.inputs.Type = "ROI"
+        ds_mask.inputs.Type = 'ROI'
 
     # fmt:off
     workflow.connect([
@@ -384,7 +384,7 @@ def init_ds_mask_wf(
     return workflow
 
 
-def init_ds_dseg_wf(*, output_dir, name="ds_dseg_wf"):
+def init_ds_dseg_wf(*, output_dir, name='ds_dseg_wf'):
     """
     Save discrete segmentations
 
@@ -411,19 +411,19 @@ def init_ds_dseg_wf(*, output_dir, name="ds_dseg_wf"):
     workflow = Workflow(name=name)
 
     inputnode = pe.Node(
-        niu.IdentityInterface(fields=["source_files", "t1w_dseg"]),
-        name="inputnode",
+        niu.IdentityInterface(fields=['source_files', 't1w_dseg']),
+        name='inputnode',
     )
-    outputnode = pe.Node(niu.IdentityInterface(fields=["t1w_dseg"]), name="outputnode")
+    outputnode = pe.Node(niu.IdentityInterface(fields=['t1w_dseg']), name='outputnode')
 
     ds_t1w_dseg = pe.Node(
         DerivativesDataSink(
             base_directory=output_dir,
-            suffix="dseg",
+            suffix='dseg',
             compress=True,
-            dismiss_entities=["desc"],
+            dismiss_entities=['desc'],
         ),
-        name="ds_t1w_dseg",
+        name='ds_t1w_dseg',
         run_without_submitting=True,
     )
 
@@ -438,7 +438,7 @@ def init_ds_dseg_wf(*, output_dir, name="ds_dseg_wf"):
     return workflow
 
 
-def init_ds_tpms_wf(*, output_dir, name="ds_tpms_wf", tpm_labels=BIDS_TISSUE_ORDER):
+def init_ds_tpms_wf(*, output_dir, name='ds_tpms_wf', tpm_labels=BIDS_TISSUE_ORDER):
     """
     Save tissue probability maps
 
@@ -467,19 +467,19 @@ def init_ds_tpms_wf(*, output_dir, name="ds_tpms_wf", tpm_labels=BIDS_TISSUE_ORD
     workflow = Workflow(name=name)
 
     inputnode = pe.Node(
-        niu.IdentityInterface(fields=["source_files", "t1w_tpms"]),
-        name="inputnode",
+        niu.IdentityInterface(fields=['source_files', 't1w_tpms']),
+        name='inputnode',
     )
-    outputnode = pe.Node(niu.IdentityInterface(fields=["t1w_tpms"]), name="outputnode")
+    outputnode = pe.Node(niu.IdentityInterface(fields=['t1w_tpms']), name='outputnode')
 
     ds_t1w_tpms = pe.Node(
         DerivativesDataSink(
             base_directory=output_dir,
-            suffix="probseg",
+            suffix='probseg',
             compress=True,
-            dismiss_entities=["desc"],
+            dismiss_entities=['desc'],
         ),
-        name="ds_t1w_tpms",
+        name='ds_t1w_tpms',
         run_without_submitting=True,
     )
     ds_t1w_tpms.inputs.label = tpm_labels
@@ -498,7 +498,7 @@ def init_ds_tpms_wf(*, output_dir, name="ds_tpms_wf", tpm_labels=BIDS_TISSUE_ORD
 def init_ds_template_registration_wf(
     *,
     output_dir,
-    name="ds_template_registration_wf",
+    name='ds_template_registration_wf',
 ):
     """
     Save template registration transforms
@@ -526,37 +526,37 @@ def init_ds_template_registration_wf(
     workflow = Workflow(name=name)
 
     inputnode = pe.Node(
-        niu.IdentityInterface(fields=["template", "source_files", "anat2std_xfm", "std2anat_xfm"]),
-        name="inputnode",
+        niu.IdentityInterface(fields=['template', 'source_files', 'anat2std_xfm', 'std2anat_xfm']),
+        name='inputnode',
     )
     outputnode = pe.Node(
-        niu.IdentityInterface(fields=["anat2std_xfm", "std2anat_xfm"]),
-        name="outputnode",
+        niu.IdentityInterface(fields=['anat2std_xfm', 'std2anat_xfm']),
+        name='outputnode',
     )
 
     ds_std2t1w_xfm = pe.MapNode(
         DerivativesDataSink(
             base_directory=output_dir,
-            to="T1w",
-            mode="image",
-            suffix="xfm",
-            dismiss_entities=["desc"],
+            to='T1w',
+            mode='image',
+            suffix='xfm',
+            dismiss_entities=['desc'],
         ),
-        iterfield=("in_file", "from"),
-        name="ds_std2t1w_xfm",
+        iterfield=('in_file', 'from'),
+        name='ds_std2t1w_xfm',
         run_without_submitting=True,
     )
 
     ds_t1w2std_xfm = pe.MapNode(
         DerivativesDataSink(
             base_directory=output_dir,
-            mode="image",
-            suffix="xfm",
-            dismiss_entities=["desc"],
-            **{"from": "T1w"},
+            mode='image',
+            suffix='xfm',
+            dismiss_entities=['desc'],
+            **{'from': 'T1w'},
         ),
-        iterfield=("in_file", "to"),
-        name="ds_t1w2std_xfm",
+        iterfield=('in_file', 'to'),
+        name='ds_t1w2std_xfm',
         run_without_submitting=True,
     )
 
@@ -581,7 +581,7 @@ def init_ds_template_registration_wf(
 def init_ds_fs_registration_wf(
     *,
     output_dir,
-    name="ds_fs_registration_wf",
+    name='ds_fs_registration_wf',
 ):
     """
     Save rigid registration between subject anatomical template and FreeSurfer T1.mgz
@@ -614,40 +614,40 @@ def init_ds_fs_registration_wf(
     workflow = Workflow(name=name)
 
     inputnode = pe.Node(
-        niu.IdentityInterface(fields=["source_files", "fsnative2t1w_xfm"]),
-        name="inputnode",
+        niu.IdentityInterface(fields=['source_files', 'fsnative2t1w_xfm']),
+        name='inputnode',
     )
     outputnode = pe.Node(
-        niu.IdentityInterface(fields=["fsnative2t1w_xfm", "t1w2fsnative_xfm"]),
-        name="outputnode",
+        niu.IdentityInterface(fields=['fsnative2t1w_xfm', 't1w2fsnative_xfm']),
+        name='outputnode',
     )
 
     from niworkflows.interfaces.nitransforms import ConcatenateXFMs
 
     # FS native space transforms
-    lta2itk = pe.Node(ConcatenateXFMs(inverse=True), name="lta2itk", run_without_submitting=True)
+    lta2itk = pe.Node(ConcatenateXFMs(inverse=True), name='lta2itk', run_without_submitting=True)
     ds_t1w_fsnative = pe.Node(
         DerivativesDataSink(
             base_directory=output_dir,
-            mode="image",
-            to="fsnative",
-            suffix="xfm",
-            extension="txt",
-            **{"from": "T1w"},
+            mode='image',
+            to='fsnative',
+            suffix='xfm',
+            extension='txt',
+            **{'from': 'T1w'},
         ),
-        name="ds_t1w_fsnative",
+        name='ds_t1w_fsnative',
         run_without_submitting=True,
     )
     ds_fsnative_t1w = pe.Node(
         DerivativesDataSink(
             base_directory=output_dir,
-            mode="image",
-            to="T1w",
-            suffix="xfm",
-            extension="txt",
-            **{"from": "fsnative"},
+            mode='image',
+            to='T1w',
+            suffix='xfm',
+            extension='txt',
+            **{'from': 'fsnative'},
         ),
-        name="ds_fsnative_t1w",
+        name='ds_fsnative_t1w',
         run_without_submitting=True,
     )
 
@@ -670,7 +670,7 @@ def init_ds_surfaces_wf(
     bids_root: str,
     output_dir: str,
     surfaces: list[str],
-    name="ds_surfaces_wf",
+    name='ds_surfaces_wf',
 ) -> Workflow:
     """
     Save GIFTI surfaces
@@ -702,31 +702,31 @@ def init_ds_surfaces_wf(
     workflow = Workflow(name=name)
 
     inputnode = pe.Node(
-        niu.IdentityInterface(fields=["source_files"] + surfaces),
-        name="inputnode",
+        niu.IdentityInterface(fields=['source_files'] + surfaces),
+        name='inputnode',
     )
-    outputnode = pe.Node(niu.IdentityInterface(fields=surfaces), name="outputnode")
+    outputnode = pe.Node(niu.IdentityInterface(fields=surfaces), name='outputnode')
 
     for surf in surfaces:
         ds_surf = pe.MapNode(
             DerivativesDataSink(
                 base_directory=output_dir,
-                hemi=["L", "R"],
-                suffix=surf.split("_")[0],  # Split for sphere_reg and sphere_reg_fsLR
-                extension=".surf.gii",
+                hemi=['L', 'R'],
+                suffix=surf.split('_')[0],  # Split for sphere_reg and sphere_reg_fsLR
+                extension='.surf.gii',
             ),
-            iterfield=("in_file", "hemi"),
-            name=f"ds_{surf}",
+            iterfield=('in_file', 'hemi'),
+            name=f'ds_{surf}',
             run_without_submitting=True,
         )
-        if surf.startswith("sphere_reg"):
-            if surf == "sphere_reg_msm":
-                ds_surf.inputs.desc = "msmsulc"
-                ds_surf.inputs.space = "fsLR"
+        if surf.startswith('sphere_reg'):
+            if surf == 'sphere_reg_msm':
+                ds_surf.inputs.desc = 'msmsulc'
+                ds_surf.inputs.space = 'fsLR'
             else:
-                ds_surf.inputs.desc = "reg"
-                if surf == "sphere_reg_fsLR":
-                    ds_surf.inputs.space = "fsLR"
+                ds_surf.inputs.desc = 'reg'
+                if surf == 'sphere_reg_fsLR':
+                    ds_surf.inputs.space = 'fsLR'
 
         # fmt:off
         workflow.connect([
@@ -743,7 +743,7 @@ def init_ds_surface_metrics_wf(
     bids_root: str,
     output_dir: str,
     metrics: list[str],
-    name="ds_surface_metrics_wf",
+    name='ds_surface_metrics_wf',
 ) -> Workflow:
     """
     Save GIFTI surface metrics
@@ -775,21 +775,21 @@ def init_ds_surface_metrics_wf(
     workflow = Workflow(name=name)
 
     inputnode = pe.Node(
-        niu.IdentityInterface(fields=["source_files"] + metrics),
-        name="inputnode",
+        niu.IdentityInterface(fields=['source_files'] + metrics),
+        name='inputnode',
     )
-    outputnode = pe.Node(niu.IdentityInterface(fields=metrics), name="outputnode")
+    outputnode = pe.Node(niu.IdentityInterface(fields=metrics), name='outputnode')
 
     for metric in metrics:
         ds_surf = pe.MapNode(
             DerivativesDataSink(
                 base_directory=output_dir,
-                hemi=["L", "R"],
+                hemi=['L', 'R'],
                 suffix=metric,
-                extension=".shape.gii",
+                extension='.shape.gii',
             ),
-            iterfield=("in_file", "hemi"),
-            name=f"ds_{metric}",
+            iterfield=('in_file', 'hemi'),
+            name=f'ds_{metric}',
             run_without_submitting=True,
         )
 
@@ -808,8 +808,8 @@ def init_ds_grayord_metrics_wf(
     bids_root: str,
     output_dir: str,
     metrics: list[str],
-    cifti_output: ty.Literal["91k", "170k"],
-    name="ds_grayord_metrics_wf",
+    cifti_output: ty.Literal['91k', '170k'],
+    name='ds_grayord_metrics_wf',
 ) -> Workflow:
     """
     Save CIFTI-2 surface metrics
@@ -846,11 +846,11 @@ def init_ds_grayord_metrics_wf(
 
     inputnode = pe.Node(
         niu.IdentityInterface(
-            fields=["source_files"] + metrics + [f"{m}_metadata" for m in metrics]
+            fields=['source_files'] + metrics + [f'{m}_metadata' for m in metrics]
         ),
-        name="inputnode",
+        name='inputnode',
     )
-    outputnode = pe.Node(niu.IdentityInterface(fields=metrics), name="outputnode")
+    outputnode = pe.Node(niu.IdentityInterface(fields=metrics), name='outputnode')
 
     for metric in metrics:
         ds_metric = pe.Node(
@@ -860,9 +860,9 @@ def init_ds_grayord_metrics_wf(
                 density=cifti_output,
                 suffix=metric,
                 compress=False,
-                extension=".dscalar.nii",
+                extension='.dscalar.nii',
             ),
-            name=f"ds_{metric}",
+            name=f'ds_{metric}',
             run_without_submitting=True,
         )
 
@@ -882,10 +882,9 @@ def init_ds_anat_volumes_wf(
     *,
     bids_root: str,
     output_dir: str,
-    name="ds_anat_volumes_wf",
+    name='ds_anat_volumes_wf',
     tpm_labels=BIDS_TISSUE_ORDER,
 ) -> pe.Workflow:
-
     workflow = pe.Workflow(name=name)
     inputnode = pe.Node(
         niu.IdentityInterface(
@@ -912,7 +911,7 @@ def init_ds_anat_volumes_wf(
     raw_sources = pe.Node(niu.Function(function=_bids_relative), name='raw_sources')
     raw_sources.inputs.bids_root = bids_root
 
-    gen_ref = pe.Node(GenerateSamplingReference(), name="gen_ref", mem_gb=0.01)
+    gen_ref = pe.Node(GenerateSamplingReference(), name='gen_ref', mem_gb=0.01)
 
     # Mask T1w preproc images
     mask_t1w = pe.Node(ApplyMask(), name='mask_t1w')
@@ -923,48 +922,46 @@ def init_ds_anat_volumes_wf(
             dimension=3,
             default_value=0,
             float=True,
-            interpolation="LanczosWindowedSinc",
+            interpolation='LanczosWindowedSinc',
         ),
-        name="anat2std_t1w",
+        name='anat2std_t1w',
     )
 
-    anat2std_mask = pe.Node(ApplyTransforms(interpolation="MultiLabel"), name="anat2std_mask")
-    anat2std_dseg = pe.Node(ApplyTransforms(interpolation="MultiLabel"), name="anat2std_dseg")
+    anat2std_mask = pe.Node(ApplyTransforms(interpolation='MultiLabel'), name='anat2std_mask')
+    anat2std_dseg = pe.Node(ApplyTransforms(interpolation='MultiLabel'), name='anat2std_dseg')
     anat2std_tpms = pe.MapNode(
-        ApplyTransforms(dimension=3, default_value=0, float=True, interpolation="Gaussian"),
-        iterfield=["input_image"],
-        name="anat2std_tpms",
+        ApplyTransforms(dimension=3, default_value=0, float=True, interpolation='Gaussian'),
+        iterfield=['input_image'],
+        name='anat2std_tpms',
     )
 
     ds_std_t1w = pe.Node(
         DerivativesDataSink(
             base_directory=output_dir,
-            desc="preproc",
+            desc='preproc',
             compress=True,
         ),
-        name="ds_std_t1w",
+        name='ds_std_t1w',
         run_without_submitting=True,
     )
     ds_std_t1w.inputs.SkullStripped = True
 
     ds_std_mask = pe.Node(
-        DerivativesDataSink(
-            base_directory=output_dir, desc="brain", suffix="mask", compress=True
-        ),
-        name="ds_std_mask",
+        DerivativesDataSink(base_directory=output_dir, desc='brain', suffix='mask', compress=True),
+        name='ds_std_mask',
         run_without_submitting=True,
     )
-    ds_std_mask.inputs.Type = "Brain"
+    ds_std_mask.inputs.Type = 'Brain'
 
     ds_std_dseg = pe.Node(
-        DerivativesDataSink(base_directory=output_dir, suffix="dseg", compress=True),
-        name="ds_std_dseg",
+        DerivativesDataSink(base_directory=output_dir, suffix='dseg', compress=True),
+        name='ds_std_dseg',
         run_without_submitting=True,
     )
 
     ds_std_tpms = pe.Node(
-        DerivativesDataSink(base_directory=output_dir, suffix="probseg", compress=True),
-        name="ds_std_tpms",
+        DerivativesDataSink(base_directory=output_dir, suffix='probseg', compress=True),
+        name='ds_std_tpms',
         run_without_submitting=True,
     )
 
@@ -1021,8 +1018,8 @@ def init_anat_second_derivatives_wf(
     *,
     bids_root: str,
     output_dir: str,
-    cifti_output: ty.Literal["91k", "170k", False],
-    name="anat_second_derivatives_wf",
+    cifti_output: ty.Literal['91k', '170k', False],
+    name='anat_second_derivatives_wf',
     tpm_labels=BIDS_TISSUE_ORDER,
 ):
     """
@@ -1076,29 +1073,29 @@ def init_anat_second_derivatives_wf(
     inputnode = pe.Node(
         niu.IdentityInterface(
             fields=[
-                "template",
-                "source_files",
-                "t1w_fs_aseg",
-                "t1w_fs_aparc",
+                'template',
+                'source_files',
+                't1w_fs_aseg',
+                't1w_fs_aparc',
             ]
         ),
-        name="inputnode",
+        name='inputnode',
     )
 
-    raw_sources = pe.Node(niu.Function(function=_bids_relative), name="raw_sources")
+    raw_sources = pe.Node(niu.Function(function=_bids_relative), name='raw_sources')
     raw_sources.inputs.bids_root = bids_root
 
     # Parcellations
     ds_t1w_fsaseg = pe.Node(
-        DerivativesDataSink(base_directory=output_dir, desc="aseg", suffix="dseg", compress=True),
-        name="ds_t1w_fsaseg",
+        DerivativesDataSink(base_directory=output_dir, desc='aseg', suffix='dseg', compress=True),
+        name='ds_t1w_fsaseg',
         run_without_submitting=True,
     )
     ds_t1w_fsparc = pe.Node(
         DerivativesDataSink(
-            base_directory=output_dir, desc="aparcaseg", suffix="dseg", compress=True
+            base_directory=output_dir, desc='aparcaseg', suffix='dseg', compress=True
         ),
-        name="ds_t1w_fsparc",
+        name='ds_t1w_fsparc',
         run_without_submitting=True,
     )
 
@@ -1114,7 +1111,7 @@ def init_anat_second_derivatives_wf(
     return workflow
 
 
-def init_template_iterator_wf(*, spaces, name="template_iterator_wf"):
+def init_template_iterator_wf(*, spaces, name='template_iterator_wf'):
     """Prepare the necessary components to resample an image to a template space
 
     This produces a workflow with an unjoined iterable named "spacesource".
@@ -1127,42 +1124,42 @@ def init_template_iterator_wf(*, spaces, name="template_iterator_wf"):
     workflow = pe.Workflow(name=name)
 
     inputnode = pe.Node(
-        niu.IdentityInterface(fields=["template", "anat2std_xfm"]),
-        name="inputnode",
+        niu.IdentityInterface(fields=['template', 'anat2std_xfm']),
+        name='inputnode',
     )
     outputnode = pe.Node(
         niu.IdentityInterface(
             fields=[
-                "space",
-                "resolution",
-                "cohort",
-                "anat2std_xfm",
-                "std_t1w",
-                "std_mask",
+                'space',
+                'resolution',
+                'cohort',
+                'anat2std_xfm',
+                'std_t1w',
+                'std_mask',
             ],
         ),
-        name="outputnode",
+        name='outputnode',
     )
 
-    spacesource = pe.Node(SpaceDataSource(), name="spacesource", run_without_submitting=True)
+    spacesource = pe.Node(SpaceDataSource(), name='spacesource', run_without_submitting=True)
     spacesource.iterables = (
-        "in_tuple",
+        'in_tuple',
         [(s.fullname, s.spec) for s in spaces.cached.get_standard(dim=(3,))],
     )
 
     gen_tplid = pe.Node(
         niu.Function(function=_fmt_cohort),
-        name="gen_tplid",
+        name='gen_tplid',
         run_without_submitting=True,
     )
 
     select_xfm = pe.Node(
-        KeySelect(fields=["anat2std_xfm"]),
-        name="select_xfm",
+        KeySelect(fields=['anat2std_xfm']),
+        name='select_xfm',
         run_without_submitting=True,
     )
     select_tpl = pe.Node(
-        TemplateFlowSelect(resolution=1), name="select_tpl", run_without_submitting=True
+        TemplateFlowSelect(resolution=1), name='select_tpl', run_without_submitting=True
     )
 
     # fmt:off
@@ -1219,33 +1216,33 @@ def _rpt_masks(mask_file, before, after, after_mask=None):
 
     msk = nb.load(mask_file).get_fdata() > 0
     bnii = nb.load(before)
-    nb.Nifti1Image(bnii.get_fdata() * msk, bnii.affine, bnii.header).to_filename("before.nii.gz")
+    nb.Nifti1Image(bnii.get_fdata() * msk, bnii.affine, bnii.header).to_filename('before.nii.gz')
     if after_mask is not None:
         msk = nb.load(after_mask).get_fdata() > 0
 
     anii = nb.load(after)
-    nb.Nifti1Image(anii.get_fdata() * msk, anii.affine, anii.header).to_filename("after.nii.gz")
-    return abspath("before.nii.gz"), abspath("after.nii.gz")
+    nb.Nifti1Image(anii.get_fdata() * msk, anii.affine, anii.header).to_filename('after.nii.gz')
+    return abspath('before.nii.gz'), abspath('after.nii.gz')
 
 
 def _drop_cohort(in_template):
     if isinstance(in_template, str):
-        return in_template.split(":")[0]
+        return in_template.split(':')[0]
     return [_drop_cohort(v) for v in in_template]
 
 
 def _pick_cohort(in_template):
     if isinstance(in_template, str):
-        if "cohort-" not in in_template:
+        if 'cohort-' not in in_template:
             from nipype.interfaces.base import Undefined
 
             return Undefined
-        return in_template.split("cohort-")[-1].split(":")[0]
+        return in_template.split('cohort-')[-1].split(':')[0]
     return [_pick_cohort(v) for v in in_template]
 
 
 def _fmt(in_template):
-    return in_template.replace(":", "_")
+    return in_template.replace(':', '_')
 
 
 def _empty_report(in_file=None):
@@ -1255,7 +1252,7 @@ def _empty_report(in_file=None):
     if in_file is not None and isdefined(in_file):
         return in_file
 
-    out_file = Path("tmp-report.html").absolute()
+    out_file = Path('tmp-report.html').absolute()
     out_file.write_text(
         """\
                 <h4 class="elem-title">A previously computed T1w template was provided.</h4>
@@ -1265,7 +1262,7 @@ def _empty_report(in_file=None):
 
 
 def _is_native(value):
-    return value == "native"
+    return value == 'native'
 
 
 def _no_native(value):
@@ -1286,14 +1283,14 @@ def _fmt_cohort(template, cohort=None):
     from nipype.interfaces.base import isdefined
 
     if cohort and isdefined(cohort):
-        return f"{template}:cohort-{cohort}"
+        return f'{template}:cohort-{cohort}'
     return template
 
 
 def _combine_cohort(in_template):
     if isinstance(in_template, str):
-        template = in_template.split(":")[0]
-        if "cohort-" not in in_template:
+        template = in_template.split(':')[0]
+        if 'cohort-' not in in_template:
             return template
         return f"{template}+{in_template.split('cohort-')[-1].split(':')[0]}"
     return [_combine_cohort(v) for v in in_template]

--- a/smriprep/workflows/outputs.py
+++ b/smriprep/workflows/outputs.py
@@ -23,13 +23,13 @@
 """Writing outputs."""
 import typing as ty
 
-from nipype.pipeline import engine as pe
 from nipype.interfaces import utility as niu
+from nipype.pipeline import engine as pe
+from niworkflows.engine.workflows import LiterateWorkflow as Workflow
 from niworkflows.interfaces.fixes import FixHeaderApplyTransforms as ApplyTransforms
 from niworkflows.interfaces.nibabel import ApplyMask, GenerateSamplingReference
 from niworkflows.interfaces.space import SpaceDataSource
 from niworkflows.interfaces.utility import KeySelect
-from niworkflows.engine.workflows import LiterateWorkflow as Workflow
 
 from ..interfaces import DerivativesDataSink
 from ..interfaces.templateflow import TemplateFlowSelect
@@ -75,10 +75,10 @@ def init_anat_reports_wf(*, spaces, freesurfer, output_dir, name='anat_reports_w
         Template space and specifications
 
     """
+    from niworkflows.interfaces.reportlets.masks import ROIsPlot
     from niworkflows.interfaces.reportlets.registration import (
         SimpleBeforeAfterRPT as SimpleBeforeAfter,
     )
-    from niworkflows.interfaces.reportlets.masks import ROIsPlot
 
     workflow = Workflow(name=name)
 
@@ -129,7 +129,7 @@ def init_anat_reports_wf(*, spaces, freesurfer, output_dir, name='anat_reports_w
     ])
     # fmt:on
 
-    if getattr(spaces, '_cached') is not None and spaces.cached.references:
+    if spaces._cached is not None and spaces.cached.references:
         template_iterator_wf = init_template_iterator_wf(spaces=spaces)
         t1w_std = pe.Node(
             ApplyTransforms(
@@ -1212,6 +1212,7 @@ def _bids_relative(in_files, bids_root):
 
 def _rpt_masks(mask_file, before, after, after_mask=None):
     from os.path import abspath
+
     import nibabel as nb
 
     msk = nb.load(mask_file).get_fdata() > 0
@@ -1247,6 +1248,7 @@ def _fmt(in_template):
 
 def _empty_report(in_file=None):
     from pathlib import Path
+
     from nipype.interfaces.base import isdefined
 
     if in_file is not None and isdefined(in_file):
@@ -1274,6 +1276,7 @@ def _no_native(value):
 
 def _drop_path(in_path):
     from pathlib import Path
+
     from templateflow.conf import TF_HOME
 
     return str(Path(in_path).relative_to(TF_HOME))

--- a/smriprep/workflows/outputs.py
+++ b/smriprep/workflows/outputs.py
@@ -1270,7 +1270,7 @@ def _is_native(value):
 def _no_native(value):
     try:
         return int(value)
-    except Exception:
+    except (TypeError, ValueError):
         return 1
 
 

--- a/smriprep/workflows/outputs.py
+++ b/smriprep/workflows/outputs.py
@@ -171,18 +171,18 @@ def init_anat_reports_wf(*, spaces, freesurfer, output_dir, name='anat_reports_w
         # fmt:off
         workflow.connect([
             (inputnode, template_iterator_wf, [
-                ("template", "inputnode.template"),
-                ("anat2std_xfm", "inputnode.anat2std_xfm"),
+                ('template', 'inputnode.template'),
+                ('anat2std_xfm', 'inputnode.anat2std_xfm'),
             ]),
-            (inputnode, t1w_std, [("t1w_preproc", "input_image")]),
-            (inputnode, mask_std, [("t1w_mask", "input_image")]),
+            (inputnode, t1w_std, [('t1w_preproc', 'input_image')]),
+            (inputnode, mask_std, [('t1w_mask', 'input_image')]),
             (template_iterator_wf, t1w_std, [
-                ("outputnode.anat2std_xfm", "transforms"),
-                ("outputnode.std_t1w", "reference_image"),
+                ('outputnode.anat2std_xfm', 'transforms'),
+                ('outputnode.std_t1w', 'reference_image'),
             ]),
             (template_iterator_wf, mask_std, [
-                ("outputnode.anat2std_xfm", "transforms"),
-                ("outputnode.std_t1w", "reference_image"),
+                ('outputnode.anat2std_xfm', 'transforms'),
+                ('outputnode.std_t1w', 'reference_image'),
             ]),
             (template_iterator_wf, norm_rpt, [('outputnode.space', 'before_label')]),
             (t1w_std, norm_msk, [('output_image', 'after')]),
@@ -283,7 +283,7 @@ def init_ds_template_wf(
     workflow.connect([
         (inputnode, ds_t1w_preproc, [('t1w_preproc', 'in_file'),
                                      ('source_files', 'source_file')]),
-        (ds_t1w_preproc, outputnode, [("out_file", "t1w_preproc")]),
+        (ds_t1w_preproc, outputnode, [('out_file', 't1w_preproc')]),
     ])
     # fmt:on
 
@@ -488,7 +488,7 @@ def init_ds_tpms_wf(*, output_dir, name='ds_tpms_wf', tpm_labels=BIDS_TISSUE_ORD
     workflow.connect([
         (inputnode, ds_t1w_tpms, [('t1w_tpms', 'in_file'),
                                   ('source_files', 'source_file')]),
-        (ds_t1w_tpms, outputnode, [("out_file", "t1w_tpms")]),
+        (ds_t1w_tpms, outputnode, [('out_file', 't1w_tpms')]),
     ])
     # fmt:on
 
@@ -570,8 +570,8 @@ def init_ds_template_registration_wf(
             ('std2anat_xfm', 'in_file'),
             (('template', _combine_cohort), 'from'),
             ('source_files', 'source_file')]),
-        (ds_t1w2std_xfm, outputnode, [("out_file", "anat2std_xfm")]),
-        (ds_std2t1w_xfm, outputnode, [("out_file", "std2anat_xfm")]),
+        (ds_t1w2std_xfm, outputnode, [('out_file', 'anat2std_xfm')]),
+        (ds_std2t1w_xfm, outputnode, [('out_file', 'std2anat_xfm')]),
     ])
     # fmt:on
 
@@ -972,22 +972,22 @@ def init_ds_anat_volumes_wf(
 
     workflow.connect([
         (inputnode, gen_ref, [
-            ("ref_file", "fixed_image"),
-            (("resolution", _is_native), "keep_native"),
+            ('ref_file', 'fixed_image'),
+            (('resolution', _is_native), 'keep_native'),
         ]),
         (inputnode, mask_t1w, [
-            ("t1w_preproc", "in_file"),
-            ("t1w_mask", "in_mask"),
+            ('t1w_preproc', 'in_file'),
+            ('t1w_mask', 'in_mask'),
         ]),
-        (mask_t1w, anat2std_t1w, [("out_file", "input_image")]),
-        (inputnode, anat2std_mask, [("t1w_mask", "input_image")]),
-        (inputnode, anat2std_dseg, [("t1w_dseg", "input_image")]),
-        (inputnode, anat2std_tpms, [("t1w_tpms", "input_image")]),
-        (inputnode, gen_ref, [("t1w_preproc", "moving_image")]),
-        (anat2std_t1w, ds_std_t1w, [("output_image", "in_file")]),
-        (anat2std_mask, ds_std_mask, [("output_image", "in_file")]),
-        (anat2std_dseg, ds_std_dseg, [("output_image", "in_file")]),
-        (anat2std_tpms, ds_std_tpms, [("output_image", "in_file")]),
+        (mask_t1w, anat2std_t1w, [('out_file', 'input_image')]),
+        (inputnode, anat2std_mask, [('t1w_mask', 'input_image')]),
+        (inputnode, anat2std_dseg, [('t1w_dseg', 'input_image')]),
+        (inputnode, anat2std_tpms, [('t1w_tpms', 'input_image')]),
+        (inputnode, gen_ref, [('t1w_preproc', 'moving_image')]),
+        (anat2std_t1w, ds_std_t1w, [('output_image', 'in_file')]),
+        (anat2std_mask, ds_std_mask, [('output_image', 'in_file')]),
+        (anat2std_dseg, ds_std_dseg, [('output_image', 'in_file')]),
+        (anat2std_tpms, ds_std_tpms, [('output_image', 'in_file')]),
     ])  # fmt:skip
 
     workflow.connect(
@@ -1179,16 +1179,16 @@ def init_template_iterator_wf(*, spaces, name='template_iterator_wf'):
             (('resolution', _no_native), 'resolution'),
         ]),
         (spacesource, outputnode, [
-            ("space", "space"),
-            ("resolution", "resolution"),
-            ("cohort", "cohort"),
+            ('space', 'space'),
+            ('resolution', 'resolution'),
+            ('cohort', 'cohort'),
         ]),
         (select_xfm, outputnode, [
-            ("anat2std_xfm", "anat2std_xfm"),
+            ('anat2std_xfm', 'anat2std_xfm'),
         ]),
         (select_tpl, outputnode, [
-            ("t1w_file", "std_t1w"),
-            ("brain_mask", "std_mask"),
+            ('t1w_file', 'std_t1w'),
+            ('brain_mask', 'std_mask'),
         ]),
     ])
     # fmt:on

--- a/smriprep/workflows/surfaces.py
+++ b/smriprep/workflows/surfaces.py
@@ -35,9 +35,12 @@ from nipype.interfaces import utility as niu
 from nipype.interfaces.base import Undefined
 from nipype.pipeline import engine as pe
 from niworkflows.engine.workflows import LiterateWorkflow as Workflow
-from niworkflows.interfaces.freesurfer import FSDetectInputs, FSInjectBrainExtracted
+from niworkflows.interfaces.freesurfer import (
+    FSDetectInputs,
+    FSInjectBrainExtracted,
+    RefineBrainMask,
+)
 from niworkflows.interfaces.freesurfer import PatchedRobustRegister as RobustRegister
-from niworkflows.interfaces.freesurfer import RefineBrainMask
 from niworkflows.interfaces.nitransforms import ConcatenateXFMs
 from niworkflows.interfaces.utility import KeySelect
 from niworkflows.interfaces.workbench import (
@@ -817,7 +820,7 @@ def init_msm_sulc_wf(*, sloppy: bool = False, name: str = 'msm_sulc_wf'):
 
 def init_gifti_surfaces_wf(
     *,
-    surfaces: ty.List[str] = ['pial', 'midthickness', 'inflated', 'white'],
+    surfaces: list[str] = ['pial', 'midthickness', 'inflated', 'white'],
     to_scanner: bool = True,
     name: str = 'gifti_surface_wf',
 ):
@@ -914,7 +917,7 @@ def init_gifti_surfaces_wf(
 
 def init_gifti_morphometrics_wf(
     *,
-    morphometrics: ty.List[str] = ['thickness', 'curv', 'sulc'],
+    morphometrics: list[str] = ['thickness', 'curv', 'sulc'],
     name: str = 'gifti_morphometrics_wf',
 ):
     r"""

--- a/smriprep/workflows/surfaces.py
+++ b/smriprep/workflows/surfaces.py
@@ -1292,16 +1292,16 @@ def init_anat_ribbon_wf(name='anat_ribbon_wf'):
     workflow.connect(
         [
             (inputnode, create_wm_distvol, [
-                ("white", "surf_file"),
-                ("ref_file", "ref_file"),
+                ('white', 'surf_file'),
+                ('ref_file', 'ref_file'),
             ]),
             (inputnode, create_pial_distvol, [
-                ("pial", "surf_file"),
-                ("ref_file", "ref_file"),
+                ('pial', 'surf_file'),
+                ('ref_file', 'ref_file'),
             ]),
-            (create_wm_distvol, make_ribbon, [("out_file", "white_distvols")]),
-            (create_pial_distvol, make_ribbon, [("out_file", "pial_distvols")]),
-            (make_ribbon, outputnode, [("ribbon", "anat_ribbon")]),
+            (create_wm_distvol, make_ribbon, [('out_file', 'white_distvols')]),
+            (create_pial_distvol, make_ribbon, [('out_file', 'pial_distvols')]),
+            (make_ribbon, outputnode, [('ribbon', 'anat_ribbon')]),
         ]
     )
     # fmt: on

--- a/smriprep/workflows/surfaces.py
+++ b/smriprep/workflows/surfaces.py
@@ -1611,7 +1611,8 @@ def _extract_fs_fields(filenames: str | list[str]) -> tuple[str, str]:
     paths = [Path(fn) for fn in filenames]
     sub_dir = paths[0].parent.parent
     subjects_dir, subject_id = sub_dir.parent, sub_dir.name
-    assert all(path == subjects_dir / subject_id / 'surf' / path.name for path in paths)
+    if not all(path.parent.parent == sub_dir for path in paths):
+        raise ValueError(f'Expected surface files from one subject.\nReceived: {filenames}')
     return str(subjects_dir), subject_id
 
 

--- a/smriprep/workflows/surfaces.py
+++ b/smriprep/workflows/surfaces.py
@@ -697,10 +697,10 @@ def init_fsLR_reg_wf(*, name='fsLR_reg_wf'):
 
     # Via
     # ${CARET7DIR}/wb_command -surface-sphere-project-unproject
-    #   "$AtlasSpaceFolder"/"$NativeFolder"/"$Subject"."$Hemisphere".sphere.reg.native.surf.gii
-    #   "$AtlasSpaceFolder"/fsaverage/"$Subject"."$Hemisphere".sphere."$HighResMesh"k_fs_"$Hemisphere".surf.gii
-    #   "$AtlasSpaceFolder"/fsaverage/"$Subject"."$Hemisphere".def_sphere."$HighResMesh"k_fs_"$Hemisphere".surf.gii
-    #   "$AtlasSpaceFolder"/"$NativeFolder"/"$Subject"."$Hemisphere".sphere.reg.reg_LR.native.surf.gii
+    #   "$NativeFolder"/"$Subject"."$Hemisphere".sphere.reg.native.surf.gii
+    #   fsaverage/"$Subject"."$Hemisphere".sphere."$HighResMesh"k_fs_"$Hemisphere".surf.gii
+    #   fsaverage/"$Subject"."$Hemisphere".def_sphere."$HighResMesh"k_fs_"$Hemisphere".surf.gii
+    #   "$NativeFolder"/"$Subject"."$Hemisphere".sphere.reg.reg_LR.native.surf.gii
     project_unproject = pe.MapNode(
         SurfaceSphereProjectUnproject(),
         iterfield=['sphere_in', 'sphere_project_to', 'sphere_unproject_from'],
@@ -820,7 +820,7 @@ def init_msm_sulc_wf(*, sloppy: bool = False, name: str = 'msm_sulc_wf'):
 
 def init_gifti_surfaces_wf(
     *,
-    surfaces: list[str] = ['pial', 'midthickness', 'inflated', 'white'],
+    surfaces: list[str] = ('pial', 'midthickness', 'inflated', 'white'),
     to_scanner: bool = True,
     name: str = 'gifti_surface_wf',
 ):
@@ -917,7 +917,7 @@ def init_gifti_surfaces_wf(
 
 def init_gifti_morphometrics_wf(
     *,
-    morphometrics: list[str] = ['thickness', 'curv', 'sulc'],
+    morphometrics: list[str] = ('thickness', 'curv', 'sulc'),
     name: str = 'gifti_morphometrics_wf',
 ):
     r"""

--- a/smriprep/workflows/surfaces.py
+++ b/smriprep/workflows/surfaces.py
@@ -62,7 +62,7 @@ def init_surface_recon_wf(
     omp_nthreads: int,
     hires: bool,
     precomputed: dict,
-    name="surface_recon_wf",
+    name='surface_recon_wf',
 ):
     r"""
     Reconstruct anatomical surfaces using FreeSurfer's ``recon-all``.
@@ -171,70 +171,68 @@ RRID:SCR_001847, @fs_reconall], and the brain mask estimated
 previously was refined with a custom variation of the method to reconcile
 ANTs-derived and FreeSurfer-derived segmentations of the cortical
 gray-matter of Mindboggle [RRID:SCR_002438, @mindboggle].
-""".format(
-        fs_ver=fs.Info().looseversion() or "<ver>"
-    )
+""".format(fs_ver=fs.Info().looseversion() or '<ver>')
 
     inputnode = pe.Node(
         niu.IdentityInterface(
             fields=[
-                "t1w",
-                "t2w",
-                "flair",
-                "skullstripped_t1",
-                "subjects_dir",
-                "subject_id",
+                't1w',
+                't2w',
+                'flair',
+                'skullstripped_t1',
+                'subjects_dir',
+                'subject_id',
             ]
         ),
-        name="inputnode",
+        name='inputnode',
     )
     outputnode = pe.Node(
         niu.IdentityInterface(
             fields=[
-                "subjects_dir",
-                "subject_id",
-                "t1w2fsnative_xfm",
-                "fsnative2t1w_xfm",
+                'subjects_dir',
+                'subject_id',
+                't1w2fsnative_xfm',
+                'fsnative2t1w_xfm',
             ]
         ),
-        name="outputnode",
+        name='outputnode',
     )
 
-    recon_config = pe.Node(FSDetectInputs(hires_enabled=hires), name="recon_config")
+    recon_config = pe.Node(FSDetectInputs(hires_enabled=hires), name='recon_config')
 
-    fov_check = pe.Node(niu.Function(function=_check_cw256), name="fov_check")
+    fov_check = pe.Node(niu.Function(function=_check_cw256), name='fov_check')
     fov_check.inputs.default_flags = ['-noskullstrip', '-noT2pial', '-noFLAIRpial']
 
     autorecon1 = pe.Node(
-        ReconAll(directive="autorecon1", openmp=omp_nthreads),
-        name="autorecon1",
+        ReconAll(directive='autorecon1', openmp=omp_nthreads),
+        name='autorecon1',
         n_procs=omp_nthreads,
         mem_gb=5,
     )
     autorecon1.interface._can_resume = False
     autorecon1.interface._always_run = True
 
-    skull_strip_extern = pe.Node(FSInjectBrainExtracted(), name="skull_strip_extern")
+    skull_strip_extern = pe.Node(FSInjectBrainExtracted(), name='skull_strip_extern')
 
     autorecon_resume_wf = init_autorecon_resume_wf(omp_nthreads=omp_nthreads)
 
-    get_surfaces = pe.Node(nio.FreeSurferSource(), name="get_surfaces")
+    get_surfaces = pe.Node(nio.FreeSurferSource(), name='get_surfaces')
 
     midthickness = pe.MapNode(
-        MakeMidthickness(thickness=True, distance=0.5, out_name="midthickness"),
-        iterfield="in_file",
-        name="midthickness",
+        MakeMidthickness(thickness=True, distance=0.5, out_name='midthickness'),
+        iterfield='in_file',
+        name='midthickness',
         n_procs=min(omp_nthreads, 12),
     )
 
-    save_midthickness = pe.Node(nio.DataSink(parameterization=False), name="save_midthickness")
+    save_midthickness = pe.Node(nio.DataSink(parameterization=False), name='save_midthickness')
 
     sync = pe.Node(
         niu.Function(
             function=_extract_fs_fields,
             output_names=['subjects_dir', 'subject_id'],
         ),
-        name="sync",
+        name='sync',
     )
 
     workflow.connect([
@@ -281,9 +279,9 @@ gray-matter of Mindboggle [RRID:SCR_002438, @mindboggle].
                             ('subject_id', 'subject_id')]),
     ])  # fmt:skip
 
-    if "fsnative" not in precomputed.get("transforms", {}):
+    if 'fsnative' not in precomputed.get('transforms', {}):
         fsnative2t1w_xfm = pe.Node(
-            RobustRegister(auto_sens=True, est_int_scale=True), name="fsnative2t1w_xfm"
+            RobustRegister(auto_sens=True, est_int_scale=True), name='fsnative2t1w_xfm'
         )
 
         workflow.connect([
@@ -295,7 +293,7 @@ gray-matter of Mindboggle [RRID:SCR_002438, @mindboggle].
     return workflow
 
 
-def init_refinement_wf(*, name="refinement_wf"):
+def init_refinement_wf(*, name='refinement_wf'):
     r"""
     Refine ANTs brain extraction with FreeSurfer segmentation
 
@@ -357,33 +355,31 @@ RRID:SCR_001847, @fs_reconall], and the brain mask estimated
 previously was refined with a custom variation of the method to reconcile
 ANTs-derived and FreeSurfer-derived segmentations of the cortical
 gray-matter of Mindboggle [RRID:SCR_002438, @mindboggle].
-""".format(
-        fs_ver=fs.Info().looseversion() or "<ver>"
-    )
+""".format(fs_ver=fs.Info().looseversion() or '<ver>')
 
     inputnode = pe.Node(
         niu.IdentityInterface(
             fields=[
-                "reference_image",
-                "ants_segs",
-                "fsnative2t1w_xfm",
-                "subjects_dir",
-                "subject_id",
+                'reference_image',
+                'ants_segs',
+                'fsnative2t1w_xfm',
+                'subjects_dir',
+                'subject_id',
             ]
         ),
-        name="inputnode",
+        name='inputnode',
     )
     outputnode = pe.Node(
         niu.IdentityInterface(
             fields=[
-                "out_brainmask",
+                'out_brainmask',
             ]
         ),
-        name="outputnode",
+        name='outputnode',
     )
 
     aseg_to_native_wf = init_segs_to_native_wf()
-    refine = pe.Node(RefineBrainMask(), name="refine")
+    refine = pe.Node(RefineBrainMask(), name='refine')
 
     # fmt:off
     workflow.connect([
@@ -404,7 +400,7 @@ gray-matter of Mindboggle [RRID:SCR_002438, @mindboggle].
     return workflow
 
 
-def init_autorecon_resume_wf(*, omp_nthreads, name="autorecon_resume_wf"):
+def init_autorecon_resume_wf(*, omp_nthreads, name='autorecon_resume_wf'):
     r"""
     Resume recon-all execution, assuming the `-autorecon1` stage has been completed.
 
@@ -467,50 +463,50 @@ def init_autorecon_resume_wf(*, omp_nthreads, name="autorecon_resume_wf"):
     workflow = Workflow(name=name)
 
     inputnode = pe.Node(
-        niu.IdentityInterface(fields=["subjects_dir", "subject_id", "use_T2", "use_FLAIR"]),
-        name="inputnode",
+        niu.IdentityInterface(fields=['subjects_dir', 'subject_id', 'use_T2', 'use_FLAIR']),
+        name='inputnode',
     )
 
     outputnode = pe.Node(
-        niu.IdentityInterface(fields=["subjects_dir", "subject_id"]), name="outputnode"
+        niu.IdentityInterface(fields=['subjects_dir', 'subject_id']), name='outputnode'
     )
 
     # FreeSurfer 7.3 removed gcareg from autorecon2-volonly
     # Adding it directly in would force it to run every time
     gcareg = pe.Node(
-        ReconAll(directive=Undefined, steps=["gcareg"], openmp=omp_nthreads),
+        ReconAll(directive=Undefined, steps=['gcareg'], openmp=omp_nthreads),
         n_procs=omp_nthreads,
         mem_gb=5,
-        name="gcareg",
+        name='gcareg',
     )
     gcareg.interface._always_run = True
 
     autorecon2_vol = pe.Node(
-        ReconAll(directive="autorecon2-volonly", openmp=omp_nthreads),
+        ReconAll(directive='autorecon2-volonly', openmp=omp_nthreads),
         n_procs=omp_nthreads,
         mem_gb=5,
-        name="autorecon2_vol",
+        name='autorecon2_vol',
     )
     autorecon2_vol.interface._always_run = True
 
     autorecon_surfs = pe.MapNode(
         ReconAll(
-            directive="autorecon-hemi",
+            directive='autorecon-hemi',
             flags=[
-                "-noparcstats",
-                "-noparcstats2",
-                "-noparcstats3",
-                "-nohyporelabel",
-                "-nobalabels",
+                '-noparcstats',
+                '-noparcstats2',
+                '-noparcstats3',
+                '-nohyporelabel',
+                '-nobalabels',
             ],
             openmp=omp_nthreads,
         ),
-        iterfield="hemi",
+        iterfield='hemi',
         n_procs=omp_nthreads,
         mem_gb=5,
-        name="autorecon_surfs",
+        name='autorecon_surfs',
     )
-    autorecon_surfs.inputs.hemi = ["lh", "rh"]
+    autorecon_surfs.inputs.hemi = ['lh', 'rh']
     autorecon_surfs.interface._always_run = True
 
     # -cortribbon is a prerequisite for -parcstats, -parcstats2, -parcstats3
@@ -519,31 +515,31 @@ def init_autorecon_resume_wf(*, omp_nthreads, name="autorecon_resume_wf"):
     # Parallelizing by hemisphere saves ~30 minutes over simply enabling
     # OpenMP on an 8 core machine.
     cortribbon = pe.Node(
-        ReconAll(directive=Undefined, steps=["cortribbon"], parallel=True),
+        ReconAll(directive=Undefined, steps=['cortribbon'], parallel=True),
         n_procs=2,
-        name="cortribbon",
+        name='cortribbon',
     )
     cortribbon.interface._always_run = True
 
     # -parcstats* can be run per-hemisphere
     # -hyporelabel is volumetric, even though it's part of -autorecon-hemi
     parcstats = pe.MapNode(
-        ReconAll(directive="autorecon-hemi", flags=["-nohyporelabel"], openmp=omp_nthreads),
-        iterfield="hemi",
+        ReconAll(directive='autorecon-hemi', flags=['-nohyporelabel'], openmp=omp_nthreads),
+        iterfield='hemi',
         n_procs=omp_nthreads,
         mem_gb=5,
-        name="parcstats",
+        name='parcstats',
     )
-    parcstats.inputs.hemi = ["lh", "rh"]
+    parcstats.inputs.hemi = ['lh', 'rh']
     parcstats.interface._always_run = True
 
     # Runs: -hyporelabel -aparc2aseg -apas2aseg -segstats -wmparc
     # All volumetric, so don't
     autorecon3 = pe.Node(
-        ReconAll(directive="autorecon3", openmp=omp_nthreads),
+        ReconAll(directive='autorecon3', openmp=omp_nthreads),
         n_procs=omp_nthreads,
         mem_gb=5,
-        name="autorecon3",
+        name='autorecon3',
     )
     autorecon3.interface._always_run = True
 
@@ -579,8 +575,8 @@ def init_autorecon_resume_wf(*, omp_nthreads, name="autorecon_resume_wf"):
 
 def init_surface_derivatives_wf(
     *,
-    cifti_output: ty.Literal["91k", "170k", False] = False,
-    name="surface_derivatives_wf",
+    cifti_output: ty.Literal['91k', '170k', False] = False,
+    name='surface_derivatives_wf',
 ):
     r"""
     Generate sMRIPrep derivatives from FreeSurfer derivatives
@@ -626,30 +622,30 @@ def init_surface_derivatives_wf(
     inputnode = pe.Node(
         niu.IdentityInterface(
             fields=[
-                "subjects_dir",
-                "subject_id",
-                "fsnative2t1w_xfm",
-                "reference",
+                'subjects_dir',
+                'subject_id',
+                'fsnative2t1w_xfm',
+                'reference',
             ]
         ),
-        name="inputnode",
+        name='inputnode',
     )
     outputnode = pe.Node(
         niu.IdentityInterface(
             fields=[
-                "inflated",
-                "curv",
-                "out_aseg",
-                "out_aparc",
+                'inflated',
+                'curv',
+                'out_aseg',
+                'out_aparc',
             ]
         ),
-        name="outputnode",
+        name='outputnode',
     )
 
-    gifti_surfaces_wf = init_gifti_surfaces_wf(surfaces=["inflated"])
-    gifti_morph_wf = init_gifti_morphometrics_wf(morphometrics=["curv"])
+    gifti_surfaces_wf = init_gifti_surfaces_wf(surfaces=['inflated'])
+    gifti_morph_wf = init_gifti_morphometrics_wf(morphometrics=['curv'])
     aseg_to_native_wf = init_segs_to_native_wf()
-    aparc_to_native_wf = init_segs_to_native_wf(segmentation="aparc_aseg")
+    aparc_to_native_wf = init_segs_to_native_wf(segmentation='aparc_aseg')
 
     # fmt:off
     workflow.connect([
@@ -687,14 +683,14 @@ def init_surface_derivatives_wf(
     return workflow
 
 
-def init_fsLR_reg_wf(*, name="fsLR_reg_wf"):
+def init_fsLR_reg_wf(*, name='fsLR_reg_wf'):
     """Generate GIFTI registration files to fsLR space"""
     from ..interfaces.workbench import SurfaceSphereProjectUnproject
 
     workflow = Workflow(name=name)
 
-    inputnode = pe.Node(niu.IdentityInterface(["sphere_reg", "sulc"]), name="inputnode")
-    outputnode = pe.Node(niu.IdentityInterface(["sphere_reg_fsLR"]), name="outputnode")
+    inputnode = pe.Node(niu.IdentityInterface(['sphere_reg', 'sulc']), name='inputnode')
+    outputnode = pe.Node(niu.IdentityInterface(['sphere_reg_fsLR']), name='outputnode')
 
     # Via
     # ${CARET7DIR}/wb_command -surface-sphere-project-unproject
@@ -704,8 +700,8 @@ def init_fsLR_reg_wf(*, name="fsLR_reg_wf"):
     #   "$AtlasSpaceFolder"/"$NativeFolder"/"$Subject"."$Hemisphere".sphere.reg.reg_LR.native.surf.gii
     project_unproject = pe.MapNode(
         SurfaceSphereProjectUnproject(),
-        iterfield=["sphere_in", "sphere_project_to", "sphere_unproject_from"],
-        name="project_unproject",
+        iterfield=['sphere_in', 'sphere_project_to', 'sphere_unproject_from'],
+        name='project_unproject',
     )
     atlases = load_resource('atlases')
     project_unproject.inputs.sphere_project_to = [
@@ -821,9 +817,9 @@ def init_msm_sulc_wf(*, sloppy: bool = False, name: str = 'msm_sulc_wf'):
 
 def init_gifti_surfaces_wf(
     *,
-    surfaces: ty.List[str] = ["pial", "midthickness", "inflated", "white"],
+    surfaces: ty.List[str] = ['pial', 'midthickness', 'inflated', 'white'],
     to_scanner: bool = True,
-    name: str = "gifti_surface_wf",
+    name: str = 'gifti_surface_wf',
 ):
     r"""
     Prepare GIFTI surfaces from a FreeSurfer subjects directory.
@@ -865,32 +861,32 @@ def init_gifti_surfaces_wf(
     workflow = Workflow(name=name)
 
     inputnode = pe.Node(
-        niu.IdentityInterface(["subjects_dir", "subject_id", "fsnative2t1w_xfm"]),
-        name="inputnode",
+        niu.IdentityInterface(['subjects_dir', 'subject_id', 'fsnative2t1w_xfm']),
+        name='inputnode',
     )
-    outputnode = pe.Node(niu.IdentityInterface(["surfaces", *surfaces]), name="outputnode")
+    outputnode = pe.Node(niu.IdentityInterface(['surfaces', *surfaces]), name='outputnode')
 
     get_surfaces = pe.Node(
         niu.Function(function=_get_surfaces, output_names=surfaces),
-        name="get_surfaces",
+        name='get_surfaces',
     )
     get_surfaces.inputs.surfaces = surfaces
 
     surface_list = pe.Node(
         niu.Merge(len(surfaces), ravel_inputs=True),
-        name="surface_list",
+        name='surface_list',
         run_without_submitting=True,
     )
     fs2gii = pe.MapNode(
-        fs.MRIsConvert(out_datatype="gii", to_scanner=to_scanner),
-        iterfield="in_file",
-        name="fs2gii",
+        fs.MRIsConvert(out_datatype='gii', to_scanner=to_scanner),
+        iterfield='in_file',
+        name='fs2gii',
     )
-    fix_surfs = pe.MapNode(NormalizeSurf(), iterfield="in_file", name="fix_surfs")
+    fix_surfs = pe.MapNode(NormalizeSurf(), iterfield='in_file', name='fix_surfs')
 
     surface_groups = pe.Node(
         niu.Split(splits=[2] * len(surfaces)),
-        name="surface_groups",
+        name='surface_groups',
         run_without_submitting=True,
     )
 
@@ -918,8 +914,8 @@ def init_gifti_surfaces_wf(
 
 def init_gifti_morphometrics_wf(
     *,
-    morphometrics: ty.List[str] = ["thickness", "curv", "sulc"],
-    name: str = "gifti_morphometrics_wf",
+    morphometrics: ty.List[str] = ['thickness', 'curv', 'sulc'],
+    name: str = 'gifti_morphometrics_wf',
 ):
     r"""
     Prepare GIFTI shape files from morphometrics found in a FreeSurfer subjects
@@ -958,35 +954,35 @@ def init_gifti_morphometrics_wf(
     workflow = Workflow(name=name)
 
     inputnode = pe.Node(
-        niu.IdentityInterface(["subjects_dir", "subject_id"]),
-        name="inputnode",
+        niu.IdentityInterface(['subjects_dir', 'subject_id']),
+        name='inputnode',
     )
     outputnode = pe.Node(
         niu.IdentityInterface(
             [
-                "morphometrics",
+                'morphometrics',
                 *morphometrics,
             ]
         ),
-        name="outputnode",
+        name='outputnode',
     )
 
-    get_subject = pe.Node(nio.FreeSurferSource(), name="get_surfaces")
+    get_subject = pe.Node(nio.FreeSurferSource(), name='get_surfaces')
 
     morphometry_list = pe.Node(
         niu.Merge(len(morphometrics), ravel_inputs=True),
-        name="surfmorph_list",
+        name='surfmorph_list',
         run_without_submitting=True,
     )
     morphs2gii = pe.MapNode(
-        MRIsConvertData(out_datatype="gii"),
-        iterfield="scalarcurv_file",
-        name="morphs2gii",
+        MRIsConvertData(out_datatype='gii'),
+        iterfield='scalarcurv_file',
+        name='morphs2gii',
     )
 
     morph_groups = pe.Node(
         niu.Split(splits=[2] * len(morphometrics)),
-        name="morph_groups",
+        name='morph_groups',
         run_without_submitting=True,
     )
 
@@ -1013,7 +1009,7 @@ def init_gifti_morphometrics_wf(
 def init_hcp_morphometrics_wf(
     *,
     omp_nthreads: int,
-    name: str = "hcp_morphometrics_wf",
+    name: str = 'hcp_morphometrics_wf',
 ) -> Workflow:
     """Convert FreeSurfer-style morphometrics to HCP-style.
 
@@ -1071,22 +1067,22 @@ def init_hcp_morphometrics_wf(
     )
 
     outputnode = pe.JoinNode(
-        niu.IdentityInterface(fields=["thickness", "curv", "sulc", "roi"]),
-        name="outputnode",
-        joinsource="itersource",
+        niu.IdentityInterface(fields=['thickness', 'curv', 'sulc', 'roi']),
+        name='outputnode',
+        joinsource='itersource',
     )
 
     select_surfaces = pe.Node(
         KeySelect(
             fields=[
-                "thickness",
-                "curv",
-                "sulc",
-                "midthickness",
+                'thickness',
+                'curv',
+                'sulc',
+                'midthickness',
             ],
-            keys=["L", "R"],
+            keys=['L', 'R'],
         ),
-        name="select_surfaces",
+        name='select_surfaces',
         run_without_submitting=True,
     )
 
@@ -1098,19 +1094,19 @@ def init_hcp_morphometrics_wf(
 
     # Native ROI is thickness > 0, with holes and islands filled
     initial_roi = pe.Node(MetricMath(metric='roi', operation='bin'), name='initial_roi')
-    fill_holes = pe.Node(MetricFillHoles(), name="fill_holes", mem_gb=DEFAULT_MEMORY_MIN_GB)
-    native_roi = pe.Node(MetricRemoveIslands(), name="native_roi", mem_gb=DEFAULT_MEMORY_MIN_GB)
+    fill_holes = pe.Node(MetricFillHoles(), name='fill_holes', mem_gb=DEFAULT_MEMORY_MIN_GB)
+    native_roi = pe.Node(MetricRemoveIslands(), name='native_roi', mem_gb=DEFAULT_MEMORY_MIN_GB)
 
     # Dilation happens separately from ROI creation
     dilate_curv = pe.Node(
         MetricDilate(distance=10, nearest=True),
-        name="dilate_curv",
+        name='dilate_curv',
         n_procs=omp_nthreads,
         mem_gb=DEFAULT_MEMORY_MIN_GB,
     )
     dilate_thickness = pe.Node(
         MetricDilate(distance=10, nearest=True),
-        name="dilate_thickness",
+        name='dilate_thickness',
         n_procs=omp_nthreads,
         mem_gb=DEFAULT_MEMORY_MIN_GB,
     )
@@ -1153,7 +1149,7 @@ def init_hcp_morphometrics_wf(
     return workflow
 
 
-def init_segs_to_native_wf(*, name="segs_to_native", segmentation="aseg"):
+def init_segs_to_native_wf(*, name='segs_to_native', segmentation='aseg'):
     """
     Get a segmentation from FreeSurfer conformed space into native T1w space.
 
@@ -1187,39 +1183,39 @@ def init_segs_to_native_wf(*, name="segs_to_native", segmentation="aseg"):
         The selected segmentation, after resampling in native space
 
     """
-    workflow = Workflow(name=f"{name}_{segmentation}")
+    workflow = Workflow(name=f'{name}_{segmentation}')
     inputnode = pe.Node(
-        niu.IdentityInterface(["in_file", "subjects_dir", "subject_id", "fsnative2t1w_xfm"]),
-        name="inputnode",
+        niu.IdentityInterface(['in_file', 'subjects_dir', 'subject_id', 'fsnative2t1w_xfm']),
+        name='inputnode',
     )
-    outputnode = pe.Node(niu.IdentityInterface(["out_file"]), name="outputnode")
+    outputnode = pe.Node(niu.IdentityInterface(['out_file']), name='outputnode')
     # Extract the aseg and aparc+aseg outputs
-    fssource = pe.Node(nio.FreeSurferSource(), name="fs_datasource")
+    fssource = pe.Node(nio.FreeSurferSource(), name='fs_datasource')
 
-    lta = pe.Node(ConcatenateXFMs(out_fmt="fs"), name="lta", run_without_submitting=True)
+    lta = pe.Node(ConcatenateXFMs(out_fmt='fs'), name='lta', run_without_submitting=True)
 
     # Resample from T1.mgz to T1w.nii.gz, applying any offset in fsnative2t1w_xfm,
     # and convert to NIfTI while we're at it
     resample = pe.Node(
-        fs.ApplyVolTransform(transformed_file="seg.nii.gz", interp="nearest"),
-        name="resample",
+        fs.ApplyVolTransform(transformed_file='seg.nii.gz', interp='nearest'),
+        name='resample',
     )
 
-    if segmentation.startswith("aparc"):
-        if segmentation == "aparc_aseg":
+    if segmentation.startswith('aparc'):
+        if segmentation == 'aparc_aseg':
 
             def _sel(x):
-                return [parc for parc in x if "aparc+" in parc][0]  # noqa
+                return [parc for parc in x if 'aparc+' in parc][0]  # noqa
 
-        elif segmentation == "aparc_a2009s":
-
-            def _sel(x):
-                return [parc for parc in x if "a2009s+" in parc][0]  # noqa
-
-        elif segmentation == "aparc_dkt":
+        elif segmentation == 'aparc_a2009s':
 
             def _sel(x):
-                return [parc for parc in x if "DKTatlas+" in parc][0]  # noqa
+                return [parc for parc in x if 'a2009s+' in parc][0]  # noqa
+
+        elif segmentation == 'aparc_dkt':
+
+            def _sel(x):
+                return [parc for parc in x if 'DKTatlas+' in parc][0]  # noqa
 
         segmentation = (segmentation, _sel)
 
@@ -1240,7 +1236,7 @@ def init_segs_to_native_wf(*, name="segs_to_native", segmentation="aseg"):
     return workflow
 
 
-def init_anat_ribbon_wf(name="anat_ribbon_wf"):
+def init_anat_ribbon_wf(name='anat_ribbon_wf'):
     """Create anatomical ribbon mask
 
     Workflow Graph
@@ -1270,24 +1266,24 @@ def init_anat_ribbon_wf(name="anat_ribbon_wf"):
     workflow = pe.Workflow(name=name)
 
     inputnode = pe.Node(
-        niu.IdentityInterface(fields=["white", "pial", "ref_file"]),
-        name="inputnode",
+        niu.IdentityInterface(fields=['white', 'pial', 'ref_file']),
+        name='inputnode',
     )
-    outputnode = pe.Node(niu.IdentityInterface(fields=["anat_ribbon"]), name="outputnode")
+    outputnode = pe.Node(niu.IdentityInterface(fields=['anat_ribbon']), name='outputnode')
 
     create_wm_distvol = pe.MapNode(
         CreateSignedDistanceVolume(),
-        iterfield=["surf_file"],
-        name="create_wm_distvol",
+        iterfield=['surf_file'],
+        name='create_wm_distvol',
     )
 
     create_pial_distvol = pe.MapNode(
         CreateSignedDistanceVolume(),
-        iterfield=["surf_file"],
-        name="create_pial_distvol",
+        iterfield=['surf_file'],
+        name='create_pial_distvol',
     )
 
-    make_ribbon = pe.Node(MakeRibbon(), name="make_ribbon", mem_gb=DEFAULT_MEMORY_MIN_GB)
+    make_ribbon = pe.Node(MakeRibbon(), name='make_ribbon', mem_gb=DEFAULT_MEMORY_MIN_GB)
 
     # fmt: off
     workflow.connect(
@@ -1311,7 +1307,7 @@ def init_anat_ribbon_wf(name="anat_ribbon_wf"):
 
 def init_resample_midthickness_wf(
     grayord_density: ty.Literal['91k', '170k'],
-    name: str = "resample_midthickness_wf",
+    name: str = 'resample_midthickness_wf',
 ):
     """
     Resample subject midthickness surface to specified density.
@@ -1348,19 +1344,19 @@ def init_resample_midthickness_wf(
 
     workflow = Workflow(name=name)
 
-    fslr_density = "32k" if grayord_density == "91k" else "59k"
+    fslr_density = '32k' if grayord_density == '91k' else '59k'
 
     inputnode = pe.Node(
-        niu.IdentityInterface(fields=["midthickness", "sphere_reg_fsLR"]),
-        name="inputnode",
+        niu.IdentityInterface(fields=['midthickness', 'sphere_reg_fsLR']),
+        name='inputnode',
     )
 
-    outputnode = pe.Node(niu.IdentityInterface(fields=["midthickness_fsLR"]), name="outputnode")
+    outputnode = pe.Node(niu.IdentityInterface(fields=['midthickness_fsLR']), name='outputnode')
 
     resampler = pe.MapNode(
         SurfaceResample(method='BARYCENTRIC'),
         iterfield=['surface_in', 'current_sphere', 'new_sphere'],
-        name="resampler",
+        name='resampler',
     )
     resampler.inputs.new_sphere = [
         str(
@@ -1390,7 +1386,7 @@ def init_resample_midthickness_wf(
 def init_morph_grayords_wf(
     grayord_density: ty.Literal['91k', '170k'],
     omp_nthreads: int,
-    name: str = "morph_grayords_wf",
+    name: str = 'morph_grayords_wf',
 ):
     """
     Sample Grayordinates files onto the fsLR atlas.
@@ -1451,21 +1447,21 @@ def init_morph_grayords_wf(
 resampled onto fsLR using the Connectome Workbench [@hcppipelines].
 """
 
-    fslr_density = "32k" if grayord_density == "91k" else "59k"
+    fslr_density = '32k' if grayord_density == '91k' else '59k'
 
     inputnode = pe.Node(
         niu.IdentityInterface(
             fields=[
-                "curv",
-                "sulc",
-                "thickness",
-                "roi",
-                "midthickness",
-                "midthickness_fsLR",
-                "sphere_reg_fsLR",
+                'curv',
+                'sulc',
+                'thickness',
+                'roi',
+                'midthickness',
+                'midthickness_fsLR',
+                'sphere_reg_fsLR',
             ]
         ),
-        name="inputnode",
+        name='inputnode',
     )
 
     # Note we have to use a different name than itersource to
@@ -1480,34 +1476,34 @@ resampled onto fsLR using the Connectome Workbench [@hcppipelines].
     outputnode = pe.Node(
         niu.IdentityInterface(
             fields=[
-                "curv_fsLR",
-                "curv_metadata",
-                "sulc_fsLR",
-                "sulc_metadata",
-                "thickness_fsLR",
-                "thickness_metadata",
+                'curv_fsLR',
+                'curv_metadata',
+                'sulc_fsLR',
+                'sulc_metadata',
+                'thickness_fsLR',
+                'thickness_metadata',
             ]
         ),
-        name="outputnode",
+        name='outputnode',
     )
 
     atlases = load_resource('atlases')
     select_surfaces = pe.Node(
         KeySelect(
             fields=[
-                "curv",
-                "sulc",
-                "thickness",
-                "roi",
-                "midthickness",
-                "midthickness_fsLR",
-                "sphere_reg_fsLR",
-                "template_sphere",
-                "template_roi",
+                'curv',
+                'sulc',
+                'thickness',
+                'roi',
+                'midthickness',
+                'midthickness_fsLR',
+                'sphere_reg_fsLR',
+                'template_sphere',
+                'template_roi',
             ],
-            keys=["L", "R"],
+            keys=['L', 'R'],
         ),
-        name="select_surfaces",
+        name='select_surfaces',
         run_without_submitting=True,
     )
     select_surfaces.inputs.template_sphere = [
@@ -1544,19 +1540,19 @@ resampled onto fsLR using the Connectome Workbench [@hcppipelines].
     for metric in ('curv', 'sulc', 'thickness'):
         resampler = pe.Node(
             MetricResample(method='ADAP_BARY_AREA', area_surfs=True),
-            name=f"resample_{metric}",
+            name=f'resample_{metric}',
             n_procs=omp_nthreads,
         )
         mask_fsLR = pe.Node(
             MetricMask(),
-            name=f"mask_{metric}",
+            name=f'mask_{metric}',
             n_procs=omp_nthreads,
         )
         cifti_metric = pe.JoinNode(
             GenerateDScalar(grayordinates=grayord_density, scalar_name=metric),
-            name=f"cifti_{metric}",
+            name=f'cifti_{metric}',
             joinfield=['scalar_surfs'],
-            joinsource="hemisource",
+            joinsource='hemisource',
         )
 
         workflow.connect([
@@ -1590,7 +1586,7 @@ def _check_cw256(in_files, default_flags):
     fov = np.array(summary_img.shape[:3]) * summary_img.header.get_zooms()[:3]
     flags = list(default_flags)
     if np.any(fov > 256):
-        flags.append("-cw256")
+        flags.append('-cw256')
     return flags
 
 
@@ -1642,20 +1638,17 @@ def _get_surfaces(subjects_dir: str, subject_id: str, surfaces: list[str]) -> tu
     from pathlib import Path
 
     expanded_surfaces = surfaces.copy()
-    if "midthickness" in surfaces:
-        expanded_surfaces.append("graymid")
+    if 'midthickness' in surfaces:
+        expanded_surfaces.append('graymid')
 
-    surf_dir = Path(subjects_dir) / subject_id / "surf"
+    surf_dir = Path(subjects_dir) / subject_id / 'surf'
     all_surfs = {
-        surface: sorted(
-            str(fn)
-            for fn in surf_dir.glob(f"[lr]h.{surface.replace('_', '.')}")
-        )
+        surface: sorted(str(fn) for fn in surf_dir.glob(f"[lr]h.{surface.replace('_', '.')}"))
         for surface in expanded_surfaces
     }
 
-    if all_surfs.get("graymid") and not all_surfs.get("midthickness"):
-        all_surfs["midthickness"] = all_surfs.pop("graymid")
+    if all_surfs.get('graymid') and not all_surfs.get('midthickness'):
+        all_surfs['midthickness'] = all_surfs.pop('graymid')
 
     ret = tuple(all_surfs[surface] for surface in surfaces)
     return ret if len(ret) > 1 else ret[0]

--- a/smriprep/workflows/tests/test_anatomical.py
+++ b/smriprep/workflows/tests/test_anatomical.py
@@ -11,60 +11,60 @@ from niworkflows.utils.testing import generate_bids_skeleton
 from ..anatomical import init_anat_preproc_wf, init_anat_fit_wf
 
 BASE_LAYOUT = {
-    "01": {
-        "anat": [
-            {"run": 1, "suffix": "T1w"},
-            {"run": 2, "suffix": "T1w"},
-            {"suffix": "T2w"},
+    '01': {
+        'anat': [
+            {'run': 1, 'suffix': 'T1w'},
+            {'run': 2, 'suffix': 'T1w'},
+            {'suffix': 'T2w'},
         ],
-        "func": [
+        'func': [
             {
-                "task": "rest",
-                "run": i,
-                "suffix": "bold",
-                "metadata": {"PhaseEncodingDirection": "j", "TotalReadoutTime": 0.6},
+                'task': 'rest',
+                'run': i,
+                'suffix': 'bold',
+                'metadata': {'PhaseEncodingDirection': 'j', 'TotalReadoutTime': 0.6},
             }
             for i in range(1, 3)
         ],
-        "fmap": [
-            {"suffix": "phasediff", "metadata": {"EchoTime1": 0.005, "EchoTime2": 0.007}},
-            {"suffix": "magnitude1", "metadata": {"EchoTime": 0.005}},
+        'fmap': [
+            {'suffix': 'phasediff', 'metadata': {'EchoTime1': 0.005, 'EchoTime2': 0.007}},
+            {'suffix': 'magnitude1', 'metadata': {'EchoTime': 0.005}},
             {
-                "suffix": "epi",
-                "direction": "PA",
-                "metadata": {"PhaseEncodingDirection": "j", "TotalReadoutTime": 0.6},
+                'suffix': 'epi',
+                'direction': 'PA',
+                'metadata': {'PhaseEncodingDirection': 'j', 'TotalReadoutTime': 0.6},
             },
             {
-                "suffix": "epi",
-                "direction": "AP",
-                "metadata": {"PhaseEncodingDirection": "j-", "TotalReadoutTime": 0.6},
+                'suffix': 'epi',
+                'direction': 'AP',
+                'metadata': {'PhaseEncodingDirection': 'j-', 'TotalReadoutTime': 0.6},
             },
         ],
     },
 }
 
 
-@pytest.fixture(scope="module", autouse=True)
+@pytest.fixture(scope='module', autouse=True)
 def quiet_logger():
     import logging
 
-    logger = logging.getLogger("nipype.workflow")
+    logger = logging.getLogger('nipype.workflow')
     old_level = logger.getEffectiveLevel()
     logger.setLevel(logging.ERROR)
     yield
     logger.setLevel(old_level)
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope='module')
 def bids_root(tmp_path_factory):
-    base = tmp_path_factory.mktemp("base")
-    bids_dir = base / "bids"
+    base = tmp_path_factory.mktemp('base')
+    bids_dir = base / 'bids'
     generate_bids_skeleton(bids_dir, BASE_LAYOUT)
     yield bids_dir
 
 
-@pytest.mark.parametrize("freesurfer", [True, False])
-@pytest.mark.parametrize("cifti_output", [False, "91k"])
+@pytest.mark.parametrize('freesurfer', [True, False])
+@pytest.mark.parametrize('cifti_output', [False, '91k'])
 def test_init_anat_preproc_wf(
     bids_root: Path,
     tmp_path: Path,
@@ -81,12 +81,12 @@ def test_init_anat_preproc_wf(
         hires=False,
         longitudinal=False,
         msm_sulc=False,
-        t1w=[str(bids_root / "sub-01" / "anat" / "sub-01_T1w.nii.gz")],
-        t2w=[str(bids_root / "sub-01" / "anat" / "sub-01_T2w.nii.gz")],
+        t1w=[str(bids_root / 'sub-01' / 'anat' / 'sub-01_T1w.nii.gz')],
+        t2w=[str(bids_root / 'sub-01' / 'anat' / 'sub-01_T2w.nii.gz')],
         skull_strip_mode='force',
-        skull_strip_template=Reference("OASIS30ANTs"),
+        skull_strip_template=Reference('OASIS30ANTs'),
         spaces=SpatialReferences(
-            spaces=["MNI152NLin2009cAsym", "fsaverage5"],
+            spaces=['MNI152NLin2009cAsym', 'fsaverage5'],
             checkpoint=True,
         ),
         precomputed={},
@@ -95,8 +95,8 @@ def test_init_anat_preproc_wf(
     )
 
 
-@pytest.mark.parametrize("msm_sulc", [True, False])
-@pytest.mark.parametrize("skull_strip_mode", ['skip', 'force'])
+@pytest.mark.parametrize('msm_sulc', [True, False])
+@pytest.mark.parametrize('skull_strip_mode', ['skip', 'force'])
 def test_anat_fit_wf(
     bids_root: Path,
     tmp_path: Path,
@@ -113,12 +113,12 @@ def test_anat_fit_wf(
         hires=False,
         longitudinal=False,
         msm_sulc=msm_sulc,
-        t1w=[str(bids_root / "sub-01" / "anat" / "sub-01_T1w.nii.gz")],
-        t2w=[str(bids_root / "sub-01" / "anat" / "sub-01_T2w.nii.gz")],
+        t1w=[str(bids_root / 'sub-01' / 'anat' / 'sub-01_T1w.nii.gz')],
+        t2w=[str(bids_root / 'sub-01' / 'anat' / 'sub-01_T2w.nii.gz')],
         skull_strip_mode=skull_strip_mode,
-        skull_strip_template=Reference("OASIS30ANTs"),
+        skull_strip_template=Reference('OASIS30ANTs'),
         spaces=SpatialReferences(
-            spaces=["MNI152NLin2009cAsym", "fsaverage5"],
+            spaces=['MNI152NLin2009cAsym', 'fsaverage5'],
             checkpoint=True,
         ),
         precomputed={},
@@ -126,16 +126,16 @@ def test_anat_fit_wf(
     )
 
 
-@pytest.mark.parametrize("t1w", [1, 2])
-@pytest.mark.parametrize("t2w", [0, 1])
-@pytest.mark.parametrize("skull_strip_mode", ['skip', 'force'])
-@pytest.mark.parametrize("t1w_preproc", [False, True])
-@pytest.mark.parametrize("t2w_preproc", [False, True])
-@pytest.mark.parametrize("t1w_mask", [False, True])
-@pytest.mark.parametrize("t1w_dseg", [False, True])
-@pytest.mark.parametrize("t1w_tpms", [False, True])
-@pytest.mark.parametrize("xfms", [False, True])
-@pytest.mark.parametrize("sphere_reg_msm", [0, 1, 2])
+@pytest.mark.parametrize('t1w', [1, 2])
+@pytest.mark.parametrize('t2w', [0, 1])
+@pytest.mark.parametrize('skull_strip_mode', ['skip', 'force'])
+@pytest.mark.parametrize('t1w_preproc', [False, True])
+@pytest.mark.parametrize('t2w_preproc', [False, True])
+@pytest.mark.parametrize('t1w_mask', [False, True])
+@pytest.mark.parametrize('t1w_dseg', [False, True])
+@pytest.mark.parametrize('t1w_tpms', [False, True])
+@pytest.mark.parametrize('xfms', [False, True])
+@pytest.mark.parametrize('sphere_reg_msm', [0, 1, 2])
 def test_anat_fit_precomputes(
     bids_root: Path,
     tmp_path: Path,
@@ -157,44 +157,43 @@ def test_anat_fit_precomputes(
 
     # Construct inputs
     t1w_list = [
-        str(bids_root / "sub-01" / "anat" / "sub-01_run-1_T1w.nii.gz"),
-        str(bids_root / "sub-01" / "anat" / "sub-01_run-2_T1w.nii.gz"),
+        str(bids_root / 'sub-01' / 'anat' / 'sub-01_run-1_T1w.nii.gz'),
+        str(bids_root / 'sub-01' / 'anat' / 'sub-01_run-2_T1w.nii.gz'),
     ][:t1w]
-    t2w_list = [str(bids_root / "sub-01" / "anat" / "sub-01_T2w.nii.gz")][:t2w]
+    t2w_list = [str(bids_root / 'sub-01' / 'anat' / 'sub-01_T2w.nii.gz')][:t2w]
 
     # Construct precomputed files
     empty_img = nb.Nifti1Image(np.zeros((1, 1, 1)), np.eye(4))
     precomputed = {}
     if t1w_preproc:
-        precomputed["t1w_preproc"] = str(tmp_path / "t1w_preproc.nii.gz")
+        precomputed['t1w_preproc'] = str(tmp_path / 't1w_preproc.nii.gz')
     if t2w_preproc:
-        precomputed["t2w_preproc"] = str(tmp_path / "t2w_preproc.nii.gz")
+        precomputed['t2w_preproc'] = str(tmp_path / 't2w_preproc.nii.gz')
     if t1w_mask:
-        precomputed["t1w_mask"] = str(tmp_path / "t1w_mask.nii.gz")
+        precomputed['t1w_mask'] = str(tmp_path / 't1w_mask.nii.gz')
     if t1w_dseg:
-        precomputed["t1w_dseg"] = str(tmp_path / "t1w_dseg.nii.gz")
+        precomputed['t1w_dseg'] = str(tmp_path / 't1w_dseg.nii.gz')
     if t1w_tpms:
-        precomputed["t1w_tpms"] = str(tmp_path / "t1w_tpms.nii.gz")
+        precomputed['t1w_tpms'] = str(tmp_path / 't1w_tpms.nii.gz')
 
     for path in precomputed.values():
         empty_img.to_filename(path)
 
-    precomputed["sphere_reg_msm"] = [
-        str(tmp_path / f"sub-01_hemi-{hemi}_desc-msm_sphere.surf.gii")
-        for hemi in ["L", "R"]
+    precomputed['sphere_reg_msm'] = [
+        str(tmp_path / f'sub-01_hemi-{hemi}_desc-msm_sphere.surf.gii') for hemi in ['L', 'R']
     ][:sphere_reg_msm]
-    for path in precomputed["sphere_reg_msm"]:
+    for path in precomputed['sphere_reg_msm']:
         Path(path).touch()
 
     if xfms:
-        transforms = precomputed["transforms"] = {}
-        transforms["MNI152NLin2009cAsym"] = {
-            "forward": str(tmp_path / "MNI152NLin2009cAsym_forward_xfm.txt"),
-            "reverse": str(tmp_path / "MNI152NLin2009cAsym_reverse_xfm.txt"),
+        transforms = precomputed['transforms'] = {}
+        transforms['MNI152NLin2009cAsym'] = {
+            'forward': str(tmp_path / 'MNI152NLin2009cAsym_forward_xfm.txt'),
+            'reverse': str(tmp_path / 'MNI152NLin2009cAsym_reverse_xfm.txt'),
         }
-        transforms["fsnative"] = {
-            "forward": str(tmp_path / "fsnative_forward_xfm.txt"),
-            "reverse": str(tmp_path / "fsnative_reverse_xfm.txt"),
+        transforms['fsnative'] = {
+            'forward': str(tmp_path / 'fsnative_forward_xfm.txt'),
+            'reverse': str(tmp_path / 'fsnative_reverse_xfm.txt'),
         }
 
         # Write dummy transforms
@@ -213,9 +212,9 @@ def test_anat_fit_precomputes(
         t1w=t1w_list,
         t2w=t2w_list,
         skull_strip_mode=skull_strip_mode,
-        skull_strip_template=Reference("OASIS30ANTs"),
+        skull_strip_template=Reference('OASIS30ANTs'),
         spaces=SpatialReferences(
-            spaces=["MNI152NLin2009cAsym", "fsaverage5"],
+            spaces=['MNI152NLin2009cAsym', 'fsaverage5'],
             checkpoint=True,
         ),
         precomputed=precomputed,

--- a/smriprep/workflows/tests/test_anatomical.py
+++ b/smriprep/workflows/tests/test_anatomical.py
@@ -44,7 +44,7 @@ BASE_LAYOUT = {
 
 
 @pytest.fixture(scope='module', autouse=True)
-def quiet_logger():
+def _quiet_logger():
     import logging
 
     logger = logging.getLogger('nipype.workflow')
@@ -59,7 +59,7 @@ def bids_root(tmp_path_factory):
     base = tmp_path_factory.mktemp('base')
     bids_dir = base / 'bids'
     generate_bids_skeleton(bids_dir, BASE_LAYOUT)
-    yield bids_dir
+    return bids_dir
 
 
 @pytest.mark.parametrize('freesurfer', [True, False])

--- a/smriprep/workflows/tests/test_anatomical.py
+++ b/smriprep/workflows/tests/test_anatomical.py
@@ -1,14 +1,13 @@
 from pathlib import Path
 
-from nipype.pipeline.engine.utils import generate_expanded_graph
 import nibabel as nb
 import numpy as np
 import pytest
-
-from niworkflows.utils.spaces import SpatialReferences, Reference
+from nipype.pipeline.engine.utils import generate_expanded_graph
+from niworkflows.utils.spaces import Reference, SpatialReferences
 from niworkflows.utils.testing import generate_bids_skeleton
 
-from ..anatomical import init_anat_preproc_wf, init_anat_fit_wf
+from ..anatomical import init_anat_fit_wf, init_anat_preproc_wf
 
 BASE_LAYOUT = {
     '01': {

--- a/smriprep/workflows/tests/test_surfaces.py
+++ b/smriprep/workflows/tests/test_surfaces.py
@@ -7,8 +7,8 @@ import numpy as np
 import pytest
 from nipype.pipeline import engine as pe
 
-from ..surfaces import init_anat_ribbon_wf, init_gifti_surfaces_wf
 from ...data import load_resource
+from ..surfaces import init_anat_ribbon_wf, init_gifti_surfaces_wf
 
 
 def test_ribbon_workflow(tmp_path: Path):

--- a/smriprep/workflows/tests/test_surfaces.py
+++ b/smriprep/workflows/tests/test_surfaces.py
@@ -14,17 +14,17 @@ from ...data import load_resource
 def test_ribbon_workflow(tmp_path: Path):
     """Create ribbon mask for fsaverage subject"""
 
-    for command in ("mris_convert", "wb_command"):
+    for command in ('mris_convert', 'wb_command'):
         if not which(command):
-            pytest.skip(f"Could not find {command} in PATH")
+            pytest.skip(f'Could not find {command} in PATH')
 
     if not os.path.exists(os.getenv('SUBJECTS_DIR')):
-        pytest.skip("Could not find $SUBJECTS_DIR")
+        pytest.skip('Could not find $SUBJECTS_DIR')
 
     # Low-res file that includes the fsaverage surfaces in its bounding box
     # We will use it both as a template and a comparison.
     test_ribbon = load_resource(
-        "../interfaces/tests/data/sub-fsaverage_res-4_desc-cropped_ribbon.nii.gz"
+        '../interfaces/tests/data/sub-fsaverage_res-4_desc-cropped_ribbon.nii.gz'
     )
 
     gifti_surfaces_wf = init_gifti_surfaces_wf(surfaces=['white', 'pial'])


### PR DESCRIPTION
Advantages:

1) Ruff is extremely fast compared to all Python equivalents.
2) In addition to formatting, its linter has a `--fix` flag that can take care of a lot of problems with no user effort.
3) Consolidates a [ridiculous number](https://docs.astral.sh/ruff/rules/) of rules from a variety of linters/plugins. We can stop using flake8, pyupgrade and isort.
4) The formatter does sensible things, where it [deviates from black](https://docs.astral.sh/ruff/formatter/black/)
5) They are considering improving numpy array formatting (https://github.com/astral-sh/ruff/discussions/8452), which is awful in black.
6) They let us use single quotes again in peace. I'm enforcing them, as I find them significantly less visually cluttering than double quotes.
7) Works in pre-commit, like everything else.

Disadvantages:

1) They still don't let hanging comments slide, but that's not a big deal in smriprep.

I've added `.git-blame-ignore-rev` to hide a lot of this.

Closes #395.