### PR TITLE
chore(ci): Increase test timeout to 30m (~2x median)

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -119,7 +119,7 @@ jobs:
       - name: Show tox config
         run: tox c
       - name: Run tox
-        run: tox -v --exit-and-dump-after 1200
+        run: tox -v --exit-and-dump-after 1800
       - uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -175,7 +175,7 @@ jobs:
       - name: Show tox config
         run: tox c
       - name: Run tox
-        run: tox -v --exit-and-dump-after 1200
+        run: tox -v --exit-and-dump-after 1800
       - uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Hitting 20m timeout. Most runs finish in the 16-17m range, so 30m is a safer indicator that something is actually wrong.