### PR TITLE
FIX: Stop excluding FS minc_modify_header used during fallback registration

### DIFF
--- a/docker/files/freesurfer7.3.2-exclude.txt
+++ b/docker/files/freesurfer7.3.2-exclude.txt
@@ -798,7 +798,6 @@ freesurfer/mni/bin/minclookup
 freesurfer/mni/bin/mincmakescalar
 freesurfer/mni/bin/mincmakevector
 freesurfer/mni/bin/mincmath
-freesurfer/mni/bin/minc_modify_header
 freesurfer/mni/bin/mincpik
 freesurfer/mni/bin/mincresample
 freesurfer/mni/bin/mincreshape


### PR DESCRIPTION
Same as https://github.com/nipreps/fmriprep/pull/3372