### PR TITLE
MNT: set copyright owner in LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright The NiPreps Developers
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
For consistency with fMRIPrep license (see https://github.com/nipreps/fmriprep/pull/3247 and https://github.com/nipreps/fmriprep/pull/3259).