### PR TITLE
Fix typo in citation boilerplate (sMRIPprep → sMRIPrep)

### DIFF
--- a/src/smriprep/workflows/base.py
+++ b/src/smriprep/workflows/base.py
@@ -373,7 +373,7 @@ def init_single_subject_wf(
     workflow = Workflow(name=name)
     workflow.__desc__ = f"""
 Results included in this manuscript come from preprocessing
-performed using *sMRIPprep* {__version__}
+performed using *sMRIPrep* {__version__}
 (@fmriprep1; @fmriprep2; RRID:SCR_016216),
 which is based on *Nipype* {nipype_ver}
 (@nipype1; @nipype2; RRID:SCR_002502).


### PR DESCRIPTION
This PR fixes a small typo in the citation boilerplate text
(`sMRIPprep` → `sMRIPrep`) in `smriprep/src/smriprep/workflows/base.py`.

Closes #488.
