### PR TITLE
Fix: correct notation for longitudinal arg value

### DIFF
--- a/src/smriprep/cli/run.py
+++ b/src/smriprep/cli/run.py
@@ -34,7 +34,7 @@ def main():
         )
 
     if opts.subject_anatomical_reference == 'unbiased':
-        opts['longitudinal'] = True
+        opts.longitudinal = True
     return build_opts(opts)
 
 


### PR DESCRIPTION
fix a trivial issue when setting the longitudinal argument:

```bash
smriprep --longitudinal /in /out participant

The "--longitudinal" flag is deprecated. Use "--subject-anatomical-reference unbiased" instead.
Traceback (most recent call last):
  File "/home/mk/.local/bin/smriprep", line 7, in <module>
    sys.exit(main())
             ~~~~^^
  File "/home/mk/work/src/smriprep/src/smriprep/cli/run.py", line 37, in main
    opts['longitudinal'] = True
    ~~~~^^^^^^^^^^^^^^^^
TypeError: 'Namespace' object does not support item assignment
```

We have to use the dot notation to change argparse arg's namespace attributes.