### PR TITLE
feat: Validate subject directory exists if --fs-no-resume

### DIFF
--- a/src/smriprep/interfaces/freesurfer.py
+++ b/src/smriprep/interfaces/freesurfer.py
@@ -27,7 +27,14 @@ import os
 from looseversion import LooseVersion
 from nipype import logging
 from nipype.interfaces import freesurfer as fs
-from nipype.interfaces.base import File, InputMultiObject, isdefined, traits
+from nipype.interfaces.base import (
+    File,
+    InputMultiObject,
+    SimpleInterface,
+    TraitedSpec,
+    isdefined,
+    traits,
+)
 from nipype.utils.filemanip import check_depends
 from niworkflows.interfaces import freesurfer as nwfs
 
@@ -338,3 +345,47 @@ class MakeMidthickness(nwfs.MakeMidthickness, fs.base.FSCommandOpenMP):
     def _num_threads_update(self):
         if self.inputs.num_threads:
             self.inputs.environ.update({'OMP_NUM_THREADS': str(self.inputs.num_threads * 3 // 2)})
+
+
+class ValidateSubjectDirInputSpec(TraitedSpec):
+    subjects_dir = traits.Directory(
+        exists=True,
+        mandatory=True,
+        desc='FreeSurfer subjects directory',
+    )
+    subject_id = traits.Str(
+        mandatory=True,
+        desc='FreeSurfer subject ID to validate',
+    )
+
+
+class ValidateSubjectDirOutputSpec(TraitedSpec):
+    subjects_dir = traits.Directory(desc='FreeSurfer subjects directory')
+    subject_id = traits.Str(desc='Validated FreeSurfer subject ID')
+
+
+class ValidateSubjectDir(SimpleInterface):
+    """Interface to validate the existence of a FreeSurfer subject directory.
+
+    The intended use case is when a FreeSurfer directory is provided as-is,
+    and sMRIPrep does not attempt to run recon-all, which would create the
+    subject directory if it does not exist.
+    """
+
+    input_spec = ValidateSubjectDirInputSpec
+    output_spec = ValidateSubjectDirOutputSpec
+
+    _always_run = True
+
+    def _run_interface(self, runtime):
+        subjects_dir = self.inputs.subjects_dir
+        subject_id = self.inputs.subject_id
+
+        if not os.path.isdir(os.path.join(subjects_dir, subject_id)):
+            raise RuntimeError(
+                f"Subject directory '{subject_id}' does not exist in '{subjects_dir}'."
+            )
+
+        self._results['subjects_dir'] = subjects_dir
+        self._results['subject_id'] = subject_id
+        return runtime

--- a/src/smriprep/interfaces/tests/test_freesurfer.py
+++ b/src/smriprep/interfaces/tests/test_freesurfer.py
@@ -1,0 +1,15 @@
+import pytest
+
+from ..freesurfer import ValidateSubjectDir
+
+
+def test_validate_subject_dir(tmp_path):
+    validate = ValidateSubjectDir(subjects_dir=tmp_path, subject_id='sub-01')
+    with pytest.raises(RuntimeError, match='.* does not exist .*'):
+        validate.run()
+
+    tmp_path.joinpath('sub-01').mkdir()
+
+    ret = validate.run()
+    assert ret.outputs.subjects_dir == str(tmp_path)
+    assert ret.outputs.subject_id == 'sub-01'

--- a/src/smriprep/workflows/surfaces.py
+++ b/src/smriprep/workflows/surfaces.py
@@ -58,7 +58,7 @@ import smriprep
 from smriprep.interfaces.surf import MakeRibbon
 from smriprep.interfaces.workbench import SurfaceResample
 
-from ..interfaces.freesurfer import MakeMidthickness, ReconAll
+from ..interfaces.freesurfer import MakeMidthickness, MRIsConvertData, ReconAll, ValidateSubjectDir
 from ..interfaces.gifti import MetricMath
 from ..interfaces.workbench import CreateSignedDistanceVolume
 
@@ -286,11 +286,16 @@ gray-matter of Mindboggle [RRID:SCR_002438, @mindboggle].
             ]),
         ])  # fmt:skip
     else:
+        validate_subject_dir = pe.Node(ValidateSubjectDir(), name='validate_subject_dir')
         # Pretend to be the autorecon1 node so fsnative2t1w_xfm gets run ASAP
         fs_base_inputs = autorecon1 = pe.Node(FreeSurferSource(), name='fs_base_inputs')
 
         workflow.connect([
-            (inputnode, fs_base_inputs, [
+            (inputnode, validate_subject_dir, [
+                ('subjects_dir', 'subjects_dir'),
+                ('subject_id', 'subject_id'),
+            ]),
+            (validate_subject_dir, fs_base_inputs, [
                 ('subjects_dir', 'subjects_dir'),
                 ('subject_id', 'subject_id'),
             ]),
@@ -972,8 +977,6 @@ def init_gifti_morphometrics_wf(
         Left and right GIFTIs for each morphometry type passed to ``morphometrics``
 
     """
-    from ..interfaces.freesurfer import MRIsConvertData
-
     workflow = Workflow(name=name)
 
     inputnode = pe.Node(


### PR DESCRIPTION
This addresses nipreps/fmriprep#3669. The root cause of that issue was that a sessionwise FreeSurfer subject ID was being generated and searched for in an existing FreeSurfer subjects directory that used only the participant label. When combined with `--fs-no-resume`, this led to searching for files in the existing directory, finding none, and then passing empty lists to nodes that expected existing files.

This replaces the resulting inscrutable errors with a `RuntimeError` that clearly indicates the subject ID that was expected. Unfortunately, this happens at workflow runtime, but moving to workflow construction time would be too much of a modification for a patch release.

I believe this is worth bending the patch-release rules, which generally require no changes to workflows. For successful workflows, rerunning should only rerun validation, as it simply passes the values through. The gain in an interpretable error message in an LTS series is worth it, IMO.

@mgxd Do you agree?