### PR TITLE
FIX: Repair FreeSurfer Dependency in Dockerfile (tcsh)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -458,6 +458,9 @@ jobs:
           name: Run anatomical workflow on ds005
           no_output_timeout: 2h
           command: |
+            # Remove part of FreeSurfer output to ensure that at least
+            # some of recon-all is attempted
+            rm /tmp/ds005/freesurfer/sub-01/stats/wmparc.stats
             bash /tmp/src/smriprep/.circleci/ds005_run.sh --write-graph
       - run:
           name: Combine coverage

--- a/Dockerfile
+++ b/Dockerfile
@@ -93,7 +93,7 @@ ENV DEBIAN_FRONTEND="noninteractive" \
     LC_ALL="en_US.UTF-8"
 
 # Some baseline tools
-# bc is needed for FreeSurfer
+# bc, tcsh are needed for FreeSurfer
 # libglu1-mesa is needed for Connectome Workbench
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -105,6 +105,7 @@ RUN apt-get update && \
                     libglu1-mesa \
                     lsb-release \
                     netbase \
+                    tcsh \
                     xvfb && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
Closes #403 

FreeSurfer's `recon-all` requires `tcsh`, but that shell was no longer being added in the Dockerfile. This installs it.

The lack of `tcsh` escaped testing during CI because `recon-all` had been skipped entirely (generally too expensive to run). This change also removes `stats/wmparc.stats` from the FreeSurfer derivatives for ds005, which ensures that at least some of the `recon-all` scripts are run (any dependencies that are only used in earlier stages would still be missed).