### PR TITLE
invert result of skull-strip check in auto mode

### DIFF
--- a/smriprep/workflows/anatomical.py
+++ b/smriprep/workflows/anatomical.py
@@ -795,7 +795,7 @@ and used as T1w-reference throughout the workflow.
     if not have_mask:
         LOGGER.info("ANAT Stage 2: Preparing brain extraction workflow")
         if skull_strip_mode == "auto":
-            run_skull_strip = all(_is_skull_stripped(img) for img in t1w)
+            run_skull_strip = not all(_is_skull_stripped(img) for img in t1w)
         else:
             run_skull_strip = {"force": True, "skip": False}[skull_strip_mode]
 


### PR DESCRIPTION
Closes #401 

By default, skull-stripping was conditional on a check whose logic was reversed in 0.13.1 (that is, run when all T1w images have had skulls stripped). This fixes the inversion.
