### PR TITLE
DOC: Remove BOLD from BIDS input requirement in usage docs (#438)

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -11,8 +11,7 @@ Execution and the BIDS format
 The *sMRIPrep* workflow takes as principal input the path of the dataset
 that is to be processed.
 The input dataset is required to be in valid :abbr:`BIDS (Brain Imaging Data
-Structure)` format, and it must include at least one T1w structural image and
-(unless disabled with a flag) a BOLD series.
+Structure)` format, and it must include at least one T1w (or T2w) structural image.
 We highly recommend that you validate your dataset with the free, online
 `BIDS Validator <https://bids-standard.github.io/bids-validator/>`_.
 


### PR DESCRIPTION
Closes #438.

`sMRIPrep` requires at least one T1w (or T2w) structural image; a BOLD series is not part of the BIDS input requirement. The CLI only queries for `T1w`/`T2w` suffixes via the BIDS layout. This removes the misleading "(unless disabled with a flag) a BOLD series" clause from `docs/usage.rst`.

Per the issue: "PRs welcome!" (https://github.com/nipreps/smriprep/issues/438#issuecomment-2402515768).
