### PR TITLE
FIX: set fast bias_iters parameter to 0

### DIFF
--- a/src/smriprep/interfaces/fsl.py
+++ b/src/smriprep/interfaces/fsl.py
@@ -1,5 +1,6 @@
 from nipype.interfaces.base import traits
-from nipype.interfaces.fsl.preprocess import FAST as _FAST, FASTInputSpec
+from nipype.interfaces.fsl.preprocess import FAST as _FAST
+from nipype.interfaces.fsl.preprocess import FASTInputSpec
 
 
 class _FixTraitFASTInputSpec(FASTInputSpec):
@@ -24,4 +25,3 @@ class FAST(_FAST):
     """
 
     input_spec = _FixTraitFASTInputSpec
-

--- a/src/smriprep/interfaces/fsl.py
+++ b/src/smriprep/interfaces/fsl.py
@@ -21,8 +21,6 @@ class FixBiasItersFAST(FAST):
 
     def _run_interface(self, runtime, correct_return_codes=(0,)):
         # Run normally
-        runtime = super()._run_interface(
-            runtime, correct_return_codes
-        )
+        runtime = super()._run_interface(runtime, correct_return_codes)
 
         return runtime

--- a/src/smriprep/interfaces/fsl.py
+++ b/src/smriprep/interfaces/fsl.py
@@ -17,11 +17,12 @@ class FAST(_FAST):
     A replacement for nipype.interfaces.fsl.preprocess.FAST that allows
     `bias_iters=0` to disable bias field correction entirely
 
-    >>> from smriprep.interfaces.fsl import FixBiasItersFAST as FAST
-    >>> fast = fsl.FAST()
+    >>> from smriprep.interfaces.fsl import FAST
+    >>> fast = FAST()
     >>> fast.inputs.in_files = 'sub-01_desc-warped_T1w.nii.gz'
+    >>> fast.inputs.bias_iters = 0
     >>> fast.cmdline
-    'fast -o fast_ -S 1 -I 0 sub-01_desc-warped_T1w.nii.gz'
+    'fast -I 0 -S 1 sub-01_desc-warped_T1w.nii.gz'
     """
 
     input_spec = _FixTraitFASTInputSpec

--- a/src/smriprep/interfaces/fsl.py
+++ b/src/smriprep/interfaces/fsl.py
@@ -1,0 +1,28 @@
+from nipype.interfaces.base import traits
+from nipype.interfaces.fsl.preprocess import FAST, FASTInputSpec
+
+
+class _FixTraitFASTInputSpec(FASTInputSpec):
+    bias_iters = traits.Range(
+        low=0,
+        high=10,
+        argstr='-I %d',
+        desc='number of main-loop iterations during bias-field removal',
+    )
+
+
+class FixBiasItersFAST(FAST):
+    """
+    A replacement for nipype.interfaces.fsl.preprocess.FAST that allows
+    `bias_iters=0` to disable bias field correction entirely
+    """
+
+    input_spec = _FixTraitFASTInputSpec
+
+    def _run_interface(self, runtime, correct_return_codes=(0,)):
+        # Run normally
+        runtime = super()._run_interface(
+            runtime, correct_return_codes
+        )
+
+        return runtime

--- a/src/smriprep/interfaces/fsl.py
+++ b/src/smriprep/interfaces/fsl.py
@@ -15,6 +15,12 @@ class FAST(_FAST):
     """
     A replacement for nipype.interfaces.fsl.preprocess.FAST that allows
     `bias_iters=0` to disable bias field correction entirely
+
+    >>> from smriprep.interfaces.fsl import FixBiasItersFAST as FAST
+    >>> fast = fsl.FAST()
+    >>> fast.inputs.in_files = 'sub-01_desc-warped_T1w.nii.gz'
+    >>> fast.cmdline
+    'fast -o fast_ -S 1 -I 0 sub-01_desc-warped_T1w.nii.gz'
     """
 
     input_spec = _FixTraitFASTInputSpec

