### PR TITLE
STY: Apply ruff/flake8-implicit-str-concat rule ISC001

### DIFF
--- a/smriprep/__main__.py
+++ b/smriprep/__main__.py
@@ -27,5 +27,5 @@ if __name__ == '__main__':
 
     # `python -m smriprep` typically displays the command as __main__.py
     if '__main__.py' in sys.argv[0]:
-        sys.argv[0] = '%s -m smriprep' % sys.executable
+        sys.argv[0] = f'{sys.executable} -m smriprep'
     main()

--- a/smriprep/workflows/base.py
+++ b/smriprep/workflows/base.py
@@ -168,7 +168,7 @@ def init_smriprep_wf(
                 freesurfer_home=os.getenv('FREESURFER_HOME'),
                 spaces=spaces.get_fs_spaces(),
             ),
-            name='fsdir_run_%s' % run_uuid.replace('-', '_'),
+            name='fsdir_run_{}'.format(run_uuid.replace('-', '_')),
             run_without_submitting=True,
         )
         if fs_subjects_dir is not None:
@@ -186,7 +186,7 @@ def init_smriprep_wf(
             longitudinal=longitudinal,
             low_mem=low_mem,
             msm_sulc=msm_sulc,
-            name='single_subject_%s_wf' % subject_id,
+            name=f'single_subject_{subject_id}_wf',
             omp_nthreads=omp_nthreads,
             output_dir=output_dir,
             skull_strip_fixed_seed=skull_strip_fixed_seed,

--- a/smriprep/workflows/fit/registration.py
+++ b/smriprep/workflows/fit/registration.py
@@ -128,10 +128,10 @@ and accessed with *TemplateFlow* [{tf_ver}, @templateflow]:
         # Append template citations to description
         for template in templates:
             template_meta = get_metadata(template.split(':')[0])
-            template_refs = ['@%s' % template.split(':')[0].lower()]
+            template_refs = ['@{}'.format(template.split(':')[0].lower())]
 
             if template_meta.get('RRID', None):
-                template_refs += ['RRID:%s' % template_meta['RRID']]
+                template_refs += [f'RRID:{template_meta["RRID"]}']
 
             workflow.__desc__ += """\
 *{template_name}* [{template_refs}; TemplateFlow ID: {template}]""".format(


### PR DESCRIPTION
	ISC001 Implicitly concatenated string literals on one line

This rule is currently disabled because it conflicts with the formatter:
	https://github.com/astral-sh/ruff/issues/8272