### PR TITLE
ENH: Generate cortex mask in anat_fit_wf

### DIFF
--- a/.circleci/ds005_outputs.txt
+++ b/.circleci/ds005_outputs.txt
@@ -22,7 +22,7 @@ smriprep/sub-01/anat/sub-01_dseg.nii.gz
 smriprep/sub-01/anat/sub-01_from-fsnative_to-T1w_mode-image_xfm.txt
 smriprep/sub-01/anat/sub-01_from-T1w_to-fsnative_mode-image_xfm.txt
 smriprep/sub-01/anat/sub-01_hemi-L_curv.shape.gii
-smriprep/sub-01/anat/sub-01_hemi-L_desc-cortex_mask.label.gii
+smriprep/sub-01/anat/sub-01_hemi-L_desc-roi_mask.label.gii
 smriprep/sub-01/anat/sub-01_hemi-L_inflated.surf.gii
 smriprep/sub-01/anat/sub-01_hemi-L_midthickness.surf.gii
 smriprep/sub-01/anat/sub-01_hemi-L_pial.surf.gii
@@ -37,7 +37,7 @@ smriprep/sub-01/anat/sub-01_hemi-L_sulc.shape.gii
 smriprep/sub-01/anat/sub-01_hemi-L_thickness.shape.gii
 smriprep/sub-01/anat/sub-01_hemi-L_white.surf.gii
 smriprep/sub-01/anat/sub-01_hemi-R_curv.shape.gii
-smriprep/sub-01/anat/sub-01_hemi-R_desc-cortex_mask.label.gii
+smriprep/sub-01/anat/sub-01_hemi-R_desc-roi_mask.label.gii
 smriprep/sub-01/anat/sub-01_hemi-R_inflated.surf.gii
 smriprep/sub-01/anat/sub-01_hemi-R_midthickness.surf.gii
 smriprep/sub-01/anat/sub-01_hemi-R_pial.surf.gii

--- a/.circleci/ds005_outputs.txt
+++ b/.circleci/ds005_outputs.txt
@@ -22,6 +22,7 @@ smriprep/sub-01/anat/sub-01_dseg.nii.gz
 smriprep/sub-01/anat/sub-01_from-fsnative_to-T1w_mode-image_xfm.txt
 smriprep/sub-01/anat/sub-01_from-T1w_to-fsnative_mode-image_xfm.txt
 smriprep/sub-01/anat/sub-01_hemi-L_curv.shape.gii
+smriprep/sub-01/anat/sub-01_hemi-L_desc-roi_mask.json
 smriprep/sub-01/anat/sub-01_hemi-L_desc-roi_mask.label.gii
 smriprep/sub-01/anat/sub-01_hemi-L_inflated.surf.gii
 smriprep/sub-01/anat/sub-01_hemi-L_midthickness.surf.gii
@@ -37,6 +38,7 @@ smriprep/sub-01/anat/sub-01_hemi-L_sulc.shape.gii
 smriprep/sub-01/anat/sub-01_hemi-L_thickness.shape.gii
 smriprep/sub-01/anat/sub-01_hemi-L_white.surf.gii
 smriprep/sub-01/anat/sub-01_hemi-R_curv.shape.gii
+smriprep/sub-01/anat/sub-01_hemi-R_desc-roi_mask.json
 smriprep/sub-01/anat/sub-01_hemi-R_desc-roi_mask.label.gii
 smriprep/sub-01/anat/sub-01_hemi-R_inflated.surf.gii
 smriprep/sub-01/anat/sub-01_hemi-R_midthickness.surf.gii

--- a/.circleci/ds005_outputs.txt
+++ b/.circleci/ds005_outputs.txt
@@ -22,6 +22,7 @@ smriprep/sub-01/anat/sub-01_dseg.nii.gz
 smriprep/sub-01/anat/sub-01_from-fsnative_to-T1w_mode-image_xfm.txt
 smriprep/sub-01/anat/sub-01_from-T1w_to-fsnative_mode-image_xfm.txt
 smriprep/sub-01/anat/sub-01_hemi-L_curv.shape.gii
+smriprep/sub-01/anat/sub-01_hemi-L_desc-cortex_mask.label.gii
 smriprep/sub-01/anat/sub-01_hemi-L_inflated.surf.gii
 smriprep/sub-01/anat/sub-01_hemi-L_midthickness.surf.gii
 smriprep/sub-01/anat/sub-01_hemi-L_pial.surf.gii
