### PR TITLE
Query "masks" section of io_spec.json in collect_derivatives

### DIFF
--- a/src/smriprep/utils/bids.py
+++ b/src/smriprep/utils/bids.py
@@ -92,6 +92,14 @@ def collect_derivatives(
 
         derivs_cache[key] = sorted(item)
 
+    for key, qry in spec['masks'].items():
+        qry = {**qry, **qry_base}
+        item = layout.get(return_type='filename', **qry)
+        if not item or len(item) != 1:
+            continue
+
+        derivs_cache[key] = item[0]
+
     return derivs_cache
 
 


### PR DESCRIPTION
Closes #509. This adds a step in `collect_derivatives` to collect queries from the "masks" section of the io_spec.json.