--- a/src/smriprep/interfaces/fsl.py
+++ b/src/smriprep/interfaces/fsl.py
@@ -1,5 +1,5 @@
 from nipype.interfaces.base import traits
-from nipype.interfaces.fsl.preprocess import FAST, FASTInputSpec
+from nipype.interfaces.fsl.preprocess import FAST as _FAST, FASTInputSpec
 
 
 class _FixTraitFASTInputSpec(FASTInputSpec):
@@ -11,7 +11,7 @@ class _FixTraitFASTInputSpec(FASTInputSpec):
     )
 
 
-class FixBiasItersFAST(FAST):
+class FAST(_FAST):
     """
     A replacement for nipype.interfaces.fsl.preprocess.FAST that allows
     `bias_iters=0` to disable bias field correction entirely
@@ -19,8 +19,3 @@ class FixBiasItersFAST(FAST):
 
     input_spec = _FixTraitFASTInputSpec
 
-    def _run_interface(self, runtime, correct_return_codes=(0,)):
-        # Run normally
-        runtime = super()._run_interface(runtime, correct_return_codes)
-
-        return runtime

--- a/src/smriprep/workflows/anatomical.py
+++ b/src/smriprep/workflows/anatomical.py
@@ -57,6 +57,7 @@ from niworkflows.utils.spaces import Reference, SpatialReferences
 import smriprep
 
 from ..interfaces import DerivativesDataSink
+from ..interfaces.fsl import FixBiasItersFAST as FAST
 from ..utils.misc import apply_lut as _apply_bids_lut
 from ..utils.misc import fs_isRunning as _fs_isRunning
 from .fit.registration import init_register_template_wf
@@ -947,14 +948,14 @@ A pre-computed brain mask was provided as input and used throughout the workflow
     # Stage 3: Segmentation
     if not (have_dseg and have_tpms):
         LOGGER.info('ANAT Stage 3: Preparing segmentation workflow')
-        fsl_ver = fsl.FAST().version or '(version unknown)'
+        fsl_ver = FAST().version or '(version unknown)'
         desc += f"""\
 Brain tissue segmentation of cerebrospinal fluid (CSF),
 white-matter (WM) and gray-matter (GM) was performed on
 the brain-extracted T1w using `fast` [FSL {fsl_ver}, RRID:SCR_002823, @fsl_fast].
 """
         fast = pe.Node(
-            fsl.FAST(segments=True, no_bias=True, probability_maps=True),
+            FAST(segments=True, no_bias=True, probability_maps=True),
             name='fast',
             mem_gb=3,
         )

--- a/src/smriprep/workflows/anatomical.py
+++ b/src/smriprep/workflows/anatomical.py
@@ -955,7 +955,7 @@ white-matter (WM) and gray-matter (GM) was performed on
 the brain-extracted T1w using `fast` [FSL {fsl_ver}, RRID:SCR_002823, @fsl_fast].
 """
         fast = pe.Node(
-            FAST(segments=True, no_bias=True, probability_maps=True),
+            FAST(segments=True, no_bias=True, probability_maps=True, bias_iters=0),
             name='fast',
             mem_gb=3,
         )

--- a/src/smriprep/workflows/anatomical.py
+++ b/src/smriprep/workflows/anatomical.py
@@ -57,7 +57,7 @@ from niworkflows.utils.spaces import Reference, SpatialReferences
 import smriprep
 
 from ..interfaces import DerivativesDataSink
-from ..interfaces.fsl import FixBiasItersFAST as FAST
+from ..interfaces.fsl import FAST
 from ..utils.misc import apply_lut as _apply_bids_lut
 from ..utils.misc import fs_isRunning as _fs_isRunning
 from .fit.registration import init_register_template_wf


### PR DESCRIPTION
This adds a new fsl interface module, which contains a patch for nipype's fast interface. The nipype interface requires bias_iters to be `1 <= integer <= 10`, but setting `bias_iters=0` is required to bypass bias field correction.

The patched interface is dropped into the anatomical workflow and the parameters are accordingly updated.

closes #471 