@@ -36,6 +37,7 @@ smriprep/sub-01/anat/sub-01_hemi-L_sulc.shape.gii
 smriprep/sub-01/anat/sub-01_hemi-L_thickness.shape.gii
 smriprep/sub-01/anat/sub-01_hemi-L_white.surf.gii
 smriprep/sub-01/anat/sub-01_hemi-R_curv.shape.gii
+smriprep/sub-01/anat/sub-01_hemi-R_desc-cortex_mask.label.gii
 smriprep/sub-01/anat/sub-01_hemi-R_inflated.surf.gii
 smriprep/sub-01/anat/sub-01_hemi-R_midthickness.surf.gii
 smriprep/sub-01/anat/sub-01_hemi-R_pial.surf.gii

--- a/.circleci/ds005_outputs.txt
+++ b/.circleci/ds005_outputs.txt
@@ -22,8 +22,8 @@ smriprep/sub-01/anat/sub-01_dseg.nii.gz
 smriprep/sub-01/anat/sub-01_from-fsnative_to-T1w_mode-image_xfm.txt
 smriprep/sub-01/anat/sub-01_from-T1w_to-fsnative_mode-image_xfm.txt
 smriprep/sub-01/anat/sub-01_hemi-L_curv.shape.gii
-smriprep/sub-01/anat/sub-01_hemi-L_desc-roi_mask.json
-smriprep/sub-01/anat/sub-01_hemi-L_desc-roi_mask.label.gii
+smriprep/sub-01/anat/sub-01_hemi-L_desc-cortex_mask.json
+smriprep/sub-01/anat/sub-01_hemi-L_desc-cortex_mask.label.gii
 smriprep/sub-01/anat/sub-01_hemi-L_inflated.surf.gii
 smriprep/sub-01/anat/sub-01_hemi-L_midthickness.surf.gii
 smriprep/sub-01/anat/sub-01_hemi-L_pial.surf.gii
@@ -38,8 +38,8 @@ smriprep/sub-01/anat/sub-01_hemi-L_sulc.shape.gii
 smriprep/sub-01/anat/sub-01_hemi-L_thickness.shape.gii
 smriprep/sub-01/anat/sub-01_hemi-L_white.surf.gii
 smriprep/sub-01/anat/sub-01_hemi-R_curv.shape.gii
-smriprep/sub-01/anat/sub-01_hemi-R_desc-roi_mask.json
-smriprep/sub-01/anat/sub-01_hemi-R_desc-roi_mask.label.gii
+smriprep/sub-01/anat/sub-01_hemi-R_desc-cortex_mask.json
+smriprep/sub-01/anat/sub-01_hemi-R_desc-cortex_mask.label.gii
 smriprep/sub-01/anat/sub-01_hemi-R_inflated.surf.gii
 smriprep/sub-01/anat/sub-01_hemi-R_midthickness.surf.gii
 smriprep/sub-01/anat/sub-01_hemi-R_pial.surf.gii

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "nibabel >= 4.0.1",
     "nipype >= 1.8.5",
     "nireports >= 25.2.0",
-    "niworkflows >= 1.13.4",
+    "niworkflows @ git+https://github.com/nipreps/niworkflows.git@master",
     "numpy >= 1.24",
     "packaging >= 24",
     "pybids >= 0.16",

--- a/src/smriprep/data/io_spec.json
+++ b/src/smriprep/data/io_spec.json
@@ -149,7 +149,7 @@
         "datatype": "anat",
         "hemi": ["L", "R"],
         "space": null,
-        "desc": "cortex",
+        "desc": "roi",
         "suffix": "mask",
         "extension": ".label.gii"
       }

--- a/src/smriprep/data/io_spec.json
+++ b/src/smriprep/data/io_spec.json
@@ -144,6 +144,14 @@
         "desc": "msmsulc",
         "suffix": "sphere",
         "extension": ".surf.gii"
+      },
+      "cortex_mask": {
+        "datatype": "anat",
+        "hemi": ["L", "R"],
+        "space": null,
+        "desc": "cortex",
+        "suffix": "mask",
+        "extension": ".label.gii"
       }
     },
     "masks": {

--- a/src/smriprep/data/io_spec.json
+++ b/src/smriprep/data/io_spec.json
@@ -149,7 +149,7 @@
         "datatype": "anat",
         "hemi": ["L", "R"],
         "space": null,
-        "desc": "roi",
+        "desc": "cortex",
         "suffix": "mask",
         "extension": ".label.gii"
       }

