### PR TITLE
FIX: Create copy of query before modifying

### DIFF
--- a/src/smriprep/utils/bids.py
+++ b/src/smriprep/utils/bids.py
@@ -59,7 +59,7 @@ def collect_derivatives(
         qry_base['session'] = session_id
 
     for key, qry in spec['baseline'].items():
-        qry |= qry_base
+        qry = {**qry, **qry_base}
         item = layout.get(**qry)
         if not item:
             continue
@@ -85,7 +85,7 @@ def collect_derivatives(
             transforms.setdefault(_space, {})[key] = item[0] if len(item) == 1 else item
 
     for key, qry in spec['surfaces'].items():
-        qry |= qry_base
+        qry = {**qry, **qry_base}
         item = layout.get(return_type='filename', **qry)
         if not item or len(item) != 2:
             continue

--- a/src/smriprep/utils/bids.py
+++ b/src/smriprep/utils/bids.py
@@ -76,8 +76,7 @@ def collect_derivatives(
     for _space in std_spaces:
         space = _space.replace(':cohort-', '+')
         for key, qry in spec['transforms'].items():
-            qry = qry.copy()
-            qry |= qry_base
+            qry = {**qry, **qry_base}
             qry['from'] = qry['from'] or space
             qry['to'] = qry['to'] or space
             item = layout.get(return_type='filename', **qry)

--- a/src/smriprep/utils/bids.py
+++ b/src/smriprep/utils/bids.py
@@ -76,6 +76,7 @@ def collect_derivatives(
     for _space in std_spaces:
         space = _space.replace(':cohort-', '+')
         for key, qry in spec['transforms'].items():
+            qry = qry.copy()
             qry |= qry_base
             qry['from'] = qry['from'] or space
             qry['to'] = qry['to'] or space

--- a/src/smriprep/utils/tests/test_bids.py
+++ b/src/smriprep/utils/tests/test_bids.py
@@ -1,14 +1,20 @@
+import pytest
 from niworkflows.utils.testing import generate_bids_skeleton
 
 from ..bids import collect_derivatives
 from . import DERIV_SKELETON
 
 
-def test_collect_derivatives(tmp_path):
+@pytest.fixture
+def deriv_dset(tmp_path):
     deriv_dir = tmp_path / 'derivatives'
     generate_bids_skeleton(deriv_dir, str(DERIV_SKELETON))
+    return deriv_dir
+
+
+def test_collect_derivatives(deriv_dset):
     output_spaces = ['MNI152NLin2009cAsym', 'MNIPediatricAsym:cohort-3']
-    collected = collect_derivatives(deriv_dir, '01', output_spaces)
+    collected = collect_derivatives(deriv_dset, '01', output_spaces)
     for suffix in ('preproc', 'mask', 'dseg'):
         assert collected[f't1w_{suffix}']
     assert len(collected['t1w_tpms']) == 3
@@ -28,3 +34,13 @@ def test_collect_derivatives(tmp_path):
         'sphere_reg_msm',
     ):
         assert len(collected[surface]) == 2
+
+
+def test_collect_derivatives_transforms(deriv_dset):
+    output_spaces = ['MNI152NLin2009cAsym', 'MNIPediatricAsym:cohort-3']
+    collected = collect_derivatives(deriv_dset, '01', output_spaces)
+    xfms = collected['transforms']
+    for space in output_spaces:
+        template = space.split(':')[0]
+        assert template in xfms[space]['reverse']
+        assert template in xfms[space]['forward']

--- a/src/smriprep/utils/tests/test_bids.py
+++ b/src/smriprep/utils/tests/test_bids.py
@@ -37,6 +37,7 @@ def test_collect_derivatives(deriv_dset):
 
 
 def test_collect_derivatives_transforms(deriv_dset):
+    """Ensure transforms are collected for the right spaces."""
     output_spaces = ['MNI152NLin2009cAsym', 'MNIPediatricAsym:cohort-3']
     collected = collect_derivatives(deriv_dset, '01', output_spaces)
     xfms = collected['transforms']


### PR DESCRIPTION
Closes #486.

Changes proposed:

- Create copy of transform queries before updating them. These are the only queries in `collect_derivatives` that are used repeatedly, so they're the only ones we should need a copy of.