### PR TITLE
chore: Pin GitHub actions by hash

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,7 +25,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v5
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 200
           fetch-tags: true
@@ -33,13 +33,13 @@ jobs:
           persist-credentials: false
 
       - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
         with:
           driver: docker
 
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -63,7 +63,7 @@ jobs:
 
       - name: Build base image
         if: steps.base.outputs.build == 'true'
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           file: Dockerfile.base
           load: true
@@ -78,12 +78,12 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
       force_versioned: ${{ steps.resolve.outputs.force_versioned }}
     steps:
       - name: Checkout repository for ref and tag resolution
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -153,7 +153,7 @@ jobs:
       has_versioned_docs: ${{ steps.has-versioned.outputs.has_versioned_docs }}
     steps:
       - name: Checkout source revision
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -166,7 +166,7 @@ jobs:
           sudo apt -y install graphviz
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
 
@@ -180,7 +180,7 @@ jobs:
         run: make -C docs NO_ET=1 SPHINXOPTS="-W" BUILDDIR="_build/no_version_html" html
 
       - name: Upload unversioned docs artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: docs-unversioned-html
           path: docs/_build/no_version_html/html
@@ -210,7 +210,7 @@ jobs:
       - name: Restore versioned docs cache
         if: steps.versioned.outputs.build_versioned == 'true'
         id: docs-cache-restore
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: docs/_build
           key: docs-v2-${{ needs.resolve_context.outputs.source_ref_name }}-${{ needs.resolve_context.outputs.source_sha }}
@@ -227,14 +227,14 @@ jobs:
 
       - name: Save versioned docs cache
         if: steps.versioned.outputs.build_versioned == 'true' && steps.docs-cache-restore.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: docs/_build
           key: docs-v2-${{ needs.resolve_context.outputs.source_ref_name }}-${{ needs.resolve_context.outputs.source_sha }}
 
       - name: Upload versioned docs artifact
         if: steps.versioned.outputs.build_versioned == 'true'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: docs-versioned-html
           path: docs/_build/html
@@ -256,7 +256,7 @@ jobs:
       contents: write
     steps:
       - name: Download versioned docs artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: docs-versioned-html
           path: /tmp/docs-site
@@ -273,7 +273,7 @@ jobs:
           printf 'docs_root=%s\n' "$docs_root" >> "$GITHUB_OUTPUT"
 
       - name: Checkout gh-pages branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: gh-pages
           fetch-depth: 0
@@ -309,7 +309,7 @@ jobs:
       contents: write
     steps:
       - name: Download versioned docs artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: docs-versioned-html
           path: /tmp/docs-site
@@ -326,7 +326,7 @@ jobs:
           printf 'docs_root=%s\n' "$docs_root" >> "$GITHUB_OUTPUT"
 
       - name: Checkout gh-pages branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: gh-pages
           fetch-depth: 0


### PR DESCRIPTION
Updates all actions and switches to using hashes. Obviates all actions-related dependabot PRs.

Migrating to pixi should obviate the pip dependabot PRs.