--- a/src/smriprep/workflows/anatomical.py
+++ b/src/smriprep/workflows/anatomical.py
@@ -1249,12 +1249,12 @@ A {t2w_or_flair} image was used to improve pial surface refinement.
                 ('outputnode.subjects_dir', 'inputnode.subjects_dir'),
                 ('outputnode.fsnative2t1w_xfm', 'inputnode.fsnative2anat_xfm'),
             ]),
-            (gifti_surfaces_wf, surfaces_buffer, [
-                (f'outputnode.{surf}', surf) for surf in surfs
-            ]),
             (sourcefile_buffer, ds_surfaces_wf, [('source_files', 'inputnode.source_files')]),
             (gifti_surfaces_wf, ds_surfaces_wf, [
                 (f'outputnode.{surf}', f'inputnode.{surf}') for surf in surfs
+            ]),
+            (ds_surfaces_wf, surfaces_buffer, [
+                (f'outputnode.{surf}', surf) for surf in surfs
             ]),
         ])
         # fmt:on
@@ -1295,12 +1295,12 @@ A {t2w_or_flair} image was used to improve pial surface refinement.
                 ('outputnode.subject_id', 'inputnode.subject_id'),
                 ('outputnode.subjects_dir', 'inputnode.subjects_dir'),
             ]),
-            (gifti_morph_wf, surfaces_buffer, [
-                (f'outputnode.{metric}', metric) for metric in metrics
-            ]),
             (sourcefile_buffer, ds_morph_wf, [('source_files', 'inputnode.source_files')]),
             (gifti_morph_wf, ds_morph_wf, [
                 (f'outputnode.{metric}', f'inputnode.{metric}') for metric in metrics
+            ]),
+            (ds_morph_wf, surfaces_buffer, [
+                (f'outputnode.{metric}', metric) for metric in metrics
             ]),
         ])
         # fmt:on

