### PR TITLE
chore(ci): Update build step, enable pre-release tests

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -46,73 +46,22 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      ## Stuck on https://github.com/astral-sh/uv/issues/5450
-      ## or https://github.com/hynek/build-and-inspect-python-package/issues/155
-      # - uses: hynek/build-and-inspect-python-package@v2
-      #   with:
-      #     upload-name-suffix: -main
-      #     attest-build-provenance-github: ${{ github.event_name != 'pull_request' }}
-      # - uses: hynek/build-and-inspect-python-package@v2
-      #   with:
-      #     path: wrapper
-      #     upload-name-suffix: -wrapper
-      #     attest-build-provenance-github: ${{ github.event_name != 'pull_request' }}
-      ## Manually reproducing with pyproject-build
-      ## Probably slightly slower
-      - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v4
-      - name: Build smriprep
-        run: uvx --from=build pyproject-build --installer uv .
-      - name: Upload smriprep as Packages-main
-        uses: actions/upload-artifact@v4
+      # Note that we cannot upgrade this past 2.9 until uv build resolves a bug
+      # or build-and-inspect-python-package lets us select build as a backend
+      #
+      # https://github.com/astral-sh/uv/issues/5450
+      # or https://github.com/hynek/build-and-inspect-python-package/issues/155
+      #
+      # When we do move on, we should leave a comment to fall back in case of future uv build bugs
+      - uses: hynek/build-and-inspect-python-package@v2.8
         with:
-          name: Packages-main
-          path: dist/
-
-      - name: Show package contents hierarchically, including metadata.
-        shell: bash
-        run: |
-          echo -e '\n<details><summary>SDist contents</summary>\n' >> $GITHUB_STEP_SUMMARY
-          tar -tvzf dist/*.tar.gz | sed 's/^/    /' | tee -a $GITHUB_STEP_SUMMARY
-          echo -e '\n</details>\n' >> $GITHUB_STEP_SUMMARY
-
-          echo -e '\n<details><summary>Wheel contents</summary>\n' >> $GITHUB_STEP_SUMMARY
-          unzip -l dist/*.whl | sed 's/^/    /' | tee -a $GITHUB_STEP_SUMMARY
-          echo -e '\n</details>\n' >> $GITHUB_STEP_SUMMARY
-
-          echo ----- Metadata Follows -----
-          echo -e '\n<details><summary>Metadata</summary>\n' >> $GITHUB_STEP_SUMMARY
-          tar --wildcards -xOf dist/*.tar.gz "*/PKG-INFO" | sed 's/^/    /' | tee -a $GITHUB_STEP_SUMMARY
-          echo -e '\n</details>\n' >> $GITHUB_STEP_SUMMARY
-          echo ----- End of Metadata  -----
-
-      - name: Report on smriprep packages
-        run: |
-          echo "name=Packages-main" >>${GITHUB_OUTPUT}
-      - name: Build smriprep-docker
-        run: uvx --from=build pyproject-build --installer uv ./wrapper
-      - name: Upload smriprep as Packages-wrapper
-        uses: actions/upload-artifact@v4
+          upload-name-suffix: -main
+          attest-build-provenance-github: ${{ github.event_name != 'pull_request' }}
+      - uses: hynek/build-and-inspect-python-package@v2
         with:
-          name: Packages-wrapper
-          path: wrapper/dist/
-
-      - name: Show package contents hierarchically, including metadata.
-        shell: bash
-        run: |
-          echo -e '\n<details><summary>SDist contents</summary>\n' >> $GITHUB_STEP_SUMMARY
-          tar -tvzf wrapper/dist/*.tar.gz | sed 's/^/    /' | tee -a $GITHUB_STEP_SUMMARY
-          echo -e '\n</details>\n' >> $GITHUB_STEP_SUMMARY
-
-          echo -e '\n<details><summary>Wheel contents</summary>\n' >> $GITHUB_STEP_SUMMARY
-          unzip -l wrapper/dist/*.whl | sed 's/^/    /' | tee -a $GITHUB_STEP_SUMMARY
-          echo -e '\n</details>\n' >> $GITHUB_STEP_SUMMARY
-
-          echo ----- Metadata Follows -----
-          echo -e '\n<details><summary>Metadata</summary>\n' >> $GITHUB_STEP_SUMMARY
-          tar --wildcards -xOf wrapper/dist/*.tar.gz "*/PKG-INFO" | sed 's/^/    /' | tee -a $GITHUB_STEP_SUMMARY
-          echo -e '\n</details>\n' >> $GITHUB_STEP_SUMMARY
-          echo ----- End of Metadata  -----
+          path: wrapper
+          upload-name-suffix: -wrapper
+          attest-build-provenance-github: ${{ github.event_name != 'pull_request' }}
 
   test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -69,8 +69,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest"]
         python-version: ["3.10", "3.11", "3.12", "3.13"]
-        dependencies: [latest] # , pre]
-        architecture: ["x64"]
+        dependencies: [latest, pre]
         include:
           # Test minimum dependencies on oldest supported Python
           - os: ubuntu-latest
@@ -95,7 +94,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          architecture: ${{ matrix.architecture }}
       - name: Display Python version
         run: python -c "import sys; print(sys.version)"
 


### PR DESCRIPTION
Following advice in https://github.com/hynek/build-and-inspect-python-package/issues/155, trying out v2.8.

Also enabling pre-release tests. Hopefully this isn't a rabbit hole.