### PR TITLE
MNT: Unpin libitk 5.3 (ANTs 2.5.3 is built with 5.4)

### DIFF
--- a/env.yml
+++ b/env.yml
@@ -10,8 +10,6 @@ dependencies:
   # Intel Math Kernel Library for numpy
   - mkl=2023.2
   - mkl-service=2.4
-  # ANTs is linked against libitk 5.3 but does not pin the version
-  - libitk=5.3
   # Base scientific python stack; required by FSL, so pinned here
   - numpy=1.26
   - scipy=1.13


### PR DESCRIPTION
Getting whiplash here.

Spent way too long today trying to fix this upstream:

* https://github.com/conda-forge/ants-feedstock/pull/12
* https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/807