--- a/src/smriprep/workflows/anatomical.py
+++ b/src/smriprep/workflows/anatomical.py
@@ -1379,7 +1379,7 @@ A {t2w_or_flair} image was used to improve pial surface refinement.
             # Combine the inputs into a list
             combine_inputs = pe.Node(
                 niu.Merge(2),
-                name='combine_inputs',
+                name=f'combine_inputs_{hemi}',
             )
             workflow.connect([
                 (select_midthickness, combine_inputs, [('out', 'in1')]),

--- a/src/smriprep/workflows/anatomical.py
+++ b/src/smriprep/workflows/anatomical.py
@@ -430,12 +430,12 @@ def init_anat_preproc_wf(
                         f"outputnode.sphere_reg_{'msm' if msm_sulc else 'fsLR'}",
                         'inputnode.sphere_reg_fsLR',
                     ),
+                    ('outputnode.cortex_mask', 'inputnode.roi'),
                 ]),
                 (hcp_morphometrics_wf, morph_grayords_wf, [
                     ('outputnode.curv', 'inputnode.curv'),
                     ('outputnode.sulc', 'inputnode.sulc'),
                     ('outputnode.thickness', 'inputnode.thickness'),
-                    ('outputnode.roi', 'inputnode.roi'),
                 ]),
                 (resample_surfaces_wf, morph_grayords_wf, [
                     ('outputnode.midthickness_fsLR', 'inputnode.midthickness_fsLR'),

--- a/src/smriprep/workflows/anatomical.py
+++ b/src/smriprep/workflows/anatomical.py
@@ -1389,7 +1389,7 @@ A {t2w_or_flair} image was used to improve pial surface refinement.
             ds_cortex_mask_wf = init_ds_mask_wf(
                 bids_root=bids_root,
                 output_dir=output_dir,
-                mask_type='roi',
+                mask_type='cortex',
                 name=f'ds_cortex_mask_wf_{hemi}',
                 extra_entities={'extension': '.label.gii', 'hemi': hemi},
             )

--- a/src/smriprep/workflows/anatomical.py
+++ b/src/smriprep/workflows/anatomical.py
@@ -1391,9 +1391,9 @@ A {t2w_or_flair} image was used to improve pial surface refinement.
     # Stage 11: Cortical surface mask
     if len(precomputed.get('cortex_mask', [])) < 2:
         LOGGER.info('ANAT Stage 11: Creating cortical surface mask')
-        anat_cortex_mask_wf = init_cortex_mask_wf()
+        cortex_mask_wf = init_cortex_mask_wf()
         workflow.connect([
-            (surfaces_buffer, anat_cortex_mask_wf, [
+            (surfaces_buffer, cortex_mask_wf, [
                 ('midthickness', 'inputnode.midthickness'),
                 ('thickness', 'inputnode.thickness'),
             ]),
@@ -1433,7 +1433,7 @@ A {t2w_or_flair} image was used to improve pial surface refinement.
                 name=f'select_mask_{hemi}',
             )
             workflow.connect([
-                (anat_cortex_mask_wf, select_mask, [('outputnode.cortex_mask', 'inlist')]),
+                (cortex_mask_wf, select_mask, [('outputnode.roi', 'inlist')]),
                 (select_mask, ds_cortex_mask_wf, [('out', 'inputnode.mask_file')]),
                 (combine_inputs, ds_cortex_mask_wf, [('out', 'inputnode.source_files')]),
                 (ds_cortex_mask_wf, merge_outputs, [('outputnode.mask_file', f'in{i_hemi + 1}')]),

--- a/src/smriprep/workflows/anatomical.py
+++ b/src/smriprep/workflows/anatomical.py
@@ -1352,20 +1352,18 @@ A {t2w_or_flair} image was used to improve pial surface refinement.
         LOGGER.info('ANAT Stage 11: Creating cortical surface mask')
 
         cortex_masks_wf = init_cortex_masks_wf()
-        workflow.connect([
-            (surfaces_buffer, cortex_masks_wf, [
-                ('midthickness', 'inputnode.midthickness'),
-                ('thickness', 'inputnode.thickness'),
-            ]),
-        ])  # fmt:skip
-
         ds_cortex_masks_wf = init_ds_surface_masks_wf(
             output_dir=output_dir,
             mask_type='cortex',
             name='ds_cortex_masks_wf',
             entities={'extension': '.label.gii'},
         )
+
         workflow.connect([
+            (surfaces_buffer, cortex_masks_wf, [
+                ('midthickness', 'inputnode.midthickness'),
+                ('thickness', 'inputnode.thickness'),
+            ]),
             (cortex_masks_wf, ds_cortex_masks_wf, [
                 ('outputnode.cortex_masks', 'inputnode.mask_files'),
                 ('outputnode.source_files', 'inputnode.source_files'),

--- a/src/smriprep/workflows/anatomical.py
+++ b/src/smriprep/workflows/anatomical.py
@@ -1370,8 +1370,8 @@ A {t2w_or_flair} image was used to improve pial surface refinement.
             cortex_mask_wf.inputs.inputnode.hemi = hemi
 
             workflow.connect([
-                (surfaces_buffer, select_midthickness, [('midthickness', 'midthickness')]),
-                (surfaces_buffer, select_thickness, [('thickness', 'thickness')]),
+                (surfaces_buffer, select_midthickness, [('midthickness', 'inlist')]),
+                (surfaces_buffer, select_thickness, [('thickness', 'inlist')]),
                 (select_midthickness, cortex_mask_wf, [('out', 'inputnode.midthickness')]),
                 (select_thickness, cortex_mask_wf, [('out', 'inputnode.thickness')]),
             ])  # fmt:skip

--- a/src/smriprep/workflows/anatomical.py
+++ b/src/smriprep/workflows/anatomical.py
@@ -1356,7 +1356,6 @@ A {t2w_or_flair} image was used to improve pial surface refinement.
             output_dir=output_dir,
             mask_type='cortex',
             name='ds_cortex_masks_wf',
-            entities={'extension': '.label.gii'},
         )
 
         workflow.connect([

--- a/src/smriprep/workflows/outputs.py
+++ b/src/smriprep/workflows/outputs.py
@@ -325,7 +325,7 @@ def init_ds_mask_wf(
     *,
     bids_root: str,
     output_dir: str,
-    mask_type: ty.Literal['brain', 'roi', 'ribbon'],
+    mask_type: ty.Literal['brain', 'roi', 'ribbon', 'cortex'],
     extra_entities: dict | None = None,
     name='ds_mask_wf',
 ):

--- a/src/smriprep/workflows/outputs.py
+++ b/src/smriprep/workflows/outputs.py
@@ -1281,7 +1281,7 @@ def init_ds_surface_masks_wf(
         niu.Merge(2),
         name='combine_masks',
     )
-    workflow.connect(combine_masks, outputnode, [('out', 'mask_files')])
+    workflow.connect([(combine_masks, outputnode, [('out', 'mask_files')])])
 
     for i_hemi, hemi in enumerate(['L', 'R']):
         select_mask = pe.Node(
@@ -1289,14 +1289,14 @@ def init_ds_surface_masks_wf(
             name=f'select_mask_{hemi}',
             run_without_submitting=True,
         )
-        workflow.connect(inputnode, select_mask, [('mask_files', 'inlist')])
+        workflow.connect([(inputnode, select_mask, [('mask_files', 'inlist')])])
 
         select_source = pe.Node(
             niu.Select(index=i_hemi),
             name=f'select_source_{hemi}',
             run_without_submitting=True,
         )
-        workflow.connect(inputnode, select_source, [('source_files', 'inlist')])
+        workflow.connect([(inputnode, select_source, [('source_files', 'inlist')])])
 
         sources = pe.Node(
             niu.Function(function=_bids_relative),

--- a/src/smriprep/workflows/outputs.py
+++ b/src/smriprep/workflows/outputs.py
@@ -325,7 +325,7 @@ def init_ds_mask_wf(
     *,
     bids_root: str,
     output_dir: str,
-    mask_type: ty.Literal['brain', 'roi', 'ribbon', 'cortex'],
+    mask_type: ty.Literal['brain', 'roi', 'ribbon'],
     extra_entities: dict | None = None,
     name='ds_mask_wf',
 ):

--- a/src/smriprep/workflows/surfaces.py
+++ b/src/smriprep/workflows/surfaces.py
@@ -1071,8 +1071,6 @@ def init_hcp_morphometrics_wf(
         HCP-style curvature file in GIFTI format
     sulc
         HCP-style sulcal depth file in GIFTI format
-    roi
-        HCP-style cortical ROI file in GIFTI format
     """
     DEFAULT_MEMORY_MIN_GB = 0.01
 
@@ -1090,7 +1088,7 @@ def init_hcp_morphometrics_wf(
     )
 
     outputnode = pe.JoinNode(
-        niu.IdentityInterface(fields=['thickness', 'curv', 'sulc', 'roi']),
+        niu.IdentityInterface(fields=['thickness', 'curv', 'sulc']),
         name='outputnode',
         joinsource='itersource',
     )
@@ -1114,11 +1112,6 @@ def init_hcp_morphometrics_wf(
     invert_sulc = pe.Node(MetricMath(metric='sulc', operation='invert'), name='invert_sulc')
     # Thickness is presumably already positive, but HCP uses abs(-thickness)
     abs_thickness = pe.Node(MetricMath(metric='thickness', operation='abs'), name='abs_thickness')
-
-    # Native ROI is thickness > 0, with holes and islands filled
-    initial_roi = pe.Node(MetricMath(metric='roi', operation='bin'), name='initial_roi')
-    fill_holes = pe.Node(MetricFillHoles(), name='fill_holes', mem_gb=DEFAULT_MEMORY_MIN_GB)
-    native_roi = pe.Node(MetricRemoveIslands(), name='native_roi', mem_gb=DEFAULT_MEMORY_MIN_GB)
 
     # Dilation happens separately from ROI creation
     dilate_curv = pe.Node(
@@ -1158,8 +1151,77 @@ def init_hcp_morphometrics_wf(
         (dilate_curv, outputnode, [('out_file', 'curv')]),
         (dilate_thickness, outputnode, [('out_file', 'thickness')]),
         (invert_sulc, outputnode, [('metric_file', 'sulc')]),
-        # Native ROI file from thickness
-        (inputnode, initial_roi, [('subject_id', 'subject_id')]),
+    ])  # fmt:skip
+
+    return workflow
+
+
+def init_cortex_mask_wf(
+    *,
+    name: str = 'cortex_mask_wf',
+):
+    """Create a cortical surface mask from a surface file.
+
+    Workflow Graph
+        .. workflow::
+            :graph2use: orig
+            :simple_form: yes
+
+            from smriprep.workflows.surfaces import init_cortex_mask_wf
+            wf = init_cortex_mask_wf()
+
+    Inputs
+    ------
+    midthickness
+        FreeSurfer midthickness surface file in GIFTI format
+    thickness
+        FreeSurfer thickness file in GIFTI format
+
+    Outputs
+    -------
+    roi
+        Cortical surface mask in GIFTI format
+    """
+    DEFAULT_MEMORY_MIN_GB = 0.01
+
+    workflow = Workflow(name=name)
+
+    inputnode = pe.Node(
+        niu.IdentityInterface(fields=['midthickness', 'thickness']),
+        name='inputnode',
+    )
+    outputnode = pe.Node(niu.IdentityInterface(fields=['roi']), name='outputnode')
+
+    itersource = pe.Node(
+        niu.IdentityInterface(fields=['hemi']),
+        name='itersource',
+        iterables=[('hemi', ['L', 'R'])],
+    )
+    select_surfaces = pe.Node(
+        KeySelect(
+            fields=['midthickness', 'thickness'],
+            keys=['L', 'R'],
+        ),
+        name='select_surfaces',
+        run_without_submitting=True,
+    )
+
+    # Thickness is presumably already positive, but HCP uses abs(-thickness)
+    abs_thickness = pe.Node(MetricMath(metric='thickness', operation='abs'), name='abs_thickness')
+
+    # Native ROI is thickness > 0, with holes and islands filled
+    initial_roi = pe.Node(MetricMath(metric='roi', operation='bin'), name='initial_roi')
+    fill_holes = pe.Node(MetricFillHoles(), name='fill_holes', mem_gb=DEFAULT_MEMORY_MIN_GB)
+    native_roi = pe.Node(MetricRemoveIslands(), name='native_roi', mem_gb=DEFAULT_MEMORY_MIN_GB)
+
+    workflow.connect([
+        (inputnode, select_surfaces, [
+            ('thickness', 'thickness'),
+            ('midthickness', 'midthickness'),
+        ]),
+        (itersource, select_surfaces, [('hemi', 'key')]),
+        (itersource, abs_thickness, [('hemi', 'hemisphere')]),
+        (select_surfaces, abs_thickness, [('thickness', 'metric_file')]),
         (itersource, initial_roi, [('hemi', 'hemisphere')]),
         (abs_thickness, initial_roi, [('metric_file', 'metric_file')]),
         (select_surfaces, fill_holes, [('midthickness', 'surface_file')]),

--- a/src/smriprep/workflows/surfaces.py
+++ b/src/smriprep/workflows/surfaces.py
@@ -1251,10 +1251,10 @@ def init_cortex_masks_wf(
         )
 
         workflow.connect([
-            (inputnode, abs_thickness, [('thickness', 'metric_file')]),
+            (select_thickness, abs_thickness, [('out', 'metric_file')]),
             (abs_thickness, initial_roi, [('metric_file', 'metric_file')]),
-            (inputnode, fill_holes, [('midthickness', 'surface_file')]),
-            (inputnode, native_roi, [('midthickness', 'surface_file')]),
+            (select_midthickness, fill_holes, [('out', 'surface_file')]),
+            (select_midthickness, native_roi, [('out', 'surface_file')]),
             (initial_roi, fill_holes, [('metric_file', 'metric_file')]),
             (fill_holes, native_roi, [('out_file', 'metric_file')]),
             (native_roi, combine_masks, [('out_file', f'in{i_hemi + 1}')]),

--- a/src/smriprep/workflows/surfaces.py
+++ b/src/smriprep/workflows/surfaces.py
@@ -1225,7 +1225,7 @@ def init_cortex_masks_wf(
             (inputnode, select_thickness, [('thickness', 'inlist')]),
         ])  # fmt:skip
 
-         # Thickness is presumably already positive, but HCP uses abs(-thickness)
+        # Thickness is presumably already positive, but HCP uses abs(-thickness)
         abs_thickness = pe.Node(
             MetricMath(metric='thickness', operation='abs'),
             name=f'abs_thickness_{hemi}',

--- a/src/smriprep/workflows/surfaces.py
+++ b/src/smriprep/workflows/surfaces.py
@@ -1190,7 +1190,10 @@ def init_cortex_masks_wf(
         niu.IdentityInterface(fields=['midthickness', 'thickness']),
         name='inputnode',
     )
-    outputnode = pe.Node(niu.IdentityInterface(fields=['cortex_masks']), name='outputnode')
+    outputnode = pe.Node(
+        niu.IdentityInterface(fields=['cortex_masks', 'source_files']),
+        name='outputnode',
+    )
 
     # Combine the inputs into a list
     combine_sources = pe.Node(

--- a/src/smriprep/workflows/surfaces.py
+++ b/src/smriprep/workflows/surfaces.py
@@ -1160,7 +1160,7 @@ def init_cortex_masks_wf(
     *,
     name: str = 'cortex_masks_wf',
 ):
-    """Create a cortical surface mask from a surface file.
+    """Create cortical surface masks from surface files.
 
     Workflow Graph
         .. workflow::
@@ -1172,15 +1172,17 @@ def init_cortex_masks_wf(
 
     Inputs
     ------
-    midthickness : list of str
+    midthickness : len-2 list of str
         Each hemisphere's FreeSurfer midthickness surface file in GIFTI format
-    thickness : list of str
+    thickness : len-2 list of str
         Each hemisphere's FreeSurfer thickness file in GIFTI format
 
     Outputs
     -------
-    cortex_masks : list of str
+    cortex_masks : len-2 list of str
         Cortical surface mask in GIFTI format for each hemisphere
+    source_files : len-2 list of lists of str
+        Each hemisphere's source files, which are used to create the mask
     """
     DEFAULT_MEMORY_MIN_GB = 0.01
 

--- a/src/smriprep/workflows/surfaces.py
+++ b/src/smriprep/workflows/surfaces.py
@@ -1236,7 +1236,7 @@ def init_cortex_masks_wf(
 
         # Native ROI is thickness > 0, with holes and islands filled
         initial_roi = pe.Node(
-            MetricMath(metric='roi', operation='bin'),
+            MetricMath(metric='roi', operation='bin', hemisphere=hemi),
             name=f'initial_roi_{hemi}',
         )
         fill_holes = pe.Node(
@@ -1245,17 +1245,13 @@ def init_cortex_masks_wf(
             mem_gb=DEFAULT_MEMORY_MIN_GB,
         )
         native_roi = pe.Node(
-            MetricRemoveIslands(),
+            MetricRemoveIslands(hemisphere=hemi),
             name=f'native_roi_{hemi}',
             mem_gb=DEFAULT_MEMORY_MIN_GB,
         )
 
         workflow.connect([
-            (inputnode, abs_thickness, [
-                ('hemi', 'hemisphere'),
-                ('thickness', 'metric_file'),
-            ]),
-            (inputnode, initial_roi, [('hemi', 'hemisphere')]),
+            (inputnode, abs_thickness, [('thickness', 'metric_file')]),
             (abs_thickness, initial_roi, [('metric_file', 'metric_file')]),
             (inputnode, fill_holes, [('midthickness', 'surface_file')]),
             (inputnode, native_roi, [('midthickness', 'surface_file')]),

--- a/src/smriprep/workflows/surfaces.py
+++ b/src/smriprep/workflows/surfaces.py
@@ -1230,7 +1230,7 @@ def init_cortex_masks_wf(
 
         # Thickness is presumably already positive, but HCP uses abs(-thickness)
         abs_thickness = pe.Node(
-            MetricMath(metric='thickness', operation='abs'),
+            MetricMath(metric='thickness', operation='abs', hemisphere=hemi),
             name=f'abs_thickness_{hemi}',
         )
 
@@ -1245,7 +1245,7 @@ def init_cortex_masks_wf(
             mem_gb=DEFAULT_MEMORY_MIN_GB,
         )
         native_roi = pe.Node(
-            MetricRemoveIslands(hemisphere=hemi),
+            MetricRemoveIslands(),
             name=f'native_roi_{hemi}',
             mem_gb=DEFAULT_MEMORY_MIN_GB,
         )

--- a/src/smriprep/workflows/surfaces.py
+++ b/src/smriprep/workflows/surfaces.py
@@ -1179,7 +1179,7 @@ def init_cortex_mask_wf(
 
     Outputs
     -------
-    roi
+    roi : list of two strings
         Cortical surface mask in GIFTI format
     """
     DEFAULT_MEMORY_MIN_GB = 0.01


### PR DESCRIPTION
Based on @effigies' idea in https://github.com/nipreps/fmriprep/pull/3491. This new output should make it possible to project data to the surface just using computed derivatives.

Changes proposed:

- Move roi output out of `init_hcp_morphometrics_wf`.
- Calculate that output in a new workflow, `init_cortex_mask_wf`.
- Add step to `init_anat_fit_wf` that calls `init_cortex_mask_wf`.