### PR TITLE
CI: Small cleanups to GHA

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -79,6 +79,7 @@ jobs:
 
     env:
       INSTALL_TYPE: ${{ matrix.install }}
+      FSLOUTPUTTYPE: NIFTI_GZ
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -35,6 +35,8 @@ jobs:
         run: |
           if [[ -z "$COMMIT_MSG" ]]; then
             COMMIT_MSG=$(git show -s --format=%s)
+          else
+            COMMIT_MSG=$(echo $COMMIT_MSG | head -n 1)
           fi
           echo $COMMIT_MSG
           echo "commit_message=$COMMIT_MSG" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Merge commits often break the `[skip ci]` check. Also the test logs are full of complaints about missing `FSLOUTPUTTYPE`.