### PR TITLE
fix: Respect label order in precomputed derivatives

### DIFF
--- a/src/smriprep/utils/bids.py
+++ b/src/smriprep/utils/bids.py
@@ -47,11 +47,17 @@ def collect_derivatives(derivatives_dir, subject_id, std_spaces, spec=None, patt
     derivs_cache = {}
     for key, qry in spec['baseline'].items():
         qry['subject'] = subject_id
-        item = layout.get(return_type='filename', **qry)
+        item = layout.get(**qry)
         if not item:
             continue
 
-        derivs_cache[f't1w_{key}'] = item[0] if len(item) == 1 else item
+        # Respect label order in queries
+        if 'label' in qry:
+            item = sorted(item, key=lambda x: qry['label'].index(x.entities['label']))
+
+        paths = [item.path for item in item]
+
+        derivs_cache[f't1w_{key}'] = paths[0] if len(paths) == 1 else paths
 
     transforms = derivs_cache.setdefault('transforms', {})
     for _space in std_spaces:


### PR DESCRIPTION
`BIDSLayout` does a `natural_sort` on all `get()` query results, which breaks ordering encoded in the query itself. This PR looks for the label entity in the query and re-sorts by the label list to ensure that values are returned as expected.

A more robust refactor might either carry around a list of tissue labels or re-order probsegs, but doing that right would be a nontrivial effort, and introduce opportunities for new bugs. This narrowly targets a known bug.

This is a bug-fix candidate PR.

Fixes #474.