### PR TITLE
RF: Remove much of the hardcoded `T1w` fields in favor of `anat`

### DIFF
--- a/smriprep/workflows/anatomical.py
+++ b/smriprep/workflows/anatomical.py
@@ -287,7 +287,6 @@ def init_anat_preproc_wf(
     ds_std_volumes_wf = init_ds_anat_volumes_wf(
         bids_root=bids_root,
         output_dir=output_dir,
-        name='ds_std_volumes_wf',
     )
 
     workflow.connect([
@@ -320,10 +319,10 @@ def init_anat_preproc_wf(
         ]),
         (anat_fit_wf, ds_std_volumes_wf, [
             ('outputnode.t1w_valid_list', 'inputnode.source_files'),
-            ('outputnode.t1w_preproc', 'inputnode.t1w_preproc'),
-            ('outputnode.t1w_mask', 'inputnode.t1w_mask'),
-            ('outputnode.t1w_dseg', 'inputnode.t1w_dseg'),
-            ('outputnode.t1w_tpms', 'inputnode.t1w_tpms'),
+            ('outputnode.t1w_preproc', 'inputnode.anat_preproc'),
+            ('outputnode.t1w_mask', 'inputnode.anat_mask'),
+            ('outputnode.t1w_dseg', 'inputnode.anat_dseg'),
+            ('outputnode.t1w_tpms', 'inputnode.anat_tpms'),
         ]),
         (template_iterator_wf, ds_std_volumes_wf, [
             ('outputnode.std_t1w', 'inputnode.ref_file'),

--- a/smriprep/workflows/anatomical.py
+++ b/smriprep/workflows/anatomical.py
@@ -767,7 +767,7 @@ non-uniformity (INU) with `N4BiasFieldCorrection` [@n4], distributed with ANTs {
             image_type='T1w',
             name='anat_template_wf',
         )
-        ds_template_wf = init_ds_template_wf(output_dir=output_dir, num_t1w=num_t1w)
+        ds_template_wf = init_ds_template_wf(output_dir=output_dir, num_anat=num_t1w)
 
         # fmt:off
         workflow.connect([
@@ -780,11 +780,11 @@ non-uniformity (INU) with `N4BiasFieldCorrection` [@n4], distributed with ANTs {
                 ('outputnode.out_report', 'inputnode.t1w_conform_report'),
             ]),
             (anat_template_wf, ds_template_wf, [
-                ('outputnode.anat_realign_xfm', 'inputnode.t1w_ref_xfms'),
+                ('outputnode.anat_realign_xfm', 'inputnode.anat_ref_xfms'),
             ]),
             (sourcefile_buffer, ds_template_wf, [('source_files', 'inputnode.source_files')]),
-            (t1w_buffer, ds_template_wf, [('t1w_preproc', 'inputnode.t1w_preproc')]),
-            (ds_template_wf, outputnode, [('outputnode.t1w_preproc', 't1w_preproc')]),
+            (t1w_buffer, ds_template_wf, [('t1w_preproc', 'inputnode.anat_preproc')]),
+            (ds_template_wf, outputnode, [('outputnode.anat_preproc', 't1w_preproc')]),
         ])
         # fmt:on
     else:

--- a/smriprep/workflows/anatomical.py
+++ b/smriprep/workflows/anatomical.py
@@ -1378,7 +1378,7 @@ def init_anat_template_wf(
 
             from smriprep.workflows.anatomical import init_anat_template_wf
             wf = init_anat_template_wf(
-                longitudinal=False, omp_nthreads=1, num_files=1, contrast="T1w"
+                longitudinal=False, omp_nthreads=1, num_files=1, image_type="T1w"
             )
 
     Parameters

--- a/smriprep/workflows/anatomical.py
+++ b/smriprep/workflows/anatomical.py
@@ -339,12 +339,8 @@ def init_anat_preproc_wf(
             bids_root=bids_root,
             output_dir=output_dir,
         )
-        surface_derivatives_wf = init_surface_derivatives_wf(
-            cifti_output=cifti_output,
-        )
-        ds_surfaces_wf = init_ds_surfaces_wf(
-            bids_root=bids_root, output_dir=output_dir, surfaces=['inflated']
-        )
+        surface_derivatives_wf = init_surface_derivatives_wf()
+        ds_surfaces_wf = init_ds_surfaces_wf(output_dir=output_dir, surfaces=['inflated'])
         ds_curv_wf = init_ds_surface_metrics_wf(
             bids_root=bids_root, output_dir=output_dir, metrics=['curv'], name='ds_curv_wf'
         )
@@ -1215,9 +1211,7 @@ A {t2w_or_flair} image was used to improve pial surface refinement.
         LOGGER.info(f'ANAT Stage 8: Creating GIFTI surfaces for {surfs + spheres}')
     if surfs:
         gifti_surfaces_wf = init_gifti_surfaces_wf(surfaces=surfs)
-        ds_surfaces_wf = init_ds_surfaces_wf(
-            bids_root=bids_root, output_dir=output_dir, surfaces=surfs
-        )
+        ds_surfaces_wf = init_ds_surfaces_wf(output_dir=output_dir, surfaces=surfs)
         # fmt:off
         workflow.connect([
             (surface_recon_wf, gifti_surfaces_wf, [
@@ -1239,7 +1233,7 @@ A {t2w_or_flair} image was used to improve pial surface refinement.
             surfaces=spheres, to_scanner=False, name='gifti_spheres_wf'
         )
         ds_spheres_wf = init_ds_surfaces_wf(
-            bids_root=bids_root, output_dir=output_dir, surfaces=spheres, name='ds_spheres_wf'
+            output_dir=output_dir, surfaces=spheres, name='ds_spheres_wf'
         )
         # fmt:off
         workflow.connect([
@@ -1315,7 +1309,6 @@ A {t2w_or_flair} image was used to improve pial surface refinement.
         LOGGER.info('ANAT Stage 9: Creating fsLR registration sphere')
         fsLR_reg_wf = init_fsLR_reg_wf()
         ds_fsLR_reg_wf = init_ds_surfaces_wf(
-            bids_root=bids_root,
             output_dir=output_dir,
             surfaces=['sphere_reg_fsLR'],
             name='ds_fsLR_reg_wf',
@@ -1340,7 +1333,6 @@ A {t2w_or_flair} image was used to improve pial surface refinement.
         LOGGER.info('ANAT Stage 10: Creating MSM-Sulc registration sphere')
         msm_sulc_wf = init_msm_sulc_wf(sloppy=sloppy)
         ds_msmsulc_wf = init_ds_surfaces_wf(
-            bids_root=bids_root,
             output_dir=output_dir,
             surfaces=['sphere_reg_msm'],
             name='ds_msmsulc_wf',

--- a/smriprep/workflows/anatomical.py
+++ b/smriprep/workflows/anatomical.py
@@ -762,7 +762,9 @@ non-uniformity (INU) with `N4BiasFieldCorrection` [@n4], distributed with ANTs {
             image_type='T1w',
             name='anat_template_wf',
         )
-        ds_template_wf = init_ds_template_wf(output_dir=output_dir, num_anat=num_t1w)
+        ds_template_wf = init_ds_template_wf(
+            output_dir=output_dir, num_anat=num_t1w, image_type='T1w'
+        )
 
         # fmt:off
         workflow.connect([
@@ -992,7 +994,9 @@ the brain-extracted T1w using `fast` [FSL {fsl_ver}, RRID:SCR_002823, @fsl_fast]
             omp_nthreads=omp_nthreads,
             templates=templates,
         )
-        ds_template_registration_wf = init_ds_template_registration_wf(output_dir=output_dir)
+        ds_template_registration_wf = init_ds_template_registration_wf(
+            output_dir=output_dir, image_type='T1w'
+        )
 
         # fmt:off
         workflow.connect([
@@ -1075,7 +1079,7 @@ A {t2w_or_flair} image was used to improve pial surface refinement.
 
     fsnative_xfms = precomputed.get('transforms', {}).get('fsnative')
     if not fsnative_xfms:
-        ds_fs_registration_wf = init_ds_fs_registration_wf(output_dir=output_dir)
+        ds_fs_registration_wf = init_ds_fs_registration_wf(output_dir=output_dir, image_type='T1w')
         # fmt:off
         workflow.connect([
             (sourcefile_buffer, ds_fs_registration_wf, [
@@ -1365,7 +1369,7 @@ def init_anat_template_wf(
     longitudinal: bool,
     omp_nthreads: int,
     num_files: int,
-    image_type: ty.Literal['T1w', 'T2w'] = 'T1w',
+    image_type: ty.Literal['T1w', 'T2w'],
     name: str = 'anat_template_wf',
 ):
     """

--- a/smriprep/workflows/anatomical.py
+++ b/smriprep/workflows/anatomical.py
@@ -953,8 +953,8 @@ the brain-extracted T1w using `fast` [FSL {fsl_ver}, RRID:SCR_002823, @fsl_fast]
             workflow.connect([
                 (fast, lut_t1w_dseg, [('partial_volume_map', 'in_dseg')]),
                 (sourcefile_buffer, ds_dseg_wf, [('source_files', 'inputnode.source_files')]),
-                (lut_t1w_dseg, ds_dseg_wf, [('out', 'inputnode.t1w_dseg')]),
-                (ds_dseg_wf, seg_buffer, [('outputnode.t1w_dseg', 't1w_dseg')]),
+                (lut_t1w_dseg, ds_dseg_wf, [('out', 'inputnode.anat_dseg')]),
+                (ds_dseg_wf, seg_buffer, [('outputnode.anat_dseg', 't1w_dseg')]),
             ])
         if not have_tpms:
             ds_tpms_wf = init_ds_tpms_wf(output_dir=output_dir)

--- a/smriprep/workflows/anatomical.py
+++ b/smriprep/workflows/anatomical.py
@@ -61,10 +61,10 @@ from ..utils.misc import fs_isRunning as _fs_isRunning
 from .fit.registration import init_register_template_wf
 from .outputs import (
     init_anat_reports_wf,
-    init_anat_second_derivatives_wf,
     init_ds_anat_volumes_wf,
     init_ds_dseg_wf,
     init_ds_fs_registration_wf,
+    init_ds_fs_segs_wf,
     init_ds_grayord_metrics_wf,
     init_ds_mask_wf,
     init_ds_surface_metrics_wf,
@@ -335,10 +335,9 @@ def init_anat_preproc_wf(
     ])  # fmt:skip
 
     if freesurfer:
-        anat_second_derivatives_wf = init_anat_second_derivatives_wf(
+        ds_fs_segs_wf = init_ds_fs_segs_wf(
             bids_root=bids_root,
             output_dir=output_dir,
-            cifti_output=cifti_output,
         )
         surface_derivatives_wf = init_surface_derivatives_wf(
             cifti_output=cifti_output,
@@ -369,12 +368,12 @@ def init_anat_preproc_wf(
             (surface_derivatives_wf, ds_curv_wf, [
                 ('outputnode.curv', 'inputnode.curv'),
             ]),
-            (anat_fit_wf, anat_second_derivatives_wf, [
+            (anat_fit_wf, ds_fs_segs_wf, [
                 ('outputnode.t1w_valid_list', 'inputnode.source_files'),
             ]),
-            (surface_derivatives_wf, anat_second_derivatives_wf, [
-                ('outputnode.out_aseg', 'inputnode.t1w_fs_aseg'),
-                ('outputnode.out_aparc', 'inputnode.t1w_fs_aparc'),
+            (surface_derivatives_wf, ds_fs_segs_wf, [
+                ('outputnode.out_aseg', 'inputnode.anat_fs_aseg'),
+                ('outputnode.out_aparc', 'inputnode.anat_fs_aparc'),
             ]),
             (surface_derivatives_wf, outputnode, [
                 ('outputnode.out_aseg', 't1w_aseg'),

--- a/smriprep/workflows/anatomical.py
+++ b/smriprep/workflows/anatomical.py
@@ -961,8 +961,8 @@ the brain-extracted T1w using `fast` [FSL {fsl_ver}, RRID:SCR_002823, @fsl_fast]
             workflow.connect([
                 (fast, fast2bids, [('partial_volume_files', 'inlist')]),
                 (sourcefile_buffer, ds_tpms_wf, [('source_files', 'inputnode.source_files')]),
-                (fast2bids, ds_tpms_wf, [('out', 'inputnode.t1w_tpms')]),
-                (ds_tpms_wf, seg_buffer, [('outputnode.t1w_tpms', 't1w_tpms')]),
+                (fast2bids, ds_tpms_wf, [('out', 'inputnode.anat_tpms')]),
+                (ds_tpms_wf, seg_buffer, [('outputnode.anat_tpms', 't1w_tpms')]),
             ])
         # fmt:on
     else:

--- a/smriprep/workflows/outputs.py
+++ b/smriprep/workflows/outputs.py
@@ -324,7 +324,7 @@ def init_ds_mask_wf(
     *,
     bids_root: str,
     output_dir: str,
-    mask_type: ty.Literal['brain', 'roi'],
+    mask_type: ty.Literal['brain', 'roi', 'ribbon'],
     extra_entities: dict | None = None,
     name='ds_mask_wf',
 ):

--- a/smriprep/workflows/outputs.py
+++ b/smriprep/workflows/outputs.py
@@ -1057,15 +1057,12 @@ def init_ds_fs_segs_wf(
         FreeSurfer's aseg segmentation, in native anatomical space
     source_files
         List of input anatomical images
-    template
-        Template space and specifications
     """
     workflow = Workflow(name=name)
 
     inputnode = pe.Node(
         niu.IdentityInterface(
             fields=[
-                'template',
                 'source_files',
                 'anat_fs_aseg',
                 'anat_fs_aparc',

--- a/smriprep/workflows/outputs.py
+++ b/smriprep/workflows/outputs.py
@@ -232,7 +232,7 @@ def init_ds_template_wf(
     *,
     num_anat: int,
     output_dir: str,
-    image_type: str = 'T1w',
+    image_type: ty.Literal['T1w', 'T2w'],
     name: str = 'ds_template_wf',
 ):
     """
@@ -532,7 +532,7 @@ def init_ds_tpms_wf(
 def init_ds_template_registration_wf(
     *,
     output_dir: str,
-    image_type: ty.Literal['T1w', 'T2w'] = 'T1w',
+    image_type: ty.Literal['T1w', 'T2w'],
     name: str = 'ds_template_registration_wf',
 ):
     """
@@ -618,7 +618,7 @@ def init_ds_template_registration_wf(
 def init_ds_fs_registration_wf(
     *,
     output_dir: str,
-    image_type: ty.Literal['T1w', 'T2w'] = 'T1w',
+    image_type: ty.Literal['T1w', 'T2w'],
     name: str = 'ds_fs_registration_wf',
 ):
     """

--- a/smriprep/workflows/outputs.py
+++ b/smriprep/workflows/outputs.py
@@ -909,11 +909,11 @@ def init_ds_anat_volumes_wf(
             fields=[
                 # Original T1w image
                 'source_files',
-                # T1w-space images
-                't1w_preproc',
-                't1w_mask',
-                't1w_dseg',
-                't1w_tpms',
+                # anat-space images
+                'anat_preproc',
+                'anat_mask',
+                'anat_dseg',
+                'anat_tpms',
                 # Template
                 'ref_file',
                 'anat2std_xfm',
@@ -932,7 +932,7 @@ def init_ds_anat_volumes_wf(
     gen_ref = pe.Node(GenerateSamplingReference(), name='gen_ref', mem_gb=0.01)
 
     # Mask T1w preproc images
-    mask_t1w = pe.Node(ApplyMask(), name='mask_t1w')
+    mask_anat = pe.Node(ApplyMask(), name='mask_anat')
 
     # Resample T1w-space inputs
     anat2std_t1w = pe.Node(
@@ -993,15 +993,15 @@ def init_ds_anat_volumes_wf(
             ('ref_file', 'fixed_image'),
             (('resolution', _is_native), 'keep_native'),
         ]),
-        (inputnode, mask_t1w, [
-            ('t1w_preproc', 'in_file'),
-            ('t1w_mask', 'in_mask'),
+        (inputnode, mask_anat, [
+            ('anat_preproc', 'in_file'),
+            ('anat_mask', 'in_mask'),
         ]),
-        (mask_t1w, anat2std_t1w, [('out_file', 'input_image')]),
-        (inputnode, anat2std_mask, [('t1w_mask', 'input_image')]),
-        (inputnode, anat2std_dseg, [('t1w_dseg', 'input_image')]),
-        (inputnode, anat2std_tpms, [('t1w_tpms', 'input_image')]),
-        (inputnode, gen_ref, [('t1w_preproc', 'moving_image')]),
+        (mask_anat, anat2std_t1w, [('out_file', 'input_image')]),
+        (inputnode, anat2std_mask, [('anat_mask', 'input_image')]),
+        (inputnode, anat2std_dseg, [('anat_dseg', 'input_image')]),
+        (inputnode, anat2std_tpms, [('anat_tpms', 'input_image')]),
+        (inputnode, gen_ref, [('anat_preproc', 'moving_image')]),
         (anat2std_t1w, ds_std_t1w, [('output_image', 'in_file')]),
         (anat2std_mask, ds_std_mask, [('output_image', 'in_file')]),
         (anat2std_dseg, ds_std_dseg, [('output_image', 'in_file')]),

--- a/smriprep/workflows/outputs.py
+++ b/smriprep/workflows/outputs.py
@@ -684,7 +684,6 @@ def init_ds_fs_registration_wf(
 
 def init_ds_surfaces_wf(
     *,
-    bids_root: str,
     output_dir: str,
     surfaces: list[str],
     name='ds_surfaces_wf',
@@ -744,6 +743,8 @@ def init_ds_surfaces_wf(
                 ds_surf.inputs.desc = 'reg'
                 if surf == 'sphere_reg_fsLR':
                     ds_surf.inputs.space = 'fsLR'
+                elif surf == 'sphere_reg_dhcpAsym':
+                    ds_surf.inputs.space = 'dhcpAsym'
 
         # fmt:off
         workflow.connect([

--- a/smriprep/workflows/outputs.py
+++ b/smriprep/workflows/outputs.py
@@ -324,7 +324,8 @@ def init_ds_mask_wf(
     *,
     bids_root: str,
     output_dir: str,
-    mask_type: str,
+    mask_type: ty.Literal['brain', 'roi'],
+    extra_entities: dict | None = None,
     name='ds_mask_wf',
 ):
     """
@@ -336,6 +337,8 @@ def init_ds_mask_wf(
         Root path of BIDS dataset
     output_dir : :obj:`str`
         Directory in which to save derivatives
+    extra_entities : :obj:`dict` or None
+        Additional entities to add to filename
     name : :obj:`str`
         Workflow name (default: ds_mask_wf)
 
@@ -363,12 +366,15 @@ def init_ds_mask_wf(
     raw_sources = pe.Node(niu.Function(function=_bids_relative), name='raw_sources')
     raw_sources.inputs.bids_root = bids_root
 
+    extra_entities = extra_entities or {}
+
     ds_mask = pe.Node(
         DerivativesDataSink(
             base_directory=output_dir,
             desc=mask_type,
             suffix='mask',
             compress=True,
+            **extra_entities,
         ),
         name='ds_anat_mask',
         run_without_submitting=True,
@@ -391,7 +397,12 @@ def init_ds_mask_wf(
     return workflow
 
 
-def init_ds_dseg_wf(*, output_dir: str, name: str = 'ds_dseg_wf'):
+def init_ds_dseg_wf(
+    *,
+    output_dir: str,
+    extra_entities: dict | None = None,
+    name: str = 'ds_dseg_wf',
+):
     """
     Save discrete segmentations
 
@@ -399,6 +410,8 @@ def init_ds_dseg_wf(*, output_dir: str, name: str = 'ds_dseg_wf'):
     ----------
     output_dir : :obj:`str`
         Directory in which to save derivatives
+    extra_entities : :obj:`dict` or None
+        Additional entities to add to filename
     name : :obj:`str`
         Workflow name (default: ds_dseg_wf)
 
@@ -423,12 +436,15 @@ def init_ds_dseg_wf(*, output_dir: str, name: str = 'ds_dseg_wf'):
     )
     outputnode = pe.Node(niu.IdentityInterface(fields=['anat_dseg']), name='outputnode')
 
+    extra_entities = extra_entities or {}
+
     ds_anat_dseg = pe.Node(
         DerivativesDataSink(
             base_directory=output_dir,
             suffix='dseg',
             compress=True,
             dismiss_entities=['desc'],
+            **extra_entities,
         ),
         name='ds_anat_dseg',
         run_without_submitting=True,
@@ -448,6 +464,7 @@ def init_ds_dseg_wf(*, output_dir: str, name: str = 'ds_dseg_wf'):
 def init_ds_tpms_wf(
     *,
     output_dir: str,
+    extra_entities: dict | None = None,
     name: str = 'ds_tpms_wf',
     tpm_labels: tuple = BIDS_TISSUE_ORDER,
 ):
@@ -458,6 +475,8 @@ def init_ds_tpms_wf(
     ----------
     output_dir : :obj:`str`
         Directory in which to save derivatives
+    extra_entities : :obj:`dict` or None
+        Additional entities to add to filename
     name : :obj:`str`
         Workflow name (default: anat_derivatives_wf)
     tpm_labels : :obj:`tuple`
@@ -484,12 +503,15 @@ def init_ds_tpms_wf(
     )
     outputnode = pe.Node(niu.IdentityInterface(fields=['anat_tpms']), name='outputnode')
 
+    extra_entities = extra_entities or {}
+
     ds_anat_tpms = pe.Node(
         DerivativesDataSink(
             base_directory=output_dir,
             suffix='probseg',
             compress=True,
             dismiss_entities=['desc'],
+            **extra_entities,
         ),
         name='ds_anat_tpms',
         run_without_submitting=True,
@@ -907,7 +929,7 @@ def init_ds_anat_volumes_wf(
     inputnode = pe.Node(
         niu.IdentityInterface(
             fields=[
-                # Original T1w image
+                # Original anat image
                 'source_files',
                 # anat-space images
                 'anat_preproc',
@@ -1036,6 +1058,7 @@ def init_ds_fs_segs_wf(
     *,
     bids_root: str,
     output_dir: str,
+    extra_entities: dict | None = None,
     name='ds_fs_segs_wf',
 ):
     """
@@ -1047,6 +1070,8 @@ def init_ds_fs_segs_wf(
         Root path of BIDS dataset
     output_dir : :obj:`str`
         Directory in which to save derivatives
+    extra_entities : :obj:`dict` or None
+        Additional entities to add to filename
     name : :obj:`str`
         Workflow name (default: ds_anat_segs_wf)
 
@@ -1075,15 +1100,27 @@ def init_ds_fs_segs_wf(
     raw_sources = pe.Node(niu.Function(function=_bids_relative), name='raw_sources')
     raw_sources.inputs.bids_root = bids_root
 
+    extra_entities = extra_entities or {}
+
     # Parcellations
     ds_anat_fsaseg = pe.Node(
-        DerivativesDataSink(base_directory=output_dir, desc='aseg', suffix='dseg', compress=True),
+        DerivativesDataSink(
+            base_directory=output_dir,
+            desc='aseg',
+            suffix='dseg',
+            compress=True,
+            **extra_entities,
+        ),
         name='ds_anat_fsaseg',
         run_without_submitting=True,
     )
     ds_anat_fsparc = pe.Node(
         DerivativesDataSink(
-            base_directory=output_dir, desc='aparcaseg', suffix='dseg', compress=True
+            base_directory=output_dir,
+            desc='aparcaseg',
+            suffix='dseg',
+            compress=True,
+            **extra_entities,
         ),
         name='ds_anat_fsparc',
         run_without_submitting=True,

--- a/smriprep/workflows/surfaces.py
+++ b/smriprep/workflows/surfaces.py
@@ -43,6 +43,7 @@ from niworkflows.interfaces.freesurfer import (
 )
 from niworkflows.interfaces.freesurfer import PatchedRobustRegister as RobustRegister
 from niworkflows.interfaces.nitransforms import ConcatenateXFMs
+from niworkflows.interfaces.patches import FreeSurferSource
 from niworkflows.interfaces.utility import KeySelect
 from niworkflows.interfaces.workbench import (
     MetricDilate,
@@ -228,7 +229,7 @@ gray-matter of Mindboggle [RRID:SCR_002438, @mindboggle].
 
     autorecon_resume_wf = init_autorecon_resume_wf(omp_nthreads=omp_nthreads)
 
-    get_surfaces = pe.Node(nio.FreeSurferSource(), name='get_surfaces')
+    get_surfaces = pe.Node(FreeSurferSource(), name='get_surfaces')
 
     midthickness = pe.MapNode(
         MakeMidthickness(thickness=True, distance=0.5, out_name='midthickness'),
@@ -284,7 +285,7 @@ gray-matter of Mindboggle [RRID:SCR_002438, @mindboggle].
         ])  # fmt:skip
     else:
         # Pretend to be the autorecon1 node so fsnative2t1w_xfm gets run ASAP
-        fs_base_inputs = autorecon1 = pe.Node(nio.FreeSurferSource(), name='fs_base_inputs')
+        fs_base_inputs = autorecon1 = pe.Node(FreeSurferSource(), name='fs_base_inputs')
 
         workflow.connect([
             (inputnode, fs_base_inputs, [
@@ -328,7 +329,9 @@ gray-matter of Mindboggle [RRID:SCR_002438, @mindboggle].
     return workflow
 
 
-def init_refinement_wf(*, name='refinement_wf'):
+def init_refinement_wf(
+    *, image_type: ty.Literal['T1w', 'T2w'] = 'T1w', name: str = 'refinement_wf'
+) -> Workflow:
     r"""
     Refine ANTs brain extraction with FreeSurfer segmentation
 
@@ -346,20 +349,12 @@ def init_refinement_wf(*, name='refinement_wf'):
         FreeSurfer SUBJECTS_DIR
     subject_id
         FreeSurfer subject ID
-    fsnative2t1w_xfm
-        LTA-style affine matrix translating from FreeSurfer-conformed subject space to T1w
+    fsnative2anat_xfm
+        LTA-style affine matrix translating from FreeSurfer-conformed subject space to anatomical
     reference_image
         Input
-    t2w
-        List of T2-weighted structural images (only first used)
-    flair
-        List of FLAIR images
-    skullstripped_t1
-        Skull-stripped T1-weighted image (or mask of image)
     ants_segs
         Brain tissue segmentation from ANTS ``antsBrainExtraction.sh``
-    corrected_t1
-        INU-corrected, merged T1-weighted image
     subjects_dir
         FreeSurfer SUBJECTS_DIR
     subject_id
@@ -367,14 +362,6 @@ def init_refinement_wf(*, name='refinement_wf'):
 
     Outputs
     -------
-    subjects_dir
-        FreeSurfer SUBJECTS_DIR
-    subject_id
-        FreeSurfer subject ID
-    t1w2fsnative_xfm
-        LTA-style affine matrix translating from T1w to FreeSurfer-conformed subject space
-    fsnative2t1w_xfm
-        LTA-style affine matrix translating from FreeSurfer-conformed subject space to T1w
     out_brainmask
         Refined brainmask, derived from FreeSurfer's ``aseg`` volume
 
@@ -397,7 +384,7 @@ gray-matter of Mindboggle [RRID:SCR_002438, @mindboggle].
             fields=[
                 'reference_image',
                 'ants_segs',
-                'fsnative2t1w_xfm',
+                'fsnative2anat_xfm',
                 'subjects_dir',
                 'subject_id',
             ]
@@ -413,24 +400,22 @@ gray-matter of Mindboggle [RRID:SCR_002438, @mindboggle].
         name='outputnode',
     )
 
-    aseg_to_native_wf = init_segs_to_native_wf()
+    aseg_to_native_wf = init_segs_to_native_wf(image_type=image_type)
     refine = pe.Node(RefineBrainMask(), name='refine')
 
-    # fmt:off
     workflow.connect([
         # Refine ANTs mask, deriving new mask from FS' aseg
         (inputnode, aseg_to_native_wf, [
             ('subjects_dir', 'inputnode.subjects_dir'),
             ('subject_id', 'inputnode.subject_id'),
             ('reference_image', 'inputnode.in_file'),
-            ('fsnative2t1w_xfm', 'inputnode.fsnative2t1w_xfm'),
+            ('fsnative2t1w_xfm', 'inputnode.fsnative2anat_xfm'),
         ]),
         (inputnode, refine, [('reference_image', 'in_anat'),
                              ('ants_segs', 'in_ants')]),
         (aseg_to_native_wf, refine, [('outputnode.out_file', 'in_aseg')]),
         (refine, outputnode, [('out_file', 'out_brainmask')]),
-    ])
-    # fmt:on
+    ])  # fmt:skip
 
     return workflow
 
@@ -610,8 +595,8 @@ def init_autorecon_resume_wf(*, omp_nthreads, name='autorecon_resume_wf'):
 
 def init_surface_derivatives_wf(
     *,
-    cifti_output: ty.Literal['91k', '170k', False] = False,
-    name='surface_derivatives_wf',
+    image_type: ty.Literal['T1w', 'T2w'] = 'T1w',
+    name: str = 'surface_derivatives_wf',
 ):
     r"""
     Generate sMRIPrep derivatives from FreeSurfer derivatives
@@ -627,9 +612,9 @@ def init_surface_derivatives_wf(
     Inputs
     ------
     reference
-        Reference image in native T1w space, for defining a resampling grid
-    fsnative2t1w_xfm
-        LTA-style affine matrix translating from FreeSurfer-conformed subject space to T1w
+        Reference image in native anatomical space, for defining a resampling grid
+    fsnative2anat_xfm
+        LTA-style affine matrix translating from FreeSurfer-conformed subject space to anatomical
     subjects_dir
         FreeSurfer SUBJECTS_DIR
     subject_id
@@ -643,9 +628,9 @@ def init_surface_derivatives_wf(
     morphometrics
         GIFTIs of cortical thickness, curvature, and sulcal depth
     out_aseg
-        FreeSurfer's aseg segmentation, in native T1w space
+        FreeSurfer's aseg segmentation, in native anatomical space
     out_aparc
-        FreeSurfer's aparc+aseg segmentation, in native T1w space
+        FreeSurfer's aparc+aseg segmentation, in native anatomical space
 
     See also
     --------
@@ -659,7 +644,7 @@ def init_surface_derivatives_wf(
             fields=[
                 'subjects_dir',
                 'subject_id',
-                'fsnative2t1w_xfm',
+                'fsnative2anat_xfm',
                 'reference',
             ]
         ),
@@ -679,8 +664,8 @@ def init_surface_derivatives_wf(
 
     gifti_surfaces_wf = init_gifti_surfaces_wf(surfaces=['inflated'])
     gifti_morph_wf = init_gifti_morphometrics_wf(morphometrics=['curv'])
-    aseg_to_native_wf = init_segs_to_native_wf()
-    aparc_to_native_wf = init_segs_to_native_wf(segmentation='aparc_aseg')
+    aseg_to_native_wf = init_segs_to_native_wf(image_type=image_type)
+    aparc_to_native_wf = init_segs_to_native_wf(image_type=image_type, segmentation='aparc_aseg')
 
     # fmt:off
     workflow.connect([
@@ -688,7 +673,7 @@ def init_surface_derivatives_wf(
         (inputnode, gifti_surfaces_wf, [
             ('subjects_dir', 'inputnode.subjects_dir'),
             ('subject_id', 'inputnode.subject_id'),
-            ('fsnative2t1w_xfm', 'inputnode.fsnative2t1w_xfm'),
+            ('fsnative2anat_xfm', 'inputnode.fsnative2anat_xfm'),
         ]),
         (inputnode, gifti_morph_wf, [
             ('subjects_dir', 'inputnode.subjects_dir'),
@@ -698,13 +683,13 @@ def init_surface_derivatives_wf(
             ('subjects_dir', 'inputnode.subjects_dir'),
             ('subject_id', 'inputnode.subject_id'),
             ('reference', 'inputnode.in_file'),
-            ('fsnative2t1w_xfm', 'inputnode.fsnative2t1w_xfm'),
+            ('fsnative2anat_xfm', 'inputnode.fsnative2anat_xfm'),
         ]),
         (inputnode, aparc_to_native_wf, [
             ('subjects_dir', 'inputnode.subjects_dir'),
             ('subject_id', 'inputnode.subject_id'),
             ('reference', 'inputnode.in_file'),
-            ('fsnative2t1w_xfm', 'inputnode.fsnative2t1w_xfm'),
+            ('fsnative2anat_xfm', 'inputnode.fsnative2anat_xfm'),
         ]),
 
         # Output
@@ -1000,7 +985,7 @@ def init_gifti_morphometrics_wf(
         name='outputnode',
     )
 
-    get_subject = pe.Node(nio.FreeSurferSource(), name='get_surfaces')
+    get_subject = pe.Node(FreeSurferSource(), name='get_surfaces')
 
     morphometry_list = pe.Node(
         niu.Merge(len(morphometrics), ravel_inputs=True),
@@ -1182,7 +1167,12 @@ def init_hcp_morphometrics_wf(
     return workflow
 
 
-def init_segs_to_native_wf(*, name='segs_to_native', segmentation='aseg'):
+def init_segs_to_native_wf(
+    *,
+    image_type: ty.Literal['T1w', 'T2w'] = 'T1w',
+    segmentation: ty.Literal['aseg', 'aparc_aseg', 'wmparc'] = 'aseg',
+    name: str = 'segs_to_native_wf',
+) -> Workflow:
     """
     Get a segmentation from FreeSurfer conformed space into native T1w space.
 
@@ -1196,19 +1186,21 @@ def init_segs_to_native_wf(*, name='segs_to_native', segmentation='aseg'):
 
     Parameters
     ----------
+    image_type
+        MR anatomical image type ('T1w' or 'T2w')
     segmentation
         The name of a segmentation ('aseg' or 'aparc_aseg' or 'wmparc')
 
     Inputs
     ------
     in_file
-        Anatomical, merged T1w image after INU correction
+        Anatomical, merged anatomical image after INU correction
     subjects_dir
         FreeSurfer SUBJECTS_DIR
     subject_id
         FreeSurfer subject ID
-    fsnative2t1w_xfm
-        LTA-style affine matrix translating from FreeSurfer-conformed subject space to T1w
+    fsnative2anat_xfm
+        LTA-style affine matrix translating from FreeSurfer-conformed subject space to anatomical
 
     Outputs
     -------
@@ -1218,16 +1210,16 @@ def init_segs_to_native_wf(*, name='segs_to_native', segmentation='aseg'):
     """
     workflow = Workflow(name=f'{name}_{segmentation}')
     inputnode = pe.Node(
-        niu.IdentityInterface(['in_file', 'subjects_dir', 'subject_id', 'fsnative2t1w_xfm']),
+        niu.IdentityInterface(['in_file', 'subjects_dir', 'subject_id', 'fsnative2anat_xfm']),
         name='inputnode',
     )
     outputnode = pe.Node(niu.IdentityInterface(['out_file']), name='outputnode')
     # Extract the aseg and aparc+aseg outputs
-    fssource = pe.Node(nio.FreeSurferSource(), name='fs_datasource')
+    fssource = pe.Node(FreeSurferSource(), name='fs_datasource')
 
     lta = pe.Node(ConcatenateXFMs(out_fmt='fs'), name='lta', run_without_submitting=True)
 
-    # Resample from T1.mgz to T1w.nii.gz, applying any offset in fsnative2t1w_xfm,
+    # Resample from T1.mgz to T1w.nii.gz, applying any offset in fsnative2anat_xfm,
     # and convert to NIfTI while we're at it
     resample = pe.Node(
         fs.ApplyVolTransform(transformed_file='seg.nii.gz', interp='nearest'),
@@ -1252,20 +1244,20 @@ def init_segs_to_native_wf(*, name='segs_to_native', segmentation='aseg'):
 
         segmentation = (segmentation, _sel)
 
-    # fmt:off
+    anat = 'T2' if image_type == 'T2w' else 'T1'
+
     workflow.connect([
         (inputnode, fssource, [
             ('subjects_dir', 'subjects_dir'),
             ('subject_id', 'subject_id')]),
         (inputnode, lta, [('in_file', 'reference'),
-                          ('fsnative2t1w_xfm', 'in_xfms')]),
-        (fssource, lta, [('T1', 'moving')]),
+                          ('fsnative2anat_xfm', 'in_xfms')]),
+        (fssource, lta, [(anat, 'moving')]),
         (inputnode, resample, [('in_file', 'target_file')]),
         (fssource, resample, [(segmentation, 'source_file')]),
         (lta, resample, [('out_xfm', 'lta_file')]),
         (resample, outputnode, [('transformed_file', 'out_file')]),
-    ])
-    # fmt:on
+    ])  # fmt:skip
     return workflow
 
 

--- a/smriprep/workflows/surfaces.py
+++ b/smriprep/workflows/surfaces.py
@@ -863,8 +863,8 @@ def init_gifti_surfaces_wf(
     ``lh/rh.inflated``, and ``lh/rh.white``.
 
     Vertex coordinates are :py:class:`transformed
-    <smriprep.interfaces.NormalizeSurf>` to align with native T1w space
-    when ``fsnative2t1w_xfm`` is provided.
+    <smriprep.interfaces.NormalizeSurf>` to align with native anatomical space
+    when ``fsnative2anat_xfm`` is provided.
 
     Workflow Graph
         .. workflow::
@@ -880,7 +880,7 @@ def init_gifti_surfaces_wf(
         FreeSurfer SUBJECTS_DIR
     subject_id
         FreeSurfer subject ID
-    fsnative2t1w_xfm
+    fsnative2anat_xfm
         LTA formatted affine transform file
 
     Outputs
@@ -896,7 +896,7 @@ def init_gifti_surfaces_wf(
     workflow = Workflow(name=name)
 
     inputnode = pe.Node(
-        niu.IdentityInterface(['subjects_dir', 'subject_id', 'fsnative2t1w_xfm']),
+        niu.IdentityInterface(['subjects_dir', 'subject_id', 'fsnative2anat_xfm']),
         name='inputnode',
     )
     outputnode = pe.Node(niu.IdentityInterface(['surfaces', *surfaces]), name='outputnode')
@@ -931,7 +931,7 @@ def init_gifti_surfaces_wf(
             ('subject_id', 'subject_id'),
         ]),
         (inputnode, fix_surfs, [
-            ('fsnative2t1w_xfm', 'transform_file'),
+            ('fsnative2anat_xfm', 'transform_file'),
         ]),
         (get_surfaces, surface_list, [
             (surf, f'in{i}') for i, surf in enumerate(surfaces, start=1)
@@ -973,8 +973,6 @@ def init_gifti_morphometrics_wf(
         FreeSurfer SUBJECTS_DIR
     subject_id
         FreeSurfer subject ID
-    fsnative2t1w_xfm
-        LTA formatted affine transform file (inverse)
 
     Outputs
     -------

--- a/smriprep/workflows/surfaces.py
+++ b/smriprep/workflows/surfaces.py
@@ -409,7 +409,7 @@ gray-matter of Mindboggle [RRID:SCR_002438, @mindboggle].
             ('subjects_dir', 'inputnode.subjects_dir'),
             ('subject_id', 'inputnode.subject_id'),
             ('reference_image', 'inputnode.in_file'),
-            ('fsnative2t1w_xfm', 'inputnode.fsnative2anat_xfm'),
+            ('fsnative2anat_xfm', 'inputnode.fsnative2anat_xfm'),
         ]),
         (inputnode, refine, [('reference_image', 'in_anat'),
                              ('ants_segs', 'in_ants')]),


### PR DESCRIPTION
This is a supplemental PR to https://github.com/nipreps/nibabies/pull/360 - since nibabies also relies on smriprep, but may be processing in T2w space, this PR generalize many of the workflows/nodes/fields to account for other anatomical references.