### PR TITLE
Resample surfaces to any space/density using Connectome Workbench.

### DIFF
--- a/src/smriprep/workflows/anatomical.py
+++ b/src/smriprep/workflows/anatomical.py
@@ -382,7 +382,8 @@ def init_anat_preproc_wf(
             hcp_morphometrics_wf = init_hcp_morphometrics_wf(omp_nthreads=omp_nthreads)
             resample_surfaces_wf = init_resample_surfaces_wf(
                 surfaces=['white', 'pial', 'midthickness'],
-                grayord_density=cifti_output,
+                space='fsLR',
+                density='32k' if cifti_output == '91k' else '59k',
             )
             morph_grayords_wf = init_morph_grayords_wf(
                 grayord_density=cifti_output, omp_nthreads=omp_nthreads

--- a/src/smriprep/workflows/anatomical.py
+++ b/src/smriprep/workflows/anatomical.py
@@ -382,7 +382,6 @@ def init_anat_preproc_wf(
             hcp_morphometrics_wf = init_hcp_morphometrics_wf(omp_nthreads=omp_nthreads)
             resample_surfaces_wf = init_resample_surfaces_wf(
                 surfaces=['white', 'pial', 'midthickness'],
-                space='fsLR',
                 density='32k' if cifti_output == '91k' else '59k',
             )
             morph_grayords_wf = init_morph_grayords_wf(

--- a/src/smriprep/workflows/surfaces.py
+++ b/src/smriprep/workflows/surfaces.py
@@ -1319,11 +1319,11 @@ def init_anat_ribbon_wf(name='anat_ribbon_wf'):
     return workflow
 
 
-def init_resample_surfaces_wb_wf(
+def init_resample_surfaces_wf(
     surfaces: list[str],
     space: str,
     density: str,
-    name: str = 'resample_surfaces_wb_wf',
+    name: str = 'resample_surfaces_wf',
 ):
     """
     Resample subject surfaces surface to specified space and density.
@@ -1333,8 +1333,8 @@ def init_resample_surfaces_wb_wf(
             :graph2use: colored
             :simple_form: yes
 
-            from smriprep.workflows.surfaces import init_resample_surfaces_wb_wf
-            wf = init_resample_surfaces_wb_wf(
+            from smriprep.workflows.surfaces import init_resample_surfaces_wf
+            wf = init_resample_surfaces_wf(
                 surfaces=['white', 'pial', 'midthickness'],
                 space='onavg',
                 density='10k',
@@ -1349,7 +1349,7 @@ def init_resample_surfaces_wb_wf(
     density : :class:`str`
         The density to resample to, e.g., ``'10k'``, ``'41k'``. Number of vertices per hemisphere.
     name : :class:`str`
-        Unique name for the subworkflow (default: ``"resample_surfaces_wb_wf"``)
+        Unique name for the subworkflow (default: ``"resample_surfaces_wf"``)
 
     Inputs
     ------
@@ -1375,7 +1375,7 @@ def init_resample_surfaces_wb_wf(
     )
 
     outputnode = pe.Node(
-        niu.IdentityInterface(fields=[f'{surf}_resampled' for surf in surfaces]), name='outputnode'
+        niu.IdentityInterface(fields=[f'{surf}_{space}' for surf in surfaces]), name='outputnode'
     )
 
     surface_list = pe.Node(
@@ -1422,84 +1422,7 @@ def init_resample_surfaces_wb_wf(
         (surface_list, resampler, [('out', 'surface_in')]),
         (resampler, surface_groups, [('surface_out', 'inlist')]),
         (surface_groups, outputnode, [
-            (f'out{i}', f'{surf}_resampled') for i, surf in enumerate(surfaces, start=1)
-        ]),
-    ])  # fmt:skip
-
-    return workflow
-
-
-def init_resample_surfaces_wf(
-    surfaces: list[str],
-    grayord_density: ty.Literal['91k', '170k'],
-    name: str = 'resample_surfaces_wf',
-):
-    """
-    Resample subject surfaces surface to specified density.
-
-    Workflow Graph
-        .. workflow::
-            :graph2use: colored
-            :simple_form: yes
-
-            from smriprep.workflows.surfaces import init_resample_surfaces_wf
-            wf = init_resample_surfaces_wf(
-                surfaces=['white', 'pial', 'midthickness'],
-                grayord_density='91k',
-            )
-
-    Parameters
-    ----------
-    surfaces : :class:`list` of :class:`str`
-        Names of surfaces (e.g., ``'white'``) to resample. Both hemispheres will be resampled.
-    grayord_density : :class:`str`
-        Either `91k` or `170k`, representing the total of vertices or *grayordinates*.
-    name : :class:`str`
-        Unique name for the subworkflow (default: ``"resample_surfaces_wf"``)
-
-    Inputs
-    ------
-    ``<surface>``
-        Left and right GIFTIs for each surface name passed to ``surfaces``
-    sphere_reg_fsLR
-        GIFTI surface mesh corresponding to the subject's fsLR registration sphere
-
-    Outputs
-    -------
-    ``<surface>``
-        Left and right GIFTI surface mesh corresponding to the input surface, resampled to fsLR
-    """
-    # import templateflow.api as tf
-    from niworkflows.engine.workflows import LiterateWorkflow as Workflow
-
-    workflow = Workflow(name=name)
-
-    fslr_density = '32k' if grayord_density == '91k' else '59k'
-
-    inputnode = pe.Node(
-        niu.IdentityInterface(fields=[*surfaces, 'sphere_reg_fsLR']),
-        name='inputnode',
-    )
-
-    outputnode = pe.Node(
-        niu.IdentityInterface(fields=[f'{surf}_fsLR' for surf in surfaces]), name='outputnode'
-    )
-
-    resample_surfaces_wb_wf = init_resample_surfaces_wb_wf(
-        surfaces=surfaces,
-        space='fsLR',
-        density=fslr_density,
-        name='resample_surfaces_fslr_wb_wf',
-    )
-    workflow.connect([
-        (inputnode, resample_surfaces_wb_wf, [
-            (surf, 'inputnode.'+surf) for surf in surfaces
-        ]),
-        (inputnode, resample_surfaces_wb_wf, [
-            ('sphere_reg_fsLR', 'inputnode.sphere_reg_fsLR'),
-        ]),
-        (resample_surfaces_wb_wf, outputnode, [
-            (f'outputnode.{surf}_resampled', f'{surf}_fsLR') for surf in surfaces
+            (f'out{i}', f'{surf}_{space}') for i, surf in enumerate(surfaces, start=1)
         ]),
     ])  # fmt:skip
 

--- a/src/smriprep/workflows/surfaces.py
+++ b/src/smriprep/workflows/surfaces.py
@@ -1389,7 +1389,7 @@ def init_resample_surfaces_wb_wf(
         iterfield=['surface_in', 'current_sphere', 'new_sphere'],
         name='resampler',
     )
-    new_sphere = [
+    resampler.inputs.new_sphere = [
         str(
             tf.get(
                 template=space,
@@ -1404,8 +1404,6 @@ def init_resample_surfaces_wb_wf(
         for _surf in surfaces
         for hemi in ['L', 'R']
     ]
-    print(new_sphere)
-    resampler.inputs.new_sphere = new_sphere
 
     surface_groups = pe.Node(
         niu.Split(splits=[2] * len(surfaces)),

--- a/src/smriprep/workflows/surfaces.py
+++ b/src/smriprep/workflows/surfaces.py
@@ -29,6 +29,7 @@ structural images.
 """
 
 import typing as ty
+import warnings
 
 from nipype.interfaces import freesurfer as fs
 from nipype.interfaces import io as nio
@@ -1321,8 +1322,9 @@ def init_anat_ribbon_wf(name='anat_ribbon_wf'):
 
 def init_resample_surfaces_wf(
     surfaces: list[str],
-    space: str,
-    density: str,
+    density: str | None = None,
+    grayord_density: str | None = None,
+    space: str = 'fsLR',
     name: str = 'resample_surfaces_wf',
 ):
     """
@@ -1366,6 +1368,17 @@ def init_resample_surfaces_wf(
     """
     import templateflow.api as tf
     from niworkflows.engine.workflows import LiterateWorkflow as Workflow
+
+    if density is None:
+        if grayord_density is None:
+            raise ValueError('No density specified. Set density argument.')
+        density = '32k' if grayord_density == '91k' else '59k'
+        warnings.warn(
+            'Deprecated grayord_density passed. Replace with\n\t'
+            "density='32k' if grayord_density == '91k' else '59k'",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
     workflow = Workflow(name=name)
 


### PR DESCRIPTION
Adding `init_resample_surfaces_wb_wf`, which is similar to `init_resample_surfaces_wf` but not limited to fsLR spaces.
It can resample surfaces to the specified space and density if the corresponding files exist in TemplateFlow.

For non-fsLR templates, it needs the `space-fsLR` files of the template, which connects the registered sphere (fsLR space) with the template (template space).
For example, with `tpl-onavg_space-fsLR_hemi-L_den-10k_sphere.surf.gii` it can resample the subject's surfaces to `space-onavg_hemi-L_den-10k`.

The code is mostly copied and modified from `init_resample_surfaces_wf`.