### PR TITLE
chore: ISC rules do not conflict with the formatter any more

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,13 +11,11 @@ repos:
       - id: check-toml
       - id: check-json
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.2
+    rev: v0.12.7
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: [--fix]
       - id: ruff-format
-      - id: ruff
-        args: [--select, ISC001, --fix]
   - repo: https://github.com/woodruffw/zizmor-pre-commit
     rev: v0.8.0
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,7 +174,6 @@ extend-select = [
 ]
 ignore = [
   "S311",  # We are not using random for cryptographic purposes
-  "ISC001",
   "S603",
 ]
 


### PR DESCRIPTION
https://astral.sh/blog/ruff-v0.9.0#fewer-single-line-implicitly-concatenated-strings