### PR TITLE
REL: 0.19.4

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,17 @@
+0.19.4 (August 24, 2026)
+========================
+Bug-fix release in the 0.19.x series.
+
+This release addresses failures to collect some precomputed derivatives, resulting
+in undesired recalculation.
+
+We also realized that PR 580 from the previous release duplicated the prior effort
+in PR 504. The latter PR has been backported and the logic of the two PRs merged.
+
+* ENH: Add node to check for subject's Freesurfer directory (#504)
+* FIX: Query io_spec masks in collect_derivatives. (#511)
+* FIX: Allow reuse of sphere reg derivatives (#576)
+
 0.19.3 (August 24, 2026)
 ========================
 Bug-fix release in the 0.19.x series.
@@ -7,7 +21,6 @@ This release adds a minor feature to produce a more informative error message if
 Previously, downstream nodes would indicate empty inputs.
 
 * ENH: Validate subject directory exists if --fs-no-resume (#580)
-
 
 0.19.2 (September 24, 2025)
 ===========================

--- a/src/smriprep/data/io_spec.json
+++ b/src/smriprep/data/io_spec.json
@@ -124,7 +124,7 @@
       "sphere_reg": {
         "datatype": "anat",
         "hemi": ["L", "R"],
-        "space": null,
+        "space": [null, "fsaverage"],
         "desc": "reg",
         "suffix": "sphere",
         "extension": ".surf.gii"

--- a/src/smriprep/interfaces/freesurfer.py
+++ b/src/smriprep/interfaces/freesurfer.py
@@ -23,6 +23,7 @@
 """Nipype's recon-all replacement."""
 
 import os
+from pathlib import Path
 
 from looseversion import LooseVersion
 from nipype import logging
@@ -378,14 +379,12 @@ class ValidateSubjectDir(SimpleInterface):
     _always_run = True
 
     def _run_interface(self, runtime):
-        subjects_dir = self.inputs.subjects_dir
         subject_id = self.inputs.subject_id
 
-        if not os.path.isdir(os.path.join(subjects_dir, subject_id)):
-            raise RuntimeError(
-                f"Subject directory '{subject_id}' does not exist in '{subjects_dir}'."
-            )
+        subjects_dir = Path(self.inputs.subjects_dir)
+        if not (subjects_dir / subject_id).exists():
+            raise FileNotFoundError(f"Subject '{subject_id}' does not exist in '{subjects_dir}'.")
 
-        self._results['subjects_dir'] = subjects_dir
+        self._results['subjects_dir'] = str(subjects_dir)
         self._results['subject_id'] = subject_id
         return runtime

--- a/src/smriprep/interfaces/tests/test_freesurfer.py
+++ b/src/smriprep/interfaces/tests/test_freesurfer.py
@@ -5,7 +5,7 @@ from ..freesurfer import ValidateSubjectDir
 
 def test_validate_subject_dir(tmp_path):
     validate = ValidateSubjectDir(subjects_dir=tmp_path, subject_id='sub-01')
-    with pytest.raises(RuntimeError, match='.* does not exist .*'):
+    with pytest.raises(FileNotFoundError, match='.* does not exist .*'):
         validate.run()
 
     tmp_path.joinpath('sub-01').mkdir()

--- a/src/smriprep/utils/bids.py
+++ b/src/smriprep/utils/bids.py
@@ -106,6 +106,14 @@ def collect_derivatives(
 
         derivs_cache[key] = sorted(item)
 
+    for key, qry in spec['masks'].items():
+        qry = {**qry, **qry_base}
+        item = layout.get(return_type='filename', **qry)
+        if not item or len(item) != 1:
+            continue
+
+        derivs_cache[key] = item[0]
+
     return derivs_cache
 
 

--- a/src/smriprep/utils/bids.py
+++ b/src/smriprep/utils/bids.py
@@ -22,6 +22,7 @@
 #
 """Utilities to handle BIDS inputs."""
 
+import logging
 from json import loads
 from pathlib import Path
 
@@ -29,6 +30,8 @@ from bids.layout import BIDSLayout
 from niworkflows.data import load as nwf_load
 
 import smriprep
+
+LOGGER = logging.getLogger('nipype.workflow')
 
 
 def collect_derivatives(
@@ -89,6 +92,17 @@ def collect_derivatives(
         item = layout.get(return_type='filename', **qry)
         if not item or len(item) != 2:
             continue
+
+        # sphere_reg added ``space-fsaverage`` in sMRIPrep 0.16.0
+        if key == 'sphere_reg':
+            legacy = [f for f in item if 'space' not in layout.parse_file_entities(f)]
+            if legacy:
+                LOGGER.warning(
+                    f"Found legacy {key} derivative(s) that lack a 'space' entity; this "
+                    'naming is deprecated and may not be recognized in a future release. '
+                    'Rename or regenerate these derivatives with sMRIPrep >= 0.16.0. Files: %s',
+                    ', '.join(sorted(Path(f).name for f in legacy)),
+                )
 
         derivs_cache[key] = sorted(item)
 

--- a/src/smriprep/utils/tests/derivatives.yml
+++ b/src/smriprep/utils/tests/derivatives.yml
@@ -61,10 +61,12 @@ dataset_description:
     extension: .surf.gii
   - suffix: sphere
     hemi: L
+    space: fsaverage
     desc: reg
     extension: .surf.gii
   - suffix: sphere
     hemi: R
+    space: fsaverage
     desc: reg
     extension: .surf.gii
   - suffix: sphere

--- a/src/smriprep/utils/tests/test_bids.py
+++ b/src/smriprep/utils/tests/test_bids.py
@@ -1,3 +1,5 @@
+import logging
+
 import pytest
 from niworkflows.utils.testing import generate_bids_skeleton
 
@@ -34,6 +36,40 @@ def test_collect_derivatives(deriv_dset):
         'sphere_reg_msm',
     ):
         assert len(collected[surface]) == 2
+
+
+@pytest.mark.parametrize(
+    ('sphere_reg_entities', 'warns'),
+    [
+        pytest.param({'desc': 'reg'}, True, id='without-fsaverage'),
+        pytest.param({'space': 'fsaverage', 'desc': 'reg'}, False, id='with-fsaverage'),
+    ],
+)
+def test_collect_derivatives_reuses_sphere_reg(tmp_path, caplog, sphere_reg_entities, warns):
+    """The fsaverage registration sphere is reusable under both naming conventions."""
+    skeleton = {
+        '01': [
+            {
+                'anat': [
+                    {
+                        'suffix': 'sphere',
+                        'hemi': hemi,
+                        'extension': '.surf.gii',
+                        **sphere_reg_entities,
+                    }
+                    for hemi in ('L', 'R')
+                ]
+            }
+        ]
+    }
+    deriv_dir = tmp_path / 'derivatives'
+    generate_bids_skeleton(deriv_dir, skeleton)
+
+    with caplog.at_level(logging.WARNING, logger='nipype.workflow'):
+        collected = collect_derivatives(deriv_dir, '01', [])
+
+    assert len(collected['sphere_reg']) == 2
+    assert any('legacy sphere_reg' in record.message for record in caplog.records) is warns
 
 
 def test_collect_derivatives_transforms(deriv_dset):

--- a/src/smriprep/workflows/surfaces.py
+++ b/src/smriprep/workflows/surfaces.py
@@ -58,7 +58,7 @@ import smriprep
 from smriprep.interfaces.surf import MakeRibbon
 from smriprep.interfaces.workbench import SurfaceResample
 
-from ..interfaces.freesurfer import MakeMidthickness, MRIsConvertData, ReconAll, ValidateSubjectDir
+from ..interfaces.freesurfer import MakeMidthickness, MRIsConvertData, ReconAll
 from ..interfaces.gifti import MetricMath
 from ..interfaces.workbench import CreateSignedDistanceVolume
 
@@ -286,25 +286,30 @@ gray-matter of Mindboggle [RRID:SCR_002438, @mindboggle].
             ]),
         ])  # fmt:skip
     else:
-        validate_subject_dir = pe.Node(ValidateSubjectDir(), name='validate_subject_dir')
-        # Pretend to be the autorecon1 node so fsnative2t1w_xfm gets run ASAP
-        fs_base_inputs = autorecon1 = pe.Node(FreeSurferSource(), name='fs_base_inputs')
+        # Check that the subject directory exists
+        check_subjects_dir = pe.Node(
+            niu.Function(
+                function=_check_subjects_dir,
+                input_names=['subjects_dir', 'subject_id'],
+                output_names=['subjects_dir', 'subject_id'],
+            ),
+            name='check_subjects_dir',
+        )
+
+        # Hook up get_surfaces immediately,
+        # pretend to be the autorecon1 node so fsnative2t1w_xfm gets run ASAP
+        autorecon1 = get_surfaces
 
         workflow.connect([
-            (inputnode, validate_subject_dir, [
+            (inputnode, check_subjects_dir, [
                 ('subjects_dir', 'subjects_dir'),
                 ('subject_id', 'subject_id'),
             ]),
-            (validate_subject_dir, fs_base_inputs, [
+            (check_subjects_dir, get_surfaces, [
                 ('subjects_dir', 'subjects_dir'),
                 ('subject_id', 'subject_id'),
             ]),
-            # Generate mid-thickness surfaces
-            (inputnode, get_surfaces, [
-                ('subjects_dir', 'subjects_dir'),
-                ('subject_id', 'subject_id'),
-            ]),
-            (inputnode, save_midthickness, [
+            (check_subjects_dir, save_midthickness, [
                 ('subjects_dir', 'base_directory'),
                 ('subject_id', 'container'),
             ]),
@@ -1818,3 +1823,29 @@ def _select_seg(in_files, segmentation):
 
 def _repeat(seq: list, count: int) -> list:
     return seq * count
+
+
+def _check_subjects_dir(subjects_dir: str, subject_id: str) -> tuple[str, str]:
+    """Raise an error if subject's directory does not exist.
+
+    Parameters
+    ----------
+    subjects_dir
+        FreeSurfer SUBJECTS_DIR
+    subject_id
+        FreeSurfer subject ID
+
+    Returns
+    -------
+    tuple
+        A tuple of the subjects_dir and subject_id
+    """
+    from pathlib import Path
+
+    subjects_dir = Path(subjects_dir)
+    if not subjects_dir.exists():
+        raise FileNotFoundError(f'Subject directory {subjects_dir} does not exist.')
+    if not (subjects_dir / subject_id).exists():
+        raise FileNotFoundError(f'Subject {subject_id} does not exist in {subjects_dir}.')
+
+    return str(subjects_dir), subject_id

--- a/src/smriprep/workflows/surfaces.py
+++ b/src/smriprep/workflows/surfaces.py
@@ -58,7 +58,7 @@ import smriprep
 from smriprep.interfaces.surf import MakeRibbon
 from smriprep.interfaces.workbench import SurfaceResample
 
-from ..interfaces.freesurfer import MakeMidthickness, MRIsConvertData, ReconAll
+from ..interfaces.freesurfer import MakeMidthickness, MRIsConvertData, ReconAll, ValidateSubjectDir
 from ..interfaces.gifti import MetricMath
 from ..interfaces.workbench import CreateSignedDistanceVolume
 
@@ -287,29 +287,22 @@ gray-matter of Mindboggle [RRID:SCR_002438, @mindboggle].
         ])  # fmt:skip
     else:
         # Check that the subject directory exists
-        check_subjects_dir = pe.Node(
-            niu.Function(
-                function=_check_subjects_dir,
-                input_names=['subjects_dir', 'subject_id'],
-                output_names=['subjects_dir', 'subject_id'],
-            ),
-            name='check_subjects_dir',
-        )
+        validate_subject_dir = pe.Node(ValidateSubjectDir(), name='validate_subject_dir')
 
         # Hook up get_surfaces immediately,
         # pretend to be the autorecon1 node so fsnative2t1w_xfm gets run ASAP
         autorecon1 = get_surfaces
 
         workflow.connect([
-            (inputnode, check_subjects_dir, [
+            (inputnode, validate_subject_dir, [
                 ('subjects_dir', 'subjects_dir'),
                 ('subject_id', 'subject_id'),
             ]),
-            (check_subjects_dir, get_surfaces, [
+            (validate_subject_dir, get_surfaces, [
                 ('subjects_dir', 'subjects_dir'),
                 ('subject_id', 'subject_id'),
             ]),
-            (check_subjects_dir, save_midthickness, [
+            (validate_subject_dir, save_midthickness, [
                 ('subjects_dir', 'base_directory'),
                 ('subject_id', 'container'),
             ]),
@@ -1823,29 +1816,3 @@ def _select_seg(in_files, segmentation):
 
 def _repeat(seq: list, count: int) -> list:
     return seq * count
-
-
-def _check_subjects_dir(subjects_dir: str, subject_id: str) -> tuple[str, str]:
-    """Raise an error if subject's directory does not exist.
-
-    Parameters
-    ----------
-    subjects_dir
-        FreeSurfer SUBJECTS_DIR
-    subject_id
-        FreeSurfer subject ID
-
-    Returns
-    -------
-    tuple
-        A tuple of the subjects_dir and subject_id
-    """
-    from pathlib import Path
-
-    subjects_dir = Path(subjects_dir)
-    if not subjects_dir.exists():
-        raise FileNotFoundError(f'Subject directory {subjects_dir} does not exist.')
-    if not (subjects_dir / subject_id).exists():
-        raise FileNotFoundError(f'Subject {subject_id} does not exist in {subjects_dir}.')
-
-    return str(subjects_dir), subject_id


### PR DESCRIPTION
When attempting to merge 0.19.3 into master I realized a couple things:

1) #580 duplicated the work of #504
2) #511 and #576 are backport-worthy fixes that I should have included.

I unified #580 and #504, utilizing the minor workflow adjustments from #504 and the `FileNotFoundError` instead of the `RuntimeError`, but kept the interface from #580.

Posting a PR to make sure tests run before a release, but I will release directly onto `maint/0.19.x`.

@mgxd Any objections?