### PR TITLE
Add `space-fsaverage` to `sphere_reg` output files

### DIFF
--- a/.circleci/ds005_outputs.txt
+++ b/.circleci/ds005_outputs.txt
@@ -25,9 +25,9 @@ smriprep/sub-01/anat/sub-01_hemi-L_curv.shape.gii
 smriprep/sub-01/anat/sub-01_hemi-L_inflated.surf.gii
 smriprep/sub-01/anat/sub-01_hemi-L_midthickness.surf.gii
 smriprep/sub-01/anat/sub-01_hemi-L_pial.surf.gii
-smriprep/sub-01/anat/sub-01_hemi-L_space-fsaverage_desc-reg_sphere.surf.gii
 smriprep/sub-01/anat/sub-01_hemi-L_space-fsLR_desc-msmsulc_sphere.surf.gii
 smriprep/sub-01/anat/sub-01_hemi-L_space-fsLR_desc-reg_sphere.surf.gii
+smriprep/sub-01/anat/sub-01_hemi-L_space-fsaverage_desc-reg_sphere.surf.gii
 smriprep/sub-01/anat/sub-01_hemi-L_sphere.surf.gii
 smriprep/sub-01/anat/sub-01_hemi-L_sulc.shape.gii
 smriprep/sub-01/anat/sub-01_hemi-L_thickness.shape.gii
@@ -36,9 +36,9 @@ smriprep/sub-01/anat/sub-01_hemi-R_curv.shape.gii
 smriprep/sub-01/anat/sub-01_hemi-R_inflated.surf.gii
 smriprep/sub-01/anat/sub-01_hemi-R_midthickness.surf.gii
 smriprep/sub-01/anat/sub-01_hemi-R_pial.surf.gii
-smriprep/sub-01/anat/sub-01_hemi-R_space-fsaverage_desc-reg_sphere.surf.gii
 smriprep/sub-01/anat/sub-01_hemi-R_space-fsLR_desc-msmsulc_sphere.surf.gii
 smriprep/sub-01/anat/sub-01_hemi-R_space-fsLR_desc-reg_sphere.surf.gii
+smriprep/sub-01/anat/sub-01_hemi-R_space-fsaverage_desc-reg_sphere.surf.gii
 smriprep/sub-01/anat/sub-01_hemi-R_sphere.surf.gii
 smriprep/sub-01/anat/sub-01_hemi-R_sulc.shape.gii
 smriprep/sub-01/anat/sub-01_hemi-R_thickness.shape.gii

--- a/.circleci/ds005_outputs.txt
+++ b/.circleci/ds005_outputs.txt
@@ -22,10 +22,10 @@ smriprep/sub-01/anat/sub-01_dseg.nii.gz
 smriprep/sub-01/anat/sub-01_from-fsnative_to-T1w_mode-image_xfm.txt
 smriprep/sub-01/anat/sub-01_from-T1w_to-fsnative_mode-image_xfm.txt
 smriprep/sub-01/anat/sub-01_hemi-L_curv.shape.gii
-smriprep/sub-01/anat/sub-01_hemi-L_desc-reg_sphere.surf.gii
 smriprep/sub-01/anat/sub-01_hemi-L_inflated.surf.gii
 smriprep/sub-01/anat/sub-01_hemi-L_midthickness.surf.gii
 smriprep/sub-01/anat/sub-01_hemi-L_pial.surf.gii
+smriprep/sub-01/anat/sub-01_hemi-L_space-fsaverage_desc-reg_sphere.surf.gii
 smriprep/sub-01/anat/sub-01_hemi-L_space-fsLR_desc-msmsulc_sphere.surf.gii
 smriprep/sub-01/anat/sub-01_hemi-L_space-fsLR_desc-reg_sphere.surf.gii
 smriprep/sub-01/anat/sub-01_hemi-L_sphere.surf.gii
@@ -33,10 +33,10 @@ smriprep/sub-01/anat/sub-01_hemi-L_sulc.shape.gii
 smriprep/sub-01/anat/sub-01_hemi-L_thickness.shape.gii
 smriprep/sub-01/anat/sub-01_hemi-L_white.surf.gii
 smriprep/sub-01/anat/sub-01_hemi-R_curv.shape.gii
-smriprep/sub-01/anat/sub-01_hemi-R_desc-reg_sphere.surf.gii
 smriprep/sub-01/anat/sub-01_hemi-R_inflated.surf.gii
 smriprep/sub-01/anat/sub-01_hemi-R_midthickness.surf.gii
 smriprep/sub-01/anat/sub-01_hemi-R_pial.surf.gii
+smriprep/sub-01/anat/sub-01_hemi-R_space-fsaverage_desc-reg_sphere.surf.gii
 smriprep/sub-01/anat/sub-01_hemi-R_space-fsLR_desc-msmsulc_sphere.surf.gii
 smriprep/sub-01/anat/sub-01_hemi-R_space-fsLR_desc-reg_sphere.surf.gii
 smriprep/sub-01/anat/sub-01_hemi-R_sphere.surf.gii

--- a/smriprep/workflows/outputs.py
+++ b/smriprep/workflows/outputs.py
@@ -731,6 +731,8 @@ def init_ds_surfaces_wf(
                 ds_surf.inputs.desc = 'reg'
                 if surf == 'sphere_reg_fsLR':
                     ds_surf.inputs.space = 'fsLR'
+                elif surf == 'sphere_reg':
+                    ds_surf.inputs.space = 'fsaverage'
 
         # fmt:off
         workflow.connect([

--- a/smriprep/workflows/outputs.py
+++ b/smriprep/workflows/outputs.py
@@ -724,15 +724,11 @@ def init_ds_surfaces_wf(
             run_without_submitting=True,
         )
         if surf.startswith('sphere_reg'):
-            if surf == 'sphere_reg_msm':
-                ds_surf.inputs.desc = 'msmsulc'
+            ds_surf.inputs.space, ds_surf.inputs.desc = 'fsaverage', 'reg'  # Default
+            if surf == 'sphere_reg_fsLR':
                 ds_surf.inputs.space = 'fsLR'
-            else:
-                ds_surf.inputs.desc = 'reg'
-                if surf == 'sphere_reg_fsLR':
-                    ds_surf.inputs.space = 'fsLR'
-                elif surf == 'sphere_reg':
-                    ds_surf.inputs.space = 'fsaverage'
+            elif surf == 'sphere_reg_msm':
+                ds_surf.inputs.space, ds_surf.inputs.desc = 'fsLR', 'msmsulc'
 
         # fmt:off
         workflow.connect([


### PR DESCRIPTION
This stems from https://github.com/nipreps/nibabies/issues/366.

Changes proposed:

- Add `space-fsaverage` to the filenames of sphere files registering fsnative to fsaverage.