### PR TITLE
REF: generalised anat_fit_wf

### DIFF
--- a/src/smriprep/workflows/anatomical.py
+++ b/src/smriprep/workflows/anatomical.py
@@ -811,7 +811,7 @@ non-uniformity (INU) with `N4BiasFieldCorrection` [@n4], distributed with ANTs {
 
         # fmt:off
         workflow.connect([
-            (inputnode, anat_template_wf, [('t1w', 'inputnode.anat_files')]),
+            (inputnode, anat_template_wf, [(anat, 'inputnode.anat_files')]),
             (anat_template_wf, anat_validate, [('outputnode.anat_ref', 'in_file')]),
             (anat_template_wf, sourcefile_buffer, [
                 ('outputnode.anat_valid_list', 'source_files'),
@@ -1212,7 +1212,7 @@ Found a {reference_anat}-to-fsnative transform without the reverse. Time to hand
         ds_t2w_preproc.inputs.SkullStripped = False
 
         workflow.connect([
-            (inputnode, t2w_template_wf, [('t2w', 'inputnode.anat_files')]),
+            (inputnode, t2w_template_wf, [(aux_anat.lower(), 'inputnode.anat_files')]),
             (t2w_template_wf, bbreg, [('outputnode.anat_ref', 'source_file')]),
             (surface_recon_wf, bbreg, [
                 ('outputnode.subject_id', 'subject_id'),
@@ -1224,7 +1224,7 @@ Found a {reference_anat}-to-fsnative transform without the reverse. Time to hand
             (t2w_template_wf, t2w_resample, [('outputnode.anat_ref', 'input_image')]),
             (t1w_buffer, t2w_resample, [('t1w_preproc', 'reference_image')]),
             (t2wtot1w_xfm, t2w_resample, [('out_xfm', 'transforms')]),
-            (inputnode, ds_t2w_preproc, [('t2w', 'source_file')]),
+            (inputnode, ds_t2w_preproc, [(aux_anat.lower(), 'source_file')]),
             (t2w_resample, ds_t2w_preproc, [('output_image', 'in_file')]),
             (ds_t2w_preproc, outputnode, [('out_file', 't2w_preproc')]),
         ])  # fmt:skip

--- a/src/smriprep/workflows/anatomical.py
+++ b/src/smriprep/workflows/anatomical.py
@@ -634,6 +634,7 @@ def init_anat_fit_wf(
         num_aux_anat = num_t2w if reference_anat == 'T1w' else num_t1w
     else:
         aux = None
+        aux_anat = None
     desc = f"""
 Anatomical data preprocessing
 

--- a/src/smriprep/workflows/anatomical.py
+++ b/src/smriprep/workflows/anatomical.py
@@ -791,8 +791,10 @@ images were found within the input BIDS dataset."""
  {'Each' if num_prefer_anat > 1 else 'The'} {reference_anat} image was corrected for intensity
 non-uniformity (INU) with `N4BiasFieldCorrection` [@n4], distributed with ANTs {ants_ver}
 [@ants, RRID:SCR_004757]"""
-        desc += '.\n' if num_prefer_anat > 1 else (
-            f', and used as {reference_anat}-reference throughout the workflow.\n'
+        desc += (
+            '.\n'
+            if num_prefer_anat > 1
+            else (f', and used as {reference_anat}-reference throughout the workflow.\n')
         )
 
         anat_template_wf = init_anat_template_wf(
@@ -1091,7 +1093,7 @@ the brain-extracted {reference_anat} using `fast` [FSL {fsl_ver}, RRID:SCR_00282
         precomputed=precomputed,
     )
     if aux or flair:
-        aux_or_flair = f'{aux_anat.strip('w')}-weighted' if aux else 'FLAIR'
+        aux_or_flair = f'{aux_anat.strip("w")}-weighted' if aux else 'FLAIR'
         surface_recon_wf.__desc__ += f"""\
 A {aux_or_flair} image was used to improve pial surface refinement.
 """
@@ -1120,8 +1122,7 @@ A {aux_or_flair} image was used to improve pial surface refinement.
     fsnative_xfms = precomputed.get('transforms', {}).get('fsnative')
     if not fsnative_xfms:
         ds_fs_registration_wf = init_ds_fs_registration_wf(
-            output_dir=output_dir,
-            image_type=reference_anat
+            output_dir=output_dir, image_type=reference_anat
         )
         # fmt:off
         workflow.connect([
@@ -1141,7 +1142,8 @@ A {aux_or_flair} image was used to improve pial surface refinement.
         outputnode.inputs.fsnative2t1w_xfm = fsnative_xfms['reverse']
     else:
         raise RuntimeError(
-            f'Found a {reference_anat}-to-fsnative transform without the reverse. Time to handle this.'
+            f"""\
+Found a {reference_anat}-to-fsnative transform without the reverse. Time to handle this."""
         )
 
     if not have_mask:

--- a/src/smriprep/workflows/anatomical.py
+++ b/src/smriprep/workflows/anatomical.py
@@ -631,7 +631,7 @@ def init_anat_fit_wf(
     if t1w and t2w:
         aux = t2w if reference_anat == 'T1w' else t1w
         aux_anat = ({'T1w', 'T2w'} - {reference_anat}).pop()
-        num_aux_anat = ({num_t1w, num_t2w} - num_prefer_anat).pop()
+        num_aux_anat = num_t2w if reference_anat == 'T1w' else num_t1w
     else:
         aux = None
     desc = f"""


### PR DESCRIPTION
This is a first-step towards having anatomical workflows be less biased towards t1w in preparation for extending to populations other than adult humans

It adds a preferred anatomical image type `reference_anat` to the fit workflow, and then changes the calls to t1w or t2w as either the reference anat or the auxiliary anat, if there is more than one type of anatomical image present

Edited to add:
the goal here is trying not to break the existing workflow. we'll add more functionality later