### PR TITLE
Fix CI failure in docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,7 +8,7 @@ pydot
 sphinx-argparse
 sphinx
 sphinx_rtd_theme
-sphinxcontrib-apidoc ~= 0.3.0
+sphinxcontrib-apidoc
 templateflow
 networkx != 2.8.1
 acres

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ doc = [
     "sphinx",
     "sphinx-argparse",
     "sphinx_rtd_theme",
-    "sphinxcontrib-apidoc ~= 0.3.0",
+    "sphinxcontrib-apidoc",
     "sphinxcontrib-napoleon",
     "sphinxcontrib-versioning",
 ]


### PR DESCRIPTION
Sphinx ≥ 8.2 requires apidoc ≥ 0.6.0