### PR TITLE
FIX: Fetch templates during workflow construction

### DIFF
--- a/smriprep/interfaces/templateflow.py
+++ b/smriprep/interfaces/templateflow.py
@@ -203,8 +203,7 @@ def fetch_template_files(
 
     files = {}
     files['t1w'] = tf.get(name[0], desc=None, suffix='T1w', **specs)
-    files['mask'] = (
-        tf.get(name[0], desc='brain', suffix='mask', **specs)
-        or tf.get(name[0], label='brain', suffix='mask', **specs)
+    files['mask'] = tf.get(name[0], desc='brain', suffix='mask', **specs) or tf.get(
+        name[0], label='brain', suffix='mask', **specs
     )
     return files

--- a/smriprep/interfaces/templateflow.py
+++ b/smriprep/interfaces/templateflow.py
@@ -163,7 +163,11 @@ class TemplateDesc(SimpleInterface):
         return runtime
 
 
-def fetch_template_files(template: str, specs: dict | None = None) -> dict:
+def fetch_template_files(
+    template: str,
+    specs: dict | None = None,
+    sloppy: bool = False,
+) -> dict:
     if specs is None:
         specs = {}
 
@@ -178,11 +182,18 @@ def fetch_template_files(template: str, specs: dict | None = None) -> dict:
             }
         )
 
-    if specs['resolution'] and not isinstance(specs['resolution'], list):
+    if res := specs.pop('res', None):
+        if res != 'native':
+            specs['resolution'] = res
+
+    if not specs.get('resolution'):
+        specs['resolution'] = 2 if sloppy else 1
+
+    if specs.get('resolution') and not isinstance(specs['resolution'], list):
         specs['resolution'] = [specs['resolution']]
 
     available_resolutions = tf.TF_LAYOUT.get_resolutions(template=name[0])
