### PR TITLE
Limit threads for mris_expand

### DIFF
--- a/src/smriprep/interfaces/freesurfer.py
+++ b/src/smriprep/interfaces/freesurfer.py
@@ -337,4 +337,4 @@ class MakeMidthickness(nwfs.MakeMidthickness, fs.base.FSCommandOpenMP):
 
     def _num_threads_update(self):
         if self.inputs.num_threads:
-            self.inputs.environ.update({'OMP_SCHEDULE': 'dynamic', 'OMP_NUM_THREADS': str(min(8, self.inputs.num_threads - 1))})
+            self.inputs.environ.update({'OMP_SCHEDULE': 'dynamic', 'OMP_NUM_THREADS': str(max(1, min(8, self.inputs.num_threads - 1)))})

--- a/src/smriprep/interfaces/freesurfer.py
+++ b/src/smriprep/interfaces/freesurfer.py
@@ -337,4 +337,4 @@ class MakeMidthickness(nwfs.MakeMidthickness, fs.base.FSCommandOpenMP):
 
     def _num_threads_update(self):
         if self.inputs.num_threads:
-            self.inputs.environ.update({'OMP_NUM_THREADS': str(self.inputs.num_threads * 3 // 2)})
+            self.inputs.environ.update({'OMP_SCHEDULE': 'dynamic', 'OMP_NUM_THREADS': str(min(8, self.inputs.num_threads - 1))})


### PR DESCRIPTION
Limits the threads for mris_expand and changes the OpenMP scheduler to dynamic.

Fixes #490.