### PR TITLE
FIX: T1w_preproc -> t1w_preproc

### DIFF
--- a/smriprep/workflows/anatomical.py
+++ b/smriprep/workflows/anatomical.py
@@ -1151,7 +1151,6 @@ A {t2w_or_flair} image was used to improve pial surface refinement.
         )
         ds_t2w_preproc.inputs.SkullStripped = False
 
-        # fmt:off
         workflow.connect([
             (inputnode, t2w_template_wf, [('t2w', 'inputnode.anat_files')]),
             (t2w_template_wf, bbreg, [('outputnode.anat_ref', 'source_file')]),
@@ -1163,13 +1162,12 @@ A {t2w_or_flair} image was used to improve pial surface refinement.
             (surface_recon_wf, coreg_xfms, [('outputnode.fsnative2t1w_xfm', 'in2')]),
             (coreg_xfms, t2wtot1w_xfm, [('out', 'in_xfms')]),
             (t2w_template_wf, t2w_resample, [('outputnode.anat_ref', 'input_image')]),
-            (t1w_buffer, t2w_resample, [('T1w_preproc', 'reference_image')]),
+            (t1w_buffer, t2w_resample, [('t1w_preproc', 'reference_image')]),
             (t2wtot1w_xfm, t2w_resample, [('out_xfm', 'transforms')]),
             (inputnode, ds_t2w_preproc, [('t2w', 'source_file')]),
             (t2w_resample, ds_t2w_preproc, [('output_image', 'in_file')]),
             (ds_t2w_preproc, outputnode, [('out_file', 't2w_preproc')]),
-        ])
-        # fmt:on
+        ])  # fmt:skip
     elif not t2w:
         LOGGER.info("ANAT No T2w images provided - skipping Stage 7")
     else:

--- a/smriprep/workflows/tests/test_anatomical.py
+++ b/smriprep/workflows/tests/test_anatomical.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+from nipype.pipeline.engine.utils import generate_expanded_graph
 import nibabel as nb
 import numpy as np
 import pytest
@@ -202,7 +203,7 @@ def test_anat_fit_precomputes(
                 Path(path).touch()
 
     # Create workflow
-    init_anat_fit_wf(
+    wf = init_anat_fit_wf(
         bids_root=str(bids_root),
         output_dir=str(output_dir),
         freesurfer=True,
@@ -220,3 +221,6 @@ def test_anat_fit_precomputes(
         precomputed=precomputed,
         omp_nthreads=1,
     )
+
+    flatgraph = wf._create_flat_graph()
+    generate_expanded_graph(flatgraph)


### PR DESCRIPTION
Small fix while writing the smoke tests in #390 turned out to be a typo. The issue was that we weren't using the `t1w_buffer` as a source for T2w preprocessing, so that if you had a preprocessed T1w image but an unprocessed T2w image, you'd try to grab the T1w from the wrong place. And I typed it wrong, and some of these checks are only found at workflow expansion.

Added workflow expansion to the test to catch this.

Fixes #398.