-    if specs['resolution'] and not set(specs['resolution']) & set(available_resolutions):
+    if specs.get('resolution') and not set(specs['resolution']) & set(available_resolutions):
         fallback_res = available_resolutions[0] if available_resolutions else None
         LOGGER.warning(
             f"Template {name[0]} does not have resolution(s): {specs['resolution']}."

--- a/smriprep/interfaces/templateflow.py
+++ b/smriprep/interfaces/templateflow.py
@@ -108,34 +108,9 @@ class TemplateFlowSelect(SimpleInterface):
         if isdefined(self.inputs.cohort):
             specs['cohort'] = self.inputs.cohort
 
-        name = self.inputs.template.strip(':').split(':', 1)
-        if len(name) > 1:
-            specs.update(
-                {
-                    k: v
-                    for modifier in name[1].split(':')
-                    for k, v in [tuple(modifier.split('-'))]
-                    if k not in specs
-                }
-            )
-
-        if specs['resolution'] and not isinstance(specs['resolution'], list):
-            specs['resolution'] = [specs['resolution']]
-
-        available_resolutions = tf.TF_LAYOUT.get_resolutions(template=name[0])
-        if specs['resolution'] and not set(specs['resolution']) & set(available_resolutions):
-            fallback_res = available_resolutions[0] if available_resolutions else None
-            LOGGER.warning(
-                f"Template {name[0]} does not have resolution(s): {specs['resolution']}."
-                f"Falling back to resolution: {fallback_res}."
-            )
-            specs['resolution'] = fallback_res
-
-        self._results['t1w_file'] = tf.get(name[0], desc=None, suffix='T1w', **specs)
-
-        self._results['brain_mask'] = tf.get(
-            name[0], desc='brain', suffix='mask', **specs
-        ) or tf.get(name[0], label='brain', suffix='mask', **specs)
+        files = fetch_template_files(self.inputs.template, specs)
+        self._results['t1w_file'] = files['t1w']
+        self._results['brain_mask'] = files['mask']
         return runtime
 
 
@@ -186,3 +161,39 @@ class TemplateDesc(SimpleInterface):
                 descsplit = desc.split('-')
                 self._results['spec'][descsplit[0]] = descsplit[1]
         return runtime
+
+
+def fetch_template_files(template: str, specs: dict | None = None) -> dict:
+    if specs is None:
+        specs = {}
+
+    name = template.strip(':').split(':', 1)
+    if len(name) > 1:
+        specs.update(
+            {
+                k: v
+                for modifier in name[1].split(':')
+                for k, v in [tuple(modifier.split('-'))]
+                if k not in specs
+            }
+        )
+
+    if specs['resolution'] and not isinstance(specs['resolution'], list):
+        specs['resolution'] = [specs['resolution']]
+
+    available_resolutions = tf.TF_LAYOUT.get_resolutions(template=name[0])
+    if specs['resolution'] and not set(specs['resolution']) & set(available_resolutions):
+        fallback_res = available_resolutions[0] if available_resolutions else None
+        LOGGER.warning(
+            f"Template {name[0]} does not have resolution(s): {specs['resolution']}."
+            f"Falling back to resolution: {fallback_res}."
+        )
+        specs['resolution'] = fallback_res
+
+    files = {}
+    files['t1w'] = tf.get(name[0], desc=None, suffix='T1w', **specs)
+    files['mask'] = (
+        tf.get(name[0], desc='brain', suffix='mask', **specs)
+        or tf.get(name[0], label='brain', suffix='mask', **specs)
+    )
+    return files

--- a/smriprep/utils/misc.py
+++ b/smriprep/utils/misc.py
@@ -22,6 +22,7 @@
 #
 """Self-contained utilities to be used within Function nodes."""
 
+
 def apply_lut(in_dseg, lut, newpath=None):
     """Map the input discrete segmentation to a new label set (lookup table, LUT)."""
     import nibabel as nb

--- a/smriprep/utils/misc.py
+++ b/smriprep/utils/misc.py
@@ -21,12 +21,6 @@
 #     https://www.nipreps.org/community/licensing/
 #
 """Self-contained utilities to be used within Function nodes."""
-from pathlib import Path
-import typing as ty
-
-if ty.TYPE_CHECKING:
-    from niworkflows.utils.spaces import Reference
-
 
 def apply_lut(in_dseg, lut, newpath=None):
     """Map the input discrete segmentation to a new label set (lookup table, LUT)."""
@@ -100,25 +94,3 @@ and proceed to delete the files listed above."""
     if logger:
         logger.warn(f'Removed "IsRunning*" files found under {subj_dir}')
     return subjects_dir
-
-
-def get_template_t1w(template: str, sloppy: bool = False) -> Path:
-    """Query templateflow for the T1w to ensure it is present on the filesystem."""
-    import templateflow.api as tf
-
-    spec = {}
-    _space = template.split(':', 1)
-    if len(_space) > 1:
-        spec['cohort'] = _space[1].replace('cohort-', '')
-    space = _space[0]
-
-    available_res = tf.TF_LAYOUT.get_resolutions(template=space)
-    if sloppy and 2 in available_res:
-        res = 2
-    elif 1 in available_res:
-        res = 1
-    else:
-        res = None
-    spec['resolution'] = res
-
-    return tf.get(space, desc=None, suffix='T1w', **spec)

--- a/smriprep/workflows/anatomical.py
+++ b/smriprep/workflows/anatomical.py
@@ -974,9 +974,9 @@ the brain-extracted T1w using `fast` [FSL {fsl_ver}, RRID:SCR_002823, @fsl_fast]
     templates = []
     found_xfms = {}
     for template in spaces.get_spaces(nonstandard=False, dim=(3,)):
-        from ..utils.misc import get_template_t1w
+        from smriprep.interfaces.templateflow import fetch_template_files
 
-        get_template_t1w(template, sloppy)
+        fetch_template_files(template, specs=None, sloppy=sloppy)
         xfms = precomputed.get('transforms', {}).get(template, {})
         if set(xfms) != {'forward', 'reverse'}:
             templates.append(template)

--- a/smriprep/workflows/anatomical.py
+++ b/smriprep/workflows/anatomical.py
@@ -974,9 +974,6 @@ the brain-extracted T1w using `fast` [FSL {fsl_ver}, RRID:SCR_002823, @fsl_fast]
     templates = []
     found_xfms = {}
     for template in spaces.get_spaces(nonstandard=False, dim=(3,)):
-        from smriprep.interfaces.templateflow import fetch_template_files
-
-        fetch_template_files(template, specs=None, sloppy=sloppy)
         xfms = precomputed.get('transforms', {}).get(template, {})
         if set(xfms) != {'forward', 'reverse'}:
             templates.append(template)

--- a/smriprep/workflows/anatomical.py
+++ b/smriprep/workflows/anatomical.py
@@ -973,6 +973,9 @@ the brain-extracted T1w using `fast` [FSL {fsl_ver}, RRID:SCR_002823, @fsl_fast]
     templates = []
     found_xfms = {}
     for template in spaces.get_spaces(nonstandard=False, dim=(3,)):
+        from ..utils.misc import get_template_t1w
+
+        get_template_t1w(template, sloppy)
         xfms = precomputed.get('transforms', {}).get(template, {})
         if set(xfms) != {'forward', 'reverse'}:
             templates.append(template)

--- a/smriprep/workflows/anatomical.py
+++ b/smriprep/workflows/anatomical.py
@@ -277,7 +277,7 @@ def init_anat_preproc_wf(
         omp_nthreads=omp_nthreads,
         skull_strip_fixed_seed=skull_strip_fixed_seed,
     )
-    template_iterator_wf = init_template_iterator_wf(spaces=spaces)
+    template_iterator_wf = init_template_iterator_wf(spaces=spaces, sloppy=sloppy)
     ds_std_volumes_wf = init_ds_anat_volumes_wf(
         bids_root=bids_root,
         output_dir=output_dir,
@@ -725,6 +725,7 @@ BIDS dataset."""
         spaces=spaces,
         freesurfer=freesurfer,
         output_dir=output_dir,
+        sloppy=sloppy,
     )
     # fmt:off
     workflow.connect([

--- a/smriprep/workflows/outputs.py
+++ b/smriprep/workflows/outputs.py
@@ -1168,7 +1168,7 @@ def init_template_iterator_wf(
         run_without_submitting=True,
     )
     select_tpl = pe.Node(
-        TemplateFlowSelect(resolution=2 if sloppy else 1), name='select_tpl', run_without_submitting=True
+        TemplateFlowSelect(), name='select_tpl', run_without_submitting=True
     )
 
     # fmt:off
@@ -1185,7 +1185,7 @@ def init_template_iterator_wf(
         (spacesource, select_tpl, [
             ('space', 'template'),
             ('cohort', 'cohort'),
-            (('resolution', _no_native), 'resolution'),
+            (('resolution', _no_native, sloppy), 'resolution'),
         ]),
         (spacesource, outputnode, [
             ('space', 'space'),
@@ -1251,10 +1251,6 @@ def _pick_cohort(in_template):
     return [_pick_cohort(v) for v in in_template]
 
 
-def _fmt(in_template):
-    return in_template.replace(':', '_')
-
-
 def _empty_report(in_file=None):
     from pathlib import Path
 
@@ -1276,11 +1272,11 @@ def _is_native(value):
     return value == 'native'
 
 
-def _no_native(value):
+def _no_native(value, sloppy=False):
     try:
         return int(value)
     except (TypeError, ValueError):
-        return 1
+        return 2 if sloppy else 1
 
 
 def _drop_path(in_path):

--- a/smriprep/workflows/outputs.py
+++ b/smriprep/workflows/outputs.py
@@ -1116,10 +1116,7 @@ def init_anat_second_derivatives_wf(
 
 
 def init_template_iterator_wf(
-    *,
-    spaces: 'SpatialReferences',
-    sloppy: bool = False,
-    name='template_iterator_wf'
+    *, spaces: 'SpatialReferences', sloppy: bool = False, name='template_iterator_wf'
 ):
     """Prepare the necessary components to resample an image to a template space
 
@@ -1130,6 +1127,11 @@ def init_template_iterator_wf(
 
     The fields in `outputnode` can be used as if they come from a single template.
     """
+    for template in spaces.get_spaces(nonstandard=False, dim=(3,)):
+        from smriprep.interfaces.templateflow import fetch_template_files
+
+        fetch_template_files(template, specs=None, sloppy=sloppy)
+
     workflow = pe.Workflow(name=name)
 
     inputnode = pe.Node(
@@ -1167,9 +1169,7 @@ def init_template_iterator_wf(
         name='select_xfm',
         run_without_submitting=True,
     )
-    select_tpl = pe.Node(
-        TemplateFlowSelect(), name='select_tpl', run_without_submitting=True
-    )
+    select_tpl = pe.Node(TemplateFlowSelect(), name='select_tpl', run_without_submitting=True)
 
     # fmt:off
     workflow.connect([

--- a/smriprep/workflows/outputs.py
+++ b/smriprep/workflows/outputs.py
@@ -33,7 +33,7 @@ from niworkflows.interfaces.space import SpaceDataSource
 from niworkflows.interfaces.utility import KeySelect
 
 from ..interfaces import DerivativesDataSink
-from ..interfaces.templateflow import TemplateFlowSelect
+from ..interfaces.templateflow import TemplateFlowSelect, fetch_template_files
 
 if ty.TYPE_CHECKING:
     from niworkflows.utils.spaces import SpatialReferences
@@ -1128,8 +1128,6 @@ def init_template_iterator_wf(
     The fields in `outputnode` can be used as if they come from a single template.
     """
     for template in spaces.get_spaces(nonstandard=False, dim=(3,)):
-        from smriprep.interfaces.templateflow import fetch_template_files
-
         fetch_template_files(template, specs=None, sloppy=sloppy)
 
     workflow = pe.Workflow(name=name)


### PR DESCRIPTION
This addresses https://github.com/nipreps/fmriprep/issues/3240, a few changes were necessary:

- Fetch templates during workflow creation - without this, I was still observing race conditions causing the T1w/brain mask files to be empty (not yet gotten through `templateflow.api.get()`)
- Add `sloppy` parameter to `init_template_iterator_wf`, since the T1w/brain mask's resolution (used in [`SpatialNormalization`](https://github.com/nipreps/niworkflows/blob/6edfb38f1aa6c706c8a4942ebadd9041738978b9/niworkflows/interfaces/norm.py#L130)) depends on this parameter as well.

I stripped out most of the logic in `TemplateFlowSelect` to avoid duplicating the behavior, since it is essentially linked.