### PR TITLE
FIX: Select function in segmentation resampling workflow

### DIFF
--- a/smriprep/workflows/surfaces.py
+++ b/smriprep/workflows/surfaces.py
@@ -1240,7 +1240,7 @@ def init_segs_to_native_wf(
         (fssource, lta, [(anat, 'moving')]),
         (inputnode, resample, [('in_file', 'target_file')]),
         (fssource, select_seg, [(segmentation, 'in_files')]),
-        (select_seg, resample, [('out_file', 'source_file')]),
+        (select_seg, resample, [('out', 'source_file')]),
         (lta, resample, [('out_xfm', 'lta_file')]),
         (resample, outputnode, [('transformed_file', 'out_file')]),
     ])  # fmt:skip

--- a/smriprep/workflows/tests/test_surfaces.py
+++ b/smriprep/workflows/tests/test_surfaces.py
@@ -9,7 +9,7 @@ from nipype.pipeline import engine as pe
 
 from smriprep.interfaces.tests.data import load as load_test_data
 
-from ..surfaces import init_anat_ribbon_wf, init_gifti_surfaces_wf
+from ..surfaces import _select_seg, init_anat_ribbon_wf, init_gifti_surfaces_wf
 
 
 def test_ribbon_workflow(tmp_path: Path):
@@ -53,3 +53,16 @@ def test_ribbon_workflow(tmp_path: Path):
     assert np.allclose(ribbon.affine, expected.affine)
     # Mask data is binary, so we can use np.array_equal
     assert np.array_equal(ribbon.dataobj, expected.dataobj)
+
+
+@pytest.mark.parametrize(
+    ('in_files', 'segmentation', 'expected'),
+    [
+        ('aparc+aseg.mgz', 'aparc_aseg', 'aparc+aseg.mgz'),
+        (['a2009s+aseg.mgz', 'aparc+aseg.mgz'], 'aparc_aseg', 'aparc+aseg.mgz'),
+        (['a2009s+aseg.mgz', 'aparc+aseg.mgz'], 'aparc_2009s', 'a2009s+aseg.mgz'),
+        ('wmparc.mgz', 'wmparc.mgz', 'wmparc.mgz'),
+    ],
+)
+def test_select_seg(in_files, segmentation, expected):
+    assert _select_seg(in_files, segmentation) == expected

--- a/smriprep/workflows/tests/test_surfaces.py
+++ b/smriprep/workflows/tests/test_surfaces.py
@@ -60,7 +60,7 @@ def test_ribbon_workflow(tmp_path: Path):
     [
         ('aparc+aseg.mgz', 'aparc_aseg', 'aparc+aseg.mgz'),
         (['a2009s+aseg.mgz', 'aparc+aseg.mgz'], 'aparc_aseg', 'aparc+aseg.mgz'),
-        (['a2009s+aseg.mgz', 'aparc+aseg.mgz'], 'aparc_2009s', 'a2009s+aseg.mgz'),
+        (['a2009s+aseg.mgz', 'aparc+aseg.mgz'], 'aparc_a2009s', 'a2009s+aseg.mgz'),
         ('wmparc.mgz', 'wmparc.mgz', 'wmparc.mgz'),
     ],
 )


### PR DESCRIPTION
The segmentation selection code was a bit convoluted, this addresses the following:

- Adding a mapping for common replacements
- Avoiding string iteration
- Stopping iteration over files upon the first match
- Raising FileNotFoundError, rather than an unclear IndexError, if no